### PR TITLE
Wait between taking snapshots on robot load

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
@@ -123,6 +123,7 @@ def take_robot_snapshots(oav: OAV, webcam: Webcam, directory: Path):
             device.filename, snapshot_format.format(device=device.name)
         )
         yield from bps.abs_set(device.directory, str(directory))
+        # Note: should be able to use `wait=True` after https://github.com/bluesky/bluesky/issues/1795
         yield from bps.trigger(device, group="snapshots")
         yield from bps.wait("snapshots")
 

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
@@ -124,7 +124,7 @@ def take_robot_snapshots(oav: OAV, webcam: Webcam, directory: Path):
         )
         yield from bps.abs_set(device.directory, str(directory))
         yield from bps.trigger(device, group="snapshots")
-    yield from bps.wait("snapshots")
+        yield from bps.wait("snapshots")
 
 
 def prepare_for_robot_load(composite: RobotLoadThenCentreComposite):


### PR DESCRIPTION
Fixes #459

Note we're not using the trigger(wait=True) due to https://github.com/bluesky/bluesky/issues/1795

Also confirm that all other problems in the linked issue are covered by other issues.