### PR TITLE
Replace calls to deprecated inject() with direct factory calls

### DIFF
--- a/src/mx_bluesky/beamlines/i04/thawing_plan.py
+++ b/src/mx_bluesky/beamlines/i04/thawing_plan.py
@@ -4,8 +4,8 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from bluesky.preprocessors import run_decorator, subs_decorator
 from dls_bluesky_core.core import MsgGenerator
+from dodal.beamlines import i04
 from dodal.beamlines.i04 import MURKO_REDIS_DB, REDIS_HOST, REDIS_PASSWORD
-from dodal.common import inject
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder, Source
 from dodal.devices.robot import BartRobot
@@ -18,11 +18,13 @@ from mx_bluesky.beamlines.i04.callbacks.murko_callback import MurkoCallback
 def thaw_and_stream_to_redis(
     time_to_thaw: float,
     rotation: float = 360,
-    robot: BartRobot = inject("robot"),
-    thawer: Thawer = inject("thawer"),
-    smargon: Smargon = inject("smargon"),
-    oav: OAV = inject("oav"),
-    oav_to_redis_forwarder: OAVToRedisForwarder = inject("oav_to_redis_forwarder"),
+    robot: BartRobot = i04.robot(wait_for_connection=False),
+    thawer: Thawer = i04.thawer(wait_for_connection=False),
+    smargon: Smargon = i04.smargon(wait_for_connection=False),
+    oav: OAV = i04.oav(wait_for_connection=False),
+    oav_to_redis_forwarder: OAVToRedisForwarder = i04.oav_to_redis_forwarder(
+        wait_for_connection=False
+    ),
 ) -> MsgGenerator:
     zoom_percentage = yield from bps.rd(oav.zoom_controller.percentage)  # type: ignore # See: https://github.com/bluesky/bluesky/issues/1809
     sample_id = yield from bps.rd(robot.sample_id)
@@ -75,8 +77,8 @@ def thaw_and_stream_to_redis(
 def thaw(
     time_to_thaw: float,
     rotation: float = 360,
-    thawer: Thawer = inject("thawer"),
-    smargon: Smargon = inject("smargon"),
+    thawer: Thawer = i04.thawer(wait_for_connection=False),
+    smargon: Smargon = i04.smargon(wait_for_connection=False),
     plan_between_rotations: Callable[[], MsgGenerator] | None = None,
 ) -> MsgGenerator:
     """Rotates the sample and thaws it at the same time.
@@ -85,9 +87,9 @@ def thaw(
         time_to_thaw (float): Time to thaw for, in seconds.
         rotation (float, optional): How much to rotate by whilst thawing, in degrees.
                                     Defaults to 360.
-        thawer (Thawer, optional): The thawing device. Defaults to inject("thawer").
+        thawer (Thawer, optional): The thawing device. Defaults to i04.thawer(wait_for_connection=False).
         smargon (Smargon, optional): The smargon used to rotate.
-                                     Defaults to inject("smargon")
+                                     Defaults to i04.smargon(wait_for_connection=False)
         plan_between_rotations (MsgGenerator, optional): A plan to run between rotations
                                     of the smargon. Defaults to no plan.
     """

--- a/src/mx_bluesky/beamlines/i24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
+++ b/src/mx_bluesky/beamlines/i24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
@@ -18,7 +18,7 @@ from time import sleep
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from blueapi.core import MsgGenerator
-from dodal.common import inject
+from dodal.beamlines import i24
 from dodal.devices.hutch_shutter import HutchShutter, ShutterDemand
 from dodal.devices.i24.aperture import Aperture
 from dodal.devices.i24.beamstop import Beamstop
@@ -72,7 +72,7 @@ def flush_print(text):
 
 @log.log_on_entry
 def initialise_extruder(
-    detector_stage: DetectorMotion = inject("detector_motion"),
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
     logger.info("Initialise Parameters for extruder data collection on I24.")
@@ -100,8 +100,8 @@ def initialise_extruder(
 @log.log_on_entry
 def laser_check(
     mode: str,
-    zebra: Zebra = inject("zebra"),
-    detector_stage: DetectorMotion = inject("detector_motion"),
+    zebra: Zebra = i24.zebra(wait_for_connection=False),
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
 ) -> MsgGenerator:
     """Plan to open the shutter and check the laser beam from the viewer by pressing \
         'Laser On' and 'Laser Off' buttons on the edm.
@@ -133,7 +133,7 @@ def laser_check(
 
 @log.log_on_entry
 def enter_hutch(
-    detector_stage: DetectorMotion = inject("detector_motion"),
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
 ) -> MsgGenerator:
     """Move the detector stage before entering hutch."""
     setup_logging()
@@ -466,13 +466,13 @@ def collection_complete_plan(
 
 
 def run_extruder_plan(
-    zebra: Zebra = inject("zebra"),
-    aperture: Aperture = inject("aperture"),
-    backlight: DualBacklight = inject("backlight"),
-    beamstop: Beamstop = inject("beamstop"),
-    detector_stage: DetectorMotion = inject("detector_motion"),
-    shutter: HutchShutter = inject("shutter"),
-    dcm: DCM = inject("dcm"),
+    zebra: Zebra = i24.zebra(wait_for_connection=False),
+    aperture: Aperture = i24.aperture(wait_for_connection=False),
+    backlight: DualBacklight = i24.backlight(wait_for_connection=False),
+    beamstop: Beamstop = i24.beamstop(wait_for_connection=False),
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
+    shutter: HutchShutter = i24.shutter(wait_for_connection=False),
+    dcm: DCM = i24.dcm(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
     start_time = datetime.now()

--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -13,7 +13,7 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import numpy as np
 from blueapi.core import MsgGenerator
-from dodal.common import inject
+from dodal.beamlines import i24
 from dodal.devices.hutch_shutter import HutchShutter, ShutterDemand
 from dodal.devices.i24.aperture import Aperture
 from dodal.devices.i24.beamstop import Beamstop
@@ -743,14 +743,14 @@ def tidy_up_after_collection_plan(
 
 
 def run_fixed_target_plan(
-    zebra: Zebra = inject("zebra"),
-    pmac: PMAC = inject("pmac"),
-    aperture: Aperture = inject("aperture"),
-    backlight: DualBacklight = inject("backlight"),
-    beamstop: Beamstop = inject("beamstop"),
-    detector_stage: DetectorMotion = inject("detector_motion"),
-    shutter: HutchShutter = inject("shutter"),
-    dcm: DCM = inject("dcm"),
+    zebra: Zebra = i24.zebra(wait_for_connection=False),
+    pmac: PMAC = i24.pmac(wait_for_connection=False),
+    aperture: Aperture = i24.aperture(wait_for_connection=False),
+    backlight: DualBacklight = i24.backlight(wait_for_connection=False),
+    beamstop: Beamstop = i24.beamstop(wait_for_connection=False),
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
+    shutter: HutchShutter = i24.shutter(wait_for_connection=False),
+    dcm: DCM = i24.dcm(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
 

--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -17,7 +17,6 @@ import bluesky.plan_stubs as bps
 import numpy as np
 from blueapi.core import MsgGenerator
 from dodal.beamlines import i24
-from dodal.common import inject
 from dodal.devices.i24.beamstop import Beamstop, BeamstopPositions
 from dodal.devices.i24.dual_backlight import BacklightPositions, DualBacklight
 from dodal.devices.i24.i24_detector_motion import DetectorMotion
@@ -73,7 +72,7 @@ def setup_logging():
 
 @log.log_on_entry
 def initialise_stages(
-    pmac: PMAC = inject("pmac"),
+    pmac: PMAC = i24.pmac(wait_for_connection=False),
 ) -> MsgGenerator:
     """Initialise the portable stages PVs, usually used only once right after setting \
         up the stages either after use at different facility.
@@ -210,7 +209,7 @@ def scrape_pvar_file(fid: str, pvar_dir: Path = PVAR_FILE_PATH):
 @log.log_on_entry
 def define_current_chip(
     chipid: str = "oxford",
-    pmac: PMAC = inject("pmac"),
+    pmac: PMAC = i24.pmac(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
     logger.debug("Run load stock map for just the first block")
@@ -255,7 +254,7 @@ def save_screen_map() -> MsgGenerator:
 
 
 @log.log_on_entry
-def upload_parameters(pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def upload_parameters(pmac: PMAC = i24.pmac(wait_for_connection=False)) -> MsgGenerator:
     setup_logging()
     logger.info("Uploading Parameters for Oxford Chip to the GeoBrick")
     caput(CHIPTYPE_PV, 0)
@@ -606,7 +605,9 @@ def load_full_map() -> MsgGenerator:
 
 
 @log.log_on_entry
-def moveto(place: str = "origin", pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def moveto(
+    place: str = "origin", pmac: PMAC = i24.pmac(wait_for_connection=False)
+) -> MsgGenerator:
     setup_logging()
     logger.info(f"Move to: {place}")
     if place == Fiducials.zero:
@@ -634,10 +635,10 @@ def moveto(place: str = "origin", pmac: PMAC = inject("pmac")) -> MsgGenerator:
 @log.log_on_entry
 def moveto_preset(
     place: str,
-    pmac: PMAC = inject("pmac"),
-    beamstop: Beamstop = inject("beamstop"),
-    backlight: DualBacklight = inject("backlight"),
-    det_stage: DetectorMotion = inject("detector_motion"),
+    pmac: PMAC = i24.pmac(wait_for_connection=False),
+    beamstop: Beamstop = i24.beamstop(wait_for_connection=False),
+    backlight: DualBacklight = i24.backlight(wait_for_connection=False),
+    det_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
 
@@ -671,7 +672,9 @@ def moveto_preset(
 
 
 @log.log_on_entry
-def laser_control(laser_setting: str, pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def laser_control(
+    laser_setting: str, pmac: PMAC = i24.pmac(wait_for_connection=False)
+) -> MsgGenerator:
     setup_logging()
     logger.info(f"Move to: {laser_setting}")
     if laser_setting == "laser1on":  # these are in laser edm
@@ -731,7 +734,9 @@ def scrape_mtr_directions(motor_file_path: Path = CS_FILES_PATH):
 
 
 @log.log_on_entry
-def fiducial(point: int = 1, pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def fiducial(
+    point: int = 1, pmac: PMAC = i24.pmac(wait_for_connection=False)
+) -> MsgGenerator:
     setup_logging()
     scale = 10000.0  # noqa: F841
 
@@ -770,7 +775,7 @@ def scrape_mtr_fiducials(
 
 
 @log.log_on_entry
-def cs_maker(pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def cs_maker(pmac: PMAC = i24.pmac(wait_for_connection=False)) -> MsgGenerator:
     """
     Coordinate system.
 
@@ -930,7 +935,7 @@ def cs_maker(pmac: PMAC = inject("pmac")) -> MsgGenerator:
     yield from bps.null()
 
 
-def cs_reset(pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def cs_reset(pmac: PMAC = i24.pmac(wait_for_connection=False)) -> MsgGenerator:
     """Used to clear CS when using Custom Chip"""
     setup_logging()
     cs1 = "#1->10000X+0Y+0Z"
@@ -994,7 +999,7 @@ def pumpprobe_calc() -> MsgGenerator:
 
 
 @log.log_on_entry
-def block_check(pmac: PMAC = inject("pmac")) -> MsgGenerator:
+def block_check(pmac: PMAC = i24.pmac(wait_for_connection=False)) -> MsgGenerator:
     setup_logging()
     # TODO See https://github.com/DiamondLightSource/mx_bluesky/issues/117
     caput(pv.me14e_gp9, 0)

--- a/src/mx_bluesky/beamlines/i24/serial/setup_beamline/setup_detector.py
+++ b/src/mx_bluesky/beamlines/i24/serial/setup_beamline/setup_detector.py
@@ -10,7 +10,7 @@ from enum import IntEnum
 import bluesky.plan_stubs as bps
 from blueapi.core import MsgGenerator
 from bluesky.utils import Msg
-from dodal.common import inject
+from dodal.beamlines import i24
 from dodal.devices.i24.i24_detector_motion import DetectorMotion
 
 from mx_bluesky.beamlines.i24.serial import log
@@ -92,7 +92,8 @@ def _get_requested_detector(det_type_pv: str) -> str:
 
 
 def setup_detector_stage(
-    expt_type: SSXType, detector_stage: DetectorMotion = inject("detector_motion")
+    expt_type: SSXType,
+    detector_stage: DetectorMotion = i24.detector_motion(wait_for_connection=False),
 ) -> MsgGenerator:
     setup_logging()
     # Grab the correct PV depending on experiment


### PR DESCRIPTION
This fixes the unit tests after the deprecation of `inject()`
see https://github.com/DiamondLightSource/dodal/issues/845
merged in PR
DiamondLightSource/dodal#854