### PR TITLE
Make it possible to have an environment with bluesky dev dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # The devcontainer should use the build target and run as root with podman
 # or docker with user namespaces.
 #
-FROM python:3.11 AS build
+FROM python:3.12 AS build
 
 ARG PIP_OPTIONS
 

--- a/.vscode/mxb-with-core-dependencies.code-workspace
+++ b/.vscode/mxb-with-core-dependencies.code-workspace
@@ -1,0 +1,23 @@
+// To use this you should obviously have these all in the parent directory
+{
+	"folders": [
+		{
+			"path": ".."
+		},
+		{
+			"path": "../../dodal"
+		},
+		{
+			"path": "../../bluesky"
+		},
+		{
+			"path": "../../ophyd"
+		},
+		{
+			"path": "../../ophyd-async"
+		}
+	],
+	"settings": {
+		"terminal.integrated.gpuAcceleration": "off"
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION} AS developer
 
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a virtual environment and put it in PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ reportMissingImports = false # Ignore missing stubs in imported modules
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "s03: marks tests as requiring the s03 simulator running (deselect with '-m \"not s03\"')",
     "dlstbx: marks tests as requiring dlstbx (deselect with '-m \"not dlstbx\"')",

--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -587,12 +587,14 @@ def load_lite_map() -> MsgGenerator:
 
 @log.log_on_entry
 def load_full_map() -> MsgGenerator:
+    from matplotlib import pyplot as plt
+
     setup_logging()
     params = startup.read_parameter_file()
 
     fullmap_fid = FULLMAP_PATH / f"{caget(MAP_FILEPATH_PV)}.spec"
     logger.info(f"Opening {fullmap_fid}")
-    mapping.plot_file(fullmap_fid, params.chip.chip_type.value)
+    mapping.plot_file(plt, fullmap_fid, params.chip.chip_type.value)
     mapping.convert_chip_to_hex(fullmap_fid, params.chip.chip_type.value)
     shutil.copy2(fullmap_fid.with_suffix(".full"), FULLMAP_PATH / "currentchip.full")
     logger.info(

--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Mapping_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Mapping_py3v1.py
@@ -8,7 +8,6 @@ import logging
 import time
 
 import numpy as np
-from matplotlib import pyplot as plt
 
 from mx_bluesky.beamlines.i24.serial import log
 from mx_bluesky.beamlines.i24.serial.fixed_target.ft_utils import ChipType
@@ -53,7 +52,7 @@ def read_file_make_dict(fid, chip_type, switch=False):
 
 
 @log.log_on_entry
-def plot_file(fid, chip_type):
+def plot_file(plt, fid, chip_type):
     chip_dict = read_file_make_dict(fid, chip_type)
     x_list, y_list, z_list = [], [], []
     for k in sorted(chip_dict.keys()):
@@ -140,7 +139,7 @@ def convert_chip_to_hex(fid, chip_type):
     return 0
 
 
-def main():
+def main(plt):
     setup_logging()
     params = read_parameter_file()
 
@@ -151,11 +150,13 @@ def main():
     fid = PARAM_FILE_PATH_FT / f"{params.filename}.spec"
     logger.info(f"FID = {fid}")
 
-    plot_file(fid, params.chip.chip_type.value)
+    plot_file(plt, fid, params.chip.chip_type.value)
     convert_chip_to_hex(fid, params.chip.chip_type.value)
 
 
 if __name__ == "__main__":
-    main()
+    from matplotlib import pyplot as plt
+
+    main(plt)
     plt.show()
-plt.close()
+    plt.close()


### PR DESCRIPTION
- update devcontainer
- add a workspace with all our core dependencies
- fix some bad use of matplotlib

To test:
- install `pyqt5`, see tests fail on main, pass on this branch