### PR TITLE
Correct default exposure time

### DIFF
--- a/src/mx_bluesky/hyperion/parameters/constants.py
+++ b/src/mx_bluesky/hyperion/parameters/constants.py
@@ -70,7 +70,7 @@ class TriggerConstants:
 @dataclass(frozen=True)
 class GridscanParamConstants:
     WIDTH_UM = 600.0
-    EXPOSURE_TIME_S = 0.02
+    EXPOSURE_TIME_S = 0.004
     USE_ROI = True
     BOX_WIDTH_UM = 20.0
     OMEGA_1 = 0.0

--- a/tests/unit_tests/hyperion/parameters/test_parameter_model.py
+++ b/tests/unit_tests/hyperion/parameters/test_parameter_model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from mx_bluesky.hyperion.parameters.constants import GridscanParamConstants
 from mx_bluesky.hyperion.parameters.gridscan import (
     OddYStepsException,
     RobotLoadThenCentre,
@@ -38,7 +39,7 @@ def test_minimal_3d_gridscan_params(minimal_3d_gridscan_params):
     assert {"sam_x", "sam_y", "sam_z"} == set(test_params.scan_points.keys())
     assert test_params.scan_indices == [0, 35]
     assert test_params.num_images == (5 * 7 + 5 * 9)
-    assert test_params.exposure_time_s == 0.02
+    assert test_params.exposure_time_s == GridscanParamConstants.EXPOSURE_TIME_S
 
 
 def test_cant_do_panda_fgs_with_odd_y_steps(minimal_3d_gridscan_params):


### PR DESCRIPTION
Hyperion's zebra gridscans work at 250hz, which corresponds to a period of 1/250 (or 0.004) seconds. Our default value here was incorrect