### PR TITLE
Make sure to wait on backlight move

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -136,7 +136,9 @@ def detect_grid_and_do_gridscan(
         parameters.snapshot_directory,
     )
 
-    yield from bps.abs_set(composite.backlight, BacklightPosition.OUT)
+    yield from bps.abs_set(
+        composite.backlight, BacklightPosition.OUT, group=CONST.WAIT.GRID_READY_FOR_DC
+    )
 
     yield from move_aperture_if_required(
         composite.aperture_scatterguard,


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/198

See `dodal` change at https://github.com/DiamondLightSource/dodal/pull/767

To test:
* Confirm wherever we move the backlight we're putting the move into a sensible group