### PR TITLE
Get moveonclick to start

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_moveonclick.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_moveonclick.py
@@ -132,10 +132,7 @@ def update_ui(oav, frame):
     cv.imshow("OAV1view", frame)
 
 
-def start_viewer(oav1: str = OAV1_CAM):
-    # Get devices out of dodal
-    oav: OAV = i24.oav()
-    pmac: PMAC = i24.pmac()
+def start_viewer(oav: OAV, pmac: PMAC, oav1: str = OAV1_CAM):
     # Create a video caputure from OAV1
     cap = cv.VideoCapture(oav1)
 
@@ -198,4 +195,7 @@ def start_viewer(oav1: str = OAV1_CAM):
 
 if __name__ == "__main__":
     RE = RunEngine()
-    RE(start_viewer())
+    # Get devices out of dodal
+    oav: OAV = i24.oav()
+    pmac: PMAC = i24.pmac()
+    RE(start_viewer(oav, pmac))


### PR DESCRIPTION
This is a workaround to get `moveonclick` to start. There seems to be an issue connecting both ophyd and ophyd_asynce devices while the plan is running - in this case the OAV device hasn't yet been moved to ophyd_async. 
The workaround instantiates the devices before running the plan.
See [here](https://github.com/bluesky/ophyd-async/issues/548) for details.