### PR TITLE
Fix pytest aborting after first encountered test failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import gzip
 import json
 import logging
+import os
 import sys
 import threading
 from collections.abc import Callable, Generator, Sequence
@@ -951,16 +952,19 @@ def pin_tip_edge_data():
     return tip_x_px, tip_y_px, top_edge_array, bottom_edge_array
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_exception_interact(call: pytest.CallInfo[Any]):
-    if call.excinfo is not None:
-        raise call.excinfo.value
-    else:
-        raise RuntimeError(
-            f"{call} has no exception data, an unknown error has occurred"
-        )
+# Prevent pytest from catching exceptions when debugging in vscode so that break on
+# exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
+if os.getenv("PYTEST_RAISE", "0") == "1":
 
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call: pytest.CallInfo[Any]):
+        if call.excinfo is not None:
+            raise call.excinfo.value
+        else:
+            raise RuntimeError(
+                f"{call} has no exception data, an unknown error has occurred"
+            )
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_internalerror(excinfo: pytest.ExceptionInfo[Any]):
-    raise excinfo.value
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo: pytest.ExceptionInfo[Any]):
+        raise excinfo.value

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,21 +1,8 @@
 import asyncio
-import os
 import time
 
 import pytest
 from bluesky.run_engine import RunEngine
-
-# Prevent pytest from catching exceptions when debugging in vscode so that break on
-# exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
-if os.getenv("PYTEST_RAISE", "0") == "1":
-
-    @pytest.hookimpl(tryfirst=True)
-    def pytest_exception_interact(call):
-        raise call.excinfo.value
-
-    @pytest.hookimpl(tryfirst=True)
-    def pytest_internalerror(excinfo):
-        raise excinfo.value
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR removes a redundant copy of some code which is a workaround for

https://github.com/pytest-dev/pytest/issues/7409

importantly it now enforces the PYTEST_RAISE environment variable must be set to 1 in order to enable the workaround.

The workaround when enabled causes pytest to bail early at the first error, so before this PR, any failing test would cause all subsequent tests to not be execute, which is undesirable.
