### PR TITLE
520 calculate bragg angle

### DIFF
--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -8,12 +8,15 @@ from dodal.devices.focusing_mirror import (
 )
 from dodal.devices.undulator_dcm import UndulatorDCM
 from dodal.devices.util.adjuster_plans import lookup_table_adjuster
-from dodal.devices.util.bragg_angle import energy_to_bragg_angle
 from dodal.devices.util.lookup_tables import (
     linear_interpolation_lut,
 )
 
 from mx_bluesky.hyperion.log import LOGGER
+from mx_bluesky.hyperion.utils.utils import (
+    SI_111_SPACING_ANGSTROMS,
+    energy_to_bragg_angle,
+)
 
 MIRROR_VOLTAGE_GROUP = "MIRROR_VOLTAGE_GROUP"
 DCM_GROUP = "DCM_GROUP"
@@ -86,7 +89,7 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     # Adjust DCM Pitch
     dcm = undulator_dcm.dcm
     LOGGER.info(f"Adjusting DCM and VFM for {energy_kev} keV")
-    bragg_deg = energy_to_bragg_angle(energy_kev)
+    bragg_deg = energy_to_bragg_angle(energy_kev, SI_111_SPACING_ANGSTROMS)
     LOGGER.info(f"Target Bragg angle = {bragg_deg} degrees")
     dcm_pitch_adjuster = lookup_table_adjuster(
         linear_interpolation_lut(undulator_dcm.pitch_energy_table_path),

--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -8,6 +8,7 @@ from dodal.devices.focusing_mirror import (
 )
 from dodal.devices.undulator_dcm import UndulatorDCM
 from dodal.devices.util.adjuster_plans import lookup_table_adjuster
+from dodal.devices.util.bragg_angle import energy_to_bragg_angle
 from dodal.devices.util.lookup_tables import (
     linear_interpolation_lut,
 )
@@ -77,16 +78,16 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     energy_kev,
 ):
     """Beamline energy-change post-adjustments : Adjust DCM and VFM directly from lookup tables.
-    Lookups are performed against the Bragg angle which will have been automatically set by EPICS as a side-effect of the
-    energy change prior to calling this function.
+    Lookups are performed against the Bragg angle which is computed directly from the target energy
+    rather than waiting for the EPICS controls PV to reach it.
     Feedback should be OFF prior to entry, in order to prevent
     feedback from making unnecessary corrections while beam is being adjusted."""
 
-    # DCM Pitch
+    # Adjust DCM Pitch
     dcm = undulator_dcm.dcm
     LOGGER.info(f"Adjusting DCM and VFM for {energy_kev} keV")
-    bragg_deg = yield from bps.rd(dcm.bragg_in_degrees.user_readback)
-    LOGGER.info(f"Read Bragg angle = {bragg_deg} degrees")
+    bragg_deg = energy_to_bragg_angle(energy_kev)
+    LOGGER.info(f"Target Bragg angle = {bragg_deg} degrees")
     dcm_pitch_adjuster = lookup_table_adjuster(
         linear_interpolation_lut(undulator_dcm.pitch_energy_table_path),
         dcm.pitch_in_mrad,

--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -14,7 +14,6 @@ from dodal.devices.util.lookup_tables import (
 
 from mx_bluesky.hyperion.log import LOGGER
 from mx_bluesky.hyperion.utils.utils import (
-    SI_111_SPACING_ANGSTROMS,
     energy_to_bragg_angle,
 )
 
@@ -89,7 +88,8 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     # Adjust DCM Pitch
     dcm = undulator_dcm.dcm
     LOGGER.info(f"Adjusting DCM and VFM for {energy_kev} keV")
-    bragg_deg = energy_to_bragg_angle(energy_kev, SI_111_SPACING_ANGSTROMS)
+    d_spacing_a: float = yield from bps.rd(undulator_dcm.dcm.crystal_metadata_d_spacing)
+    bragg_deg = energy_to_bragg_angle(energy_kev, d_spacing_a)
     LOGGER.info(f"Target Bragg angle = {bragg_deg} degrees")
     dcm_pitch_adjuster = lookup_table_adjuster(
         linear_interpolation_lut(undulator_dcm.pitch_energy_table_path),

--- a/src/mx_bluesky/hyperion/utils/utils.py
+++ b/src/mx_bluesky/hyperion/utils/utils.py
@@ -4,9 +4,6 @@ from math import asin
 from scanspec.core import AxesPoints, Axis
 from scipy.constants import physical_constants
 
-# This value taken from BeamLineEnergy_DCM_Angstrom_To_Deg_converter.xml
-SI_111_SPACING_ANGSTROMS = 3.13475
-
 hc_in_eV_and_Angstrom: float = (
     physical_constants["speed of light in vacuum"][0]
     * physical_constants["Planck constant in eV/Hz"][0]

--- a/src/mx_bluesky/hyperion/utils/utils.py
+++ b/src/mx_bluesky/hyperion/utils/utils.py
@@ -1,5 +1,11 @@
+import math
+from math import asin
+
 from scanspec.core import AxesPoints, Axis
 from scipy.constants import physical_constants
+
+# This value taken from BeamLineEnergy_DCM_Angstrom_To_Deg_converter.xml
+SI_111_SPACING_ANGSTROMS = 3.13475
 
 hc_in_eV_and_Angstrom: float = (
     physical_constants["speed of light in vacuum"][0]
@@ -23,3 +29,17 @@ def convert_angstrom_to_eV(wavelength: float) -> float:
 def number_of_frames_from_scan_spec(scan_points: AxesPoints[Axis]):
     ax = list(scan_points.keys())[0]
     return len(scan_points[ax])
+
+
+def energy_to_bragg_angle(energy_kev: float, d_a: float) -> float:
+    """Compute the bragg angle given the energy in kev.
+
+    Args:
+        energy_kev:  The energy in keV
+        d_a:         The lattice spacing in Angstroms
+    Returns:
+        The bragg angle in degrees
+    """
+    wavelength_a = convert_eV_to_angstrom(energy_kev * 1000)
+    d = d_a
+    return asin(wavelength_a / (2 * d)) * 180 / math.pi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,6 +425,7 @@ def dcm(RE):
     dcm = i03.dcm(fake_with_ophyd_sim=True)
     set_mock_value(dcm.energy_in_kev.user_readback, 12.7)
     set_mock_value(dcm.pitch_in_mrad.user_readback, 1)
+    set_mock_value(dcm.crystal_metadata_d_spacing, 3.13475)
     with (
         oa_patch_motor(dcm.roll_in_mrad),
         oa_patch_motor(dcm.pitch_in_mrad),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,12 +471,8 @@ def mirror_voltages():
 def undulator_dcm(RE, dcm):
     undulator_dcm = i03.undulator_dcm(fake_with_ophyd_sim=True)
     undulator_dcm.dcm = dcm
-    undulator_dcm.roll_energy_table_path = (
-        "tests/test_data/test_beamline_dcm_roll_converter.txt"
-    )
-    undulator_dcm.pitch_energy_table_path = (
-        "tests/test_data/test_beamline_dcm_pitch_converter.txt"
-    )
+    undulator_dcm.roll_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
+    undulator_dcm.pitch_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
     yield undulator_dcm
     beamline_utils.clear_devices()
 

--- a/tests/test_data/test_beamline_vfm_lat_converter.txt
+++ b/tests/test_data/test_beamline_vfm_lat_converter.txt
@@ -2,4 +2,4 @@
 # The values cannot change direction.
 Units Deg Deg
 5.0 10.0
-25.0 10.0
+25.0 10.1

--- a/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+from math import isclose
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine
@@ -83,28 +84,23 @@ def test_adjust_dcm_pitch_roll_vfm_from_lut(
     sim_run_engine: RunEngineSimulator,
 ):
     sim_run_engine.add_handler_for_callback_subscribes()
-    sim_run_engine.add_handler(
-        "read",
-        lambda msg: {"dcm-bragg_in_degrees": {"value": 5.0}},
-        "dcm-bragg_in_degrees",
-    )
 
     messages = sim_run_engine.simulate_plan(
         adjust_dcm_pitch_roll_vfm_from_lut(undulator_dcm, vfm, mirror_voltages, 7.5)
     )
-
+    # target bragg angle 15.288352 deg
     messages = assert_message_and_return_remaining(
         messages,
         lambda msg: msg.command == "set"
         and msg.obj.name == "dcm-pitch_in_mrad"
-        and abs(msg.args[0] - -0.75859) < 1e-5
+        and abs(msg.args[0] - -0.78229639) < 1e-5
         and msg.kwargs["group"] == "DCM_GROUP",
     )
     messages = assert_message_and_return_remaining(
         messages[1:],
         lambda msg: msg.command == "set"
         and msg.obj.name == "dcm-roll_in_mrad"
-        and abs(msg.args[0] - 4.0) < 1e-5
+        and abs(msg.args[0] - -0.2799) < 1e-5
         and msg.kwargs["group"] == "DCM_GROUP",
     )
     messages = assert_message_and_return_remaining(
@@ -152,5 +148,5 @@ def test_adjust_dcm_pitch_roll_vfm_from_lut(
         messages[1:],
         lambda msg: msg.command == "set"
         and msg.obj.name == "vfm-x_mm"
-        and msg.args == (10.0,),
+        and isclose(msg.args[0], 10.05144, abs_tol=1e-5),
     )

--- a/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
@@ -1,5 +1,5 @@
 from math import isclose
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from bluesky.run_engine import RunEngine
@@ -83,6 +83,9 @@ def test_adjust_dcm_pitch_roll_vfm_from_lut(
     mirror_voltages: MirrorVoltages,
     sim_run_engine: RunEngineSimulator,
 ):
+    sim_run_engine.add_read_handler_for(
+        undulator_dcm.dcm.crystal_metadata_d_spacing, 3.13475
+    )
     sim_run_engine.add_handler_for_callback_subscribes()
 
     messages = sim_run_engine.simulate_plan(

--- a/tests/unit_tests/hyperion/test_utils.py
+++ b/tests/unit_tests/hyperion/test_utils.py
@@ -1,8 +1,12 @@
+import math
+
 import pytest
 
 from mx_bluesky.hyperion.utils.utils import (
+    SI_111_SPACING_ANGSTROMS,
     convert_angstrom_to_eV,
     convert_eV_to_angstrom,
+    energy_to_bragg_angle,
 )
 
 test_wavelengths = [1.620709, 1.2398425, 0.9762539, 0.8265616, 0.68880138]
@@ -23,3 +27,17 @@ def test_ev_to_a_converter(test_wavelength, test_energy):
 )
 def test_a_to_ev_converter(test_wavelength, test_energy):
     assert convert_angstrom_to_eV(test_wavelength) == pytest.approx(test_energy)
+
+
+@pytest.mark.parametrize(
+    "input_energy_kev, expected_bragg_angle_deg",
+    [[7, 16.41], [8, 14.31], [11, 10.35], [12.3, 9.25], [15, 7.57]],
+)
+def test_energy_to_bragg_angle(
+    input_energy_kev: float, expected_bragg_angle_deg: float
+):
+    assert math.isclose(
+        energy_to_bragg_angle(input_energy_kev, SI_111_SPACING_ANGSTROMS),
+        expected_bragg_angle_deg,
+        abs_tol=0.01,
+    )

--- a/tests/unit_tests/hyperion/test_utils.py
+++ b/tests/unit_tests/hyperion/test_utils.py
@@ -3,11 +3,12 @@ import math
 import pytest
 
 from mx_bluesky.hyperion.utils.utils import (
-    SI_111_SPACING_ANGSTROMS,
     convert_angstrom_to_eV,
     convert_eV_to_angstrom,
     energy_to_bragg_angle,
 )
+
+SI_111_SPACING_ANGSTROMS = 3.13475
 
 test_wavelengths = [1.620709, 1.2398425, 0.9762539, 0.8265616, 0.68880138]
 test_energies = [7650, 10000, 12700, 15000, 18000]


### PR DESCRIPTION
Fixes #520 

Calculates the Bragg angle directly from the target energy instead of reading from the EPICS PV which is liable to return transient values.

