### PR TITLE
Fix unit test failure due to deprecated pkg_resource usage in python-workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ filterwarnings = [
     "ignore:(.*)unclosed event loop(.*):ResourceWarning",
     # Ignore pydantic 2 issues from blueapi, see https://github.com/DiamondLightSource/blueapi/issues/622
     "ignore::DeprecationWarning:blueapi",
+    # Ignore deprecation warning from python-workflows https://github.com/DiamondLightSource/python-workflows/issues/180
+    "ignore:.*pkg_resources.*:DeprecationWarning",
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests/unit_tests"


### PR DESCRIPTION
See https://github.com/DiamondLightSource/python-workflows/issues/180