### PR TITLE
Pin blueapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic",
     "fastapi[all]",
     "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git",
-    "blueapi==0.4.4",
+    "blueapi==0.4.5-a1",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"


### PR DESCRIPTION
Pin blueapi to `0.4.5-a1` until a new release is made, to get [554](https://github.com/DiamondLightSource/blueapi/pull/554)