### PR TITLE
Fix MultiRotationScan so that pydantic model_dump_json() works 

### DIFF
--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -115,12 +115,16 @@ class MultiRotationScan(RotationExperiment, SplitScan):
 
     def _single_rotation_scan(self, scan: RotationScanPerSweep) -> RotationScan:
         # self has everything from RotationExperiment
-        params = self.model_dump()
-        del params["rotation_scans"]
+        allowed_keys = RotationScan.model_fields.keys()
+        params_dump = self.model_dump()
         # provided `scan` has everything from RotationScanPerSweep
-        params.update(scan.model_dump())
+        scan_dump = scan.model_dump()
+        rotation_scan_kv_pairs = {
+            k: v for k, v in (params_dump | scan_dump).items() if k in allowed_keys
+        }
         # together they have everything for RotationScan
-        return RotationScan(**params)
+        rotation_scan = RotationScan(**rotation_scan_kv_pairs)
+        return rotation_scan
 
     @model_validator(mode="after")
     @classmethod

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -132,6 +132,30 @@ def grid_detection_callback_with_detected_grid():
         yield callback
 
 
+def test_can_serialize_load_centre_collect_params(load_centre_collect_params):
+    load_centre_collect_params.model_dump_json()
+
+
+def test_can_serialize_load_centre_collect_robot_load_params(
+    load_centre_collect_params,
+):
+    load_centre_collect_params.robot_load_then_centre.model_dump_json()
+
+
+def test_can_serialize_load_centre_collect_multi_rotation_scan(
+    load_centre_collect_params,
+):
+    load_centre_collect_params.multi_rotation_scan.model_dump_json()
+
+
+def test_can_serialize_load_centre_collect_single_rotation_scans(
+    load_centre_collect_params,
+):
+    list(load_centre_collect_params.multi_rotation_scan.single_rotation_scans)[
+        0
+    ].model_dump_json()
+
+
 @patch(
     "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.pin_centre_then_xray_centre_plan",
     return_value=iter([]),


### PR DESCRIPTION
This fixes an issue found in system tests where pydantic was reporting failure to serialize `semver.SemanticVersion`.

