### PR TITLE
Fix the docker image CI build workflow

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -36,8 +36,11 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.release
       - name: Generate artifact attestation
         # v1.4.0
         uses: actions/attest-build-provenance@210c1913531870065f03ce1f9440dd87bc0938cd


### PR DESCRIPTION
This should fix the `Publish Docker Image` github workflow.

@DominicOram I don't have permission to push an image to the registry, but I've run the action manually in this branch as far as it will go up to the point where it pushes to `ghcr.io` where it fails presumably because I don't have permissions to push to the `diamondlightsource` ghcr.io repo - so you may want to try this before merging.
