### PR TITLE
Reinstate warning exception for python-workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ filterwarnings = [
     "ignore:(.*)unclosed file(.*)name='(.*)dodal.log'(.*):ResourceWarning",
     "ignore:(.*)unclosed <socket(.*):ResourceWarning",
     "ignore:(.*)unclosed event loop(.*):ResourceWarning",
+    # Ignore deprecation warning from python-workflows https://github.com/DiamondLightSource/python-workflows/issues/180
+    "ignore:.*pkg_resources.*:DeprecationWarning",
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests/unit_tests"


### PR DESCRIPTION
Reinstates the warning ignore in pyproject.toml for python-workflows that was removed in #567 