### PR TITLE
Configure both inputs on Zebra auto AND gate during setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.3a5",
     "bluesky >= 1.13.0a4",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@f33211c502c8069ed62032eec54aafaa7e952977",
 ]
 
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
@@ -75,13 +75,43 @@ def tidy_up_zebra_after_rotation_scan(
 
 
 def set_shutter_auto_input(zebra: Zebra, input: int, group="set_shutter_trigger"):
-    """Set the input that the shutter uses when set to auto.
+    """Set the signal that controls the shutter when set to auto. We use the second input to the
+    Zebra's AND2 gate for this input. Shutter must be in auto mode for this input to take control
 
     For more details see the ZebraShutter device."""
     auto_shutter_control = zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
     yield from bps.abs_set(
-        auto_shutter_control.sources[AUTO_SHUTTER_INPUT_1], input, group
+        auto_shutter_control.sources[AUTO_SHUTTER_INPUT_2], input, group
     )
+
+
+def configure_zebra_and_shutter_for_auto_shutter(
+    zebra: Zebra, zebra_shutter: ZebraShutter, input: int, group="use_automatic_shutter"
+):
+    """Set the shutter to auto mode, and configure the zebra to trigger the shutter on
+    an input source. For the input, use one of the source constants in zebra.py
+
+    When the shutter is in auto/manual, logic in EPICS sets the Zebra's
+    SOFT_IN1 to low/high respectively. The Zebra's AND2 gate should be used to control the shutter while in auto mode.
+    To do this, we need (AND2 = SOFT_IN1 AND input), where input is any zebra signal
+    """
+    # See https://github.com/DiamondLightSource/dodal/issues/813 for better typing here.
+
+    # Set shutter to auto mode
+    yield from bps.abs_set(
+        zebra_shutter.control_mode, ZebraShutterControl.AUTO, group=group
+    )
+
+    # Set first input of AND2 gate to SOFT_IN1, which is high when shutter is in auto mode
+    # Note the Zebra should ALWAYS be setup this way. See https://github.com/DiamondLightSource/mx-bluesky/issues/551
+    yield from bps.abs_set(
+        zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE].sources[AUTO_SHUTTER_INPUT_1],
+        SOFT_IN1,
+        group=group,
+    )
+
+    # Set the second input of AND2 gate to the requested zebra input source
+    yield from set_shutter_auto_input(zebra, input, group=group)
 
 
 @bluesky_retry
@@ -139,16 +169,10 @@ def setup_zebra_for_rotation(
     yield from bps.abs_set(zebra.pc.pulse_start, abs(shutter_opening_s), group=group)
     # Set gate position to be angle of interest
     yield from bps.abs_set(zebra.pc.gate_trigger, axis.value, group=group)
-    # Trigger the shutter with the gate
-    yield from bps.abs_set(
-        zebra_shutter.control_mode, ZebraShutterControl.AUTO, group=group
+    # Set shutter to automatic and to trigger via PC_GATE
+    yield from configure_zebra_and_shutter_for_auto_shutter(
+        zebra, zebra_shutter, PC_GATE, group=group
     )
-    yield from bps.abs_set(
-        zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE].sources[AUTO_SHUTTER_INPUT_2],
-        SOFT_IN1,
-        group=group,
-    )
-    yield from set_shutter_auto_input(zebra, PC_GATE, group=group)
     # Trigger the detector with a pulse
     yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], PC_PULSE, group=group)
     # Don't use the fluorescence detector
@@ -166,23 +190,12 @@ def setup_zebra_for_gridscan(
     group="setup_zebra_for_gridscan",
     wait=True,
 ):
-    # Set shutter to auto mode
-    yield from bps.abs_set(
-        zebra_shutter.control_mode, ZebraShutterControl.AUTO, group=group
+    # Set shutter to automatic and to trigger via motion controller GPIO signal (IN4_TTL)
+    yield from configure_zebra_and_shutter_for_auto_shutter(
+        zebra, zebra_shutter, IN4_TTL, group=group
     )
-
-    # Set the 'auto' AND gate to have an input controlled by the zebra shutter control mode
-    yield from bps.abs_set(
-        zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE].sources[AUTO_SHUTTER_INPUT_2],
-        SOFT_IN1,
-        group=group,
-    )
-
-    # Set the 'auto' AND gate to have an input controlled by the GPIO motion controller signal
-    yield from set_shutter_auto_input(zebra, IN4_TTL, group=group)
 
     yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], IN3_TTL, group=group)
-
     yield from bps.abs_set(zebra.output.out_pvs[TTL_XSPRESS3], DISCONNECT, group=group)
     yield from bps.abs_set(zebra.output.pulse_1.input, DISCONNECT, group=group)
 
@@ -217,11 +230,10 @@ def setup_zebra_for_panda_flyscan(
     # Forwards eiger trigger signal from panda
     yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], IN1_TTL, group=group)
 
-    # Forwards signal from PPMAC to fast shutter. High while panda PLC is running
-    yield from bps.abs_set(
-        zebra_shutter.control_mode, ZebraShutterControl.AUTO, group=group
+    # Set shutter to automatic and to trigger via motion controller GPIO signal (IN4_TTL)
+    yield from configure_zebra_and_shutter_for_auto_shutter(
+        zebra, zebra_shutter, IN4_TTL, group=group
     )
-    yield from set_shutter_auto_input(zebra, IN4_TTL, group=group)
 
     yield from bps.abs_set(zebra.output.out_pvs[TTL_XSPRESS3], DISCONNECT, group=group)
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
@@ -93,7 +93,7 @@ def configure_zebra_and_shutter_for_auto_shutter(
 
     When the shutter is in auto/manual, logic in EPICS sets the Zebra's
     SOFT_IN1 to low/high respectively. The Zebra's AND2 gate should be used to control the shutter while in auto mode.
-    To do this, we need (AND2 = SOFT_IN1 AND input), where input is any zebra signal
+    To do this, we need (AND2 = SOFT_IN1 AND input), where input is the zebra signal we want to control the shutter when in auto mode.
     """
     # See https://github.com/DiamondLightSource/dodal/issues/813 for better typing here.
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
@@ -75,8 +75,8 @@ def tidy_up_zebra_after_rotation_scan(
 
 
 def set_shutter_auto_input(zebra: Zebra, input: int, group="set_shutter_trigger"):
-    """Set the signal that controls the shutter when set to auto. We use the second input to the
-    Zebra's AND2 gate for this input. Shutter must be in auto mode for this input to take control
+    """Set the signal that controls the shutter. We use the second input to the
+    Zebra's AND2 gate for this input. ZebraShutter control mode must be in auto for this input to take control
 
     For more details see the ZebraShutter device."""
     auto_shutter_control = zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]

--- a/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
@@ -1,25 +1,28 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from bluesky import plan_stubs as bps
 from dodal.beamlines import i03
 from dodal.devices.zebra import (
     AUTO_SHUTTER_GATE,
+    AUTO_SHUTTER_INPUT_1,
     AUTO_SHUTTER_INPUT_2,
     IN1_TTL,
     IN3_TTL,
     IN4_TTL,
     PC_GATE,
     PC_PULSE,
+    SOFT_IN1,
     TTL_DETECTOR,
     TTL_PANDA,
     I03Axes,
     Zebra,
 )
-from dodal.devices.zebra_controlled_shutter import ZebraShutter
+from dodal.devices.zebra_controlled_shutter import ZebraShutter, ZebraShutterControl
 
 from mx_bluesky.hyperion.device_setup_plans.setup_zebra import (
     bluesky_retry,
+    configure_zebra_and_shutter_for_auto_shutter,
     setup_zebra_for_gridscan,
     setup_zebra_for_panda_flyscan,
     setup_zebra_for_rotation,
@@ -37,10 +40,18 @@ def zebra_shutter(RE):
     return i03.sample_shutter(fake_with_ophyd_sim=True)
 
 
-async def _get_shutter_input_1(zebra: Zebra):
+async def _get_shutter_input_2(zebra: Zebra):
     return (
         await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
         .sources[AUTO_SHUTTER_INPUT_2]
+        .get_value()
+    )
+
+
+async def _get_shutter_input_1(zebra: Zebra):
+    return (
+        await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
+        .sources[AUTO_SHUTTER_INPUT_1]
         .get_value()
     )
 
@@ -51,25 +62,33 @@ async def test_zebra_set_up_for_panda_gridscan(
     RE(setup_zebra_for_panda_flyscan(zebra, zebra_shutter, wait=True))
     assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == IN1_TTL
     assert await zebra.output.out_pvs[TTL_PANDA].get_value() == IN3_TTL
-    assert await _get_shutter_input_1(zebra) == IN4_TTL
+    assert await _get_shutter_input_2(zebra) == IN4_TTL
 
 
 async def test_zebra_set_up_for_gridscan(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
-    RE(setup_zebra_for_gridscan(zebra, zebra_shutter, wait=True))
-    assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == IN3_TTL
-    assert await _get_shutter_input_1(zebra) == IN4_TTL
+    with patch(
+        "mx_bluesky.hyperion.device_setup_plans.setup_zebra.configure_zebra_and_shutter_for_auto_shutter"
+    ) as mock_config_shutter:
+        RE(setup_zebra_for_gridscan(zebra, zebra_shutter, wait=True))
+        assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == IN3_TTL
+        assert await _get_shutter_input_2(zebra) == IN4_TTL
+        mock_config_shutter.assert_called_once()
 
 
 async def test_zebra_set_up_for_rotation(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
-    RE(setup_zebra_for_rotation(zebra, zebra_shutter, wait=True))
-    assert await zebra.pc.gate_trigger.get_value() == I03Axes.OMEGA.value
-    assert await zebra.pc.gate_width.get_value() == pytest.approx(360, 0.01)
+    with patch(
+        "mx_bluesky.hyperion.device_setup_plans.setup_zebra.configure_zebra_and_shutter_for_auto_shutter"
+    ) as mock_config_shutter:
+        RE(setup_zebra_for_rotation(zebra, zebra_shutter, wait=True))
+        assert await zebra.pc.gate_trigger.get_value() == I03Axes.OMEGA.value
+        assert await zebra.pc.gate_width.get_value() == pytest.approx(360, 0.01)
+        mock_config_shutter.assert_called_once()
 
 
 async def test_zebra_cleanup(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
     RE(tidy_up_zebra_after_gridscan(zebra, zebra_shutter, wait=True))
     assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == PC_PULSE
-    assert await _get_shutter_input_1(zebra) == PC_GATE
+    assert await _get_shutter_input_2(zebra) == PC_GATE
 
 
 class MyException(Exception):
@@ -104,3 +123,22 @@ def test_when_all_tries_fail_then_bluesky_retry_throws_error(RE, done_status):
         RE(my_plan(10))
 
     assert e.value == exception_2
+
+
+async def test_configure_zebra_and_shutter_for_auto(
+    RE, zebra: Zebra, zebra_shutter: ZebraShutter
+):
+    RE(configure_zebra_and_shutter_for_auto_shutter(zebra, zebra_shutter, IN4_TTL))
+    assert await zebra_shutter.control_mode.get_value() == ZebraShutterControl.AUTO
+    assert (
+        await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
+        .sources[AUTO_SHUTTER_INPUT_1]
+        .get_value()
+        == SOFT_IN1
+    )
+    assert (
+        await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
+        .sources[AUTO_SHUTTER_INPUT_2]
+        .get_value()
+        == IN4_TTL
+    )

--- a/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
@@ -5,7 +5,7 @@ from bluesky import plan_stubs as bps
 from dodal.beamlines import i03
 from dodal.devices.zebra import (
     AUTO_SHUTTER_GATE,
-    AUTO_SHUTTER_INPUT_1,
+    AUTO_SHUTTER_INPUT_2,
     IN1_TTL,
     IN3_TTL,
     IN4_TTL,
@@ -37,10 +37,10 @@ def zebra_shutter(RE):
     return i03.sample_shutter(fake_with_ophyd_sim=True)
 
 
-async def _get_shutter_input(zebra: Zebra):
+async def _get_shutter_input_1(zebra: Zebra):
     return (
         await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
-        .sources[AUTO_SHUTTER_INPUT_1]
+        .sources[AUTO_SHUTTER_INPUT_2]
         .get_value()
     )
 
@@ -51,13 +51,13 @@ async def test_zebra_set_up_for_panda_gridscan(
     RE(setup_zebra_for_panda_flyscan(zebra, zebra_shutter, wait=True))
     assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == IN1_TTL
     assert await zebra.output.out_pvs[TTL_PANDA].get_value() == IN3_TTL
-    assert await _get_shutter_input(zebra) == IN4_TTL
+    assert await _get_shutter_input_1(zebra) == IN4_TTL
 
 
 async def test_zebra_set_up_for_gridscan(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
     RE(setup_zebra_for_gridscan(zebra, zebra_shutter, wait=True))
     assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == IN3_TTL
-    assert await _get_shutter_input(zebra) == IN4_TTL
+    assert await _get_shutter_input_1(zebra) == IN4_TTL
 
 
 async def test_zebra_set_up_for_rotation(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
@@ -69,7 +69,7 @@ async def test_zebra_set_up_for_rotation(RE, zebra: Zebra, zebra_shutter: ZebraS
 async def test_zebra_cleanup(RE, zebra: Zebra, zebra_shutter: ZebraShutter):
     RE(tidy_up_zebra_after_gridscan(zebra, zebra_shutter, wait=True))
     assert await zebra.output.out_pvs[TTL_DETECTOR].get_value() == PC_PULSE
-    assert await _get_shutter_input(zebra) == PC_GATE
+    assert await _get_shutter_input_1(zebra) == PC_GATE
 
 
 class MyException(Exception):

--- a/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
@@ -5,7 +5,7 @@ from bluesky import plan_stubs as bps
 from dodal.beamlines import i03
 from dodal.devices.zebra import (
     AUTO_SHUTTER_GATE,
-    AUTO_SHUTTER_INPUT,
+    AUTO_SHUTTER_INPUT_1,
     IN1_TTL,
     IN3_TTL,
     IN4_TTL,
@@ -40,7 +40,7 @@ def zebra_shutter(RE):
 async def _get_shutter_input(zebra: Zebra):
     return (
         await zebra.logic_gates.and_gates[AUTO_SHUTTER_GATE]
-        .sources[AUTO_SHUTTER_INPUT]
+        .sources[AUTO_SHUTTER_INPUT_1]
         .get_value()
     )
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -14,7 +14,7 @@ from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.xbpm_feedback import Pause
-from dodal.devices.zebra import PC_GATE, Zebra
+from dodal.devices.zebra import PC_GATE, SOFT_IN1, Zebra
 from dodal.devices.zebra_controlled_shutter import ZebraShutterControl
 from ophyd_async.core import get_mock_put
 
@@ -598,9 +598,17 @@ def test_rotation_scan_turns_shutter_to_auto_with_pc_gate_then_back_to_manual(
     msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
+        and msg.obj.name == "zebra-logic_gates-and_gates-2-sources-1"
+        and msg.args[0] == SOFT_IN1,  # type:ignore
+    )
+
+    msgs = assert_message_and_return_remaining(
+        msgs,
+        lambda msg: msg.command == "set"
         and msg.obj.name == "zebra-logic_gates-and_gates-2-sources-2"
         and msg.args[0] == PC_GATE,  # type:ignore
     )
+
     msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -598,7 +598,7 @@ def test_rotation_scan_turns_shutter_to_auto_with_pc_gate_then_back_to_manual(
     msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
-        and msg.obj.name == "zebra-logic_gates-and_gates-2-sources-1"
+        and msg.obj.name == "zebra-logic_gates-and_gates-2-sources-2"
         and msg.args[0] == PC_GATE,  # type:ignore
     )
     msgs = assert_message_and_return_remaining(


### PR DESCRIPTION
Fixes #546 

Requires dodal change: https://github.com/DiamondLightSource/dodal/pull/823

Also attempts to make the ZebraShutter logic easier to understand