### PR TITLE
595 write to ispyb sample status after collection

### DIFF
--- a/src/mx_bluesky/common/parameters/constants.py
+++ b/src/mx_bluesky/common/parameters/constants.py
@@ -14,6 +14,7 @@ TEST_MODE = BEAMLINE == "test"
 class DocDescriptorNames:
     # Robot load event descriptor
     ROBOT_LOAD = "robot_load"
+    ROBOT_LOAD_EXCEPTION = "robot_load_exception"
     # For callbacks to use
     OAV_ROTATION_SNAPSHOT_TRIGGERED = "rotation_snapshot_triggered"
     OAV_GRID_SNAPSHOT_TRIGGERED = "snapshot_to_ispyb"

--- a/src/mx_bluesky/common/parameters/constants.py
+++ b/src/mx_bluesky/common/parameters/constants.py
@@ -37,6 +37,7 @@ class OavConstants:
 
 @dataclass(frozen=True)
 class PlanNameConstants:
+    LOAD_CENTRE_COLLECT = "load_centre_collect"
     # Robot load subplan
     ROBOT_LOAD = "robot_load"
     # Gridscan
@@ -46,6 +47,9 @@ class PlanNameConstants:
     GRIDSCAN_AND_MOVE = "run_gridscan_and_move"
     GRIDSCAN_MAIN = "run_gridscan"
     DO_FGS = "do_fgs"
+    # IspyB callback activation
+    ISPYB_ACTIVATION = "ispyb_activation"
+    ROBOT_LOAD_AND_SNAPSHOTS = "robot_load_and_snapshots"
     # Rotation scan
     ROTATION_MULTI = "multi_rotation_wrapper"
     ROTATION_OUTER = "rotation_scan_with_cleanup"

--- a/src/mx_bluesky/common/parameters/constants.py
+++ b/src/mx_bluesky/common/parameters/constants.py
@@ -14,12 +14,12 @@ TEST_MODE = BEAMLINE == "test"
 class DocDescriptorNames:
     # Robot load event descriptor
     ROBOT_LOAD = "robot_load"
-    ROBOT_LOAD_EXCEPTION = "robot_load_exception"
     # For callbacks to use
     OAV_ROTATION_SNAPSHOT_TRIGGERED = "rotation_snapshot_triggered"
     OAV_GRID_SNAPSHOT_TRIGGERED = "snapshot_to_ispyb"
     HARDWARE_READ_PRE = "read_hardware_for_callbacks_pre_collection"
     HARDWARE_READ_DURING = "read_hardware_for_callbacks_during_collection"
+    SAMPLE_HANDLING_EXCEPTION = "sample_handling_exception"
     ZOCALO_HW_READ = "zocalo_read_hardware_plan"
     FLYSCAN_RESULTS = "flyscan_results_obtained"
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/smargon.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/smargon.py
@@ -2,17 +2,17 @@ import numpy as np
 from bluesky import plan_stubs as bps
 from dodal.devices.smargon import Smargon
 
-from mx_bluesky.hyperion.exceptions import WarningException
+from mx_bluesky.hyperion.exceptions import SampleException
 
 
 def move_smargon_warn_on_out_of_range(
     smargon: Smargon, position: np.ndarray | list[float] | tuple[float, float, float]
 ):
-    """Throws a WarningException if the specified position is out of range for the
+    """Throws a SampleException if the specified position is out of range for the
     smargon. Otherwise moves to that position."""
     limits = yield from smargon.get_xyz_limits()
     if not limits.position_valid(position):
-        raise WarningException(
+        raise SampleException(
             "Pin tip centring failed - pin too long/short/bent and out of range"
         )
     yield from bps.mv(

--- a/src/mx_bluesky/hyperion/exceptions.py
+++ b/src/mx_bluesky/hyperion/exceptions.py
@@ -42,7 +42,7 @@ def catch_exception_and_warn(
 
     def warn_if_exception_matches(exception: Exception):
         if isinstance(exception, exception_to_catch):
-            raise WarningException(str(exception))
+            raise SampleException from exception
         yield from null()
 
     return (

--- a/src/mx_bluesky/hyperion/exceptions.py
+++ b/src/mx_bluesky/hyperion/exceptions.py
@@ -22,6 +22,12 @@ class SampleException(WarningException):
 T = TypeVar("T")
 
 
+class CrystalNotFoundException(SampleException):
+    """Raised if grid detection completed normally but no crystal was found."""
+
+    pass
+
+
 def catch_exception_and_warn(
     exception_to_catch: type[Exception],
     func: Callable[..., Generator[Msg, None, T]],

--- a/src/mx_bluesky/hyperion/exceptions.py
+++ b/src/mx_bluesky/hyperion/exceptions.py
@@ -42,7 +42,7 @@ def catch_exception_and_warn(
 
     def warn_if_exception_matches(exception: Exception):
         if isinstance(exception, exception_to_catch):
-            raise SampleException from exception
+            raise SampleException(str(exception)) from exception
         yield from null()
 
     return (

--- a/src/mx_bluesky/hyperion/exceptions.py
+++ b/src/mx_bluesky/hyperion/exceptions.py
@@ -13,6 +13,12 @@ class WarningException(Exception):
     pass
 
 
+class SampleException(WarningException):
+    """An exception which identifies an issue relating to the sample."""
+
+    pass
+
+
 T = TypeVar("T")
 
 

--- a/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -66,7 +66,7 @@ from mx_bluesky.hyperion.device_setup_plans.setup_zebra import (
 from mx_bluesky.hyperion.device_setup_plans.xbpm_feedback import (
     transmission_and_xbpm_feedback_for_collection_decorator,
 )
-from mx_bluesky.hyperion.exceptions import WarningException
+from mx_bluesky.hyperion.exceptions import SampleException
 from mx_bluesky.hyperion.experiment_plans.change_aperture_then_move_plan import (
     change_aperture_then_move_to_xtal,
 )
@@ -84,7 +84,7 @@ class SmargonSpeedException(Exception):
     pass
 
 
-class CrystalNotFoundException(WarningException):
+class CrystalNotFoundException(SampleException):
     """Raised if grid detection completed normally but no crystal was found."""
 
     pass
@@ -378,7 +378,7 @@ def wait_for_gridscan_valid(fgs_motors: FastGridScanCommon, timeout=0.5):
             LOGGER.info("Gridscan scan valid and position counter reset")
             return
         yield from bps.sleep(SLEEP_PER_CHECK)
-    raise WarningException("Scan invalid - pin too long/short/bent and out of range")
+    raise SampleException("Scan invalid - pin too long/short/bent and out of range")
 
 
 @dataclasses.dataclass

--- a/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -66,7 +66,7 @@ from mx_bluesky.hyperion.device_setup_plans.setup_zebra import (
 from mx_bluesky.hyperion.device_setup_plans.xbpm_feedback import (
     transmission_and_xbpm_feedback_for_collection_decorator,
 )
-from mx_bluesky.hyperion.exceptions import SampleException
+from mx_bluesky.hyperion.exceptions import CrystalNotFoundException, SampleException
 from mx_bluesky.hyperion.experiment_plans.change_aperture_then_move_plan import (
     change_aperture_then_move_to_xtal,
 )
@@ -81,12 +81,6 @@ from mx_bluesky.hyperion.utils.context import device_composite_from_context
 
 
 class SmargonSpeedException(Exception):
-    pass
-
-
-class CrystalNotFoundException(SampleException):
-    """Raised if grid detection completed normally but no crystal was found."""
-
     pass
 
 

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -57,11 +57,6 @@ def load_centre_collect_full(
     if not oav_params:
         oav_params = OAVParameters(context="xrayCentring")
 
-    # Below causes close_run not received before open_run in _open_run
-    # @set_run_key_decorator(CONST.PLAN.LOAD_CENTRE_COLLECT)
-    # @run_decorator(md={"metadata": {"sample_id": params.sample_id},
-    #                    "activate_callbacks": ["SampleHandlingCallback"]})
-    # @sample_handling_callback_decorator()
     @set_run_key_decorator(CONST.PLAN.LOAD_CENTRE_COLLECT)
     @run_decorator(
         md={

--- a/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -8,8 +8,8 @@ import bluesky.plan_stubs as bps
 import numpy as np
 import pydantic
 from blueapi.core import BlueskyContext
-from bluesky import Msg
 from bluesky.preprocessors import contingency_wrapper
+from bluesky.utils import Msg
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection

--- a/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Generator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import bluesky.plan_stubs as bps
 import numpy as np
 import pydantic
 from blueapi.core import BlueskyContext
-from bluesky.preprocessors import contingency_wrapper
-from bluesky.utils import Msg
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -20,7 +17,7 @@ from dodal.devices.smargon import Smargon
 from mx_bluesky.hyperion.device_setup_plans.setup_oav import (
     pre_centring_setup_oav,
 )
-from mx_bluesky.hyperion.exceptions import SampleException
+from mx_bluesky.hyperion.exceptions import catch_exception_and_warn
 from mx_bluesky.hyperion.log import LOGGER
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
@@ -108,13 +105,8 @@ def grid_detection_plan(
         # See #673 for improvements
         yield from bps.sleep(CONST.HARDWARE.OAV_REFRESH_DELAY)
 
-        def wrap_exception(e: Exception) -> Generator[Msg, Any, Any]:
-            if isinstance(e, PinNotFoundException):
-                raise SampleException(str(e))
-            yield from []
-
-        tip_x_px, tip_y_px = yield from contingency_wrapper(
-            wait_for_tip_to_be_found(pin_tip_detection), except_plan=wrap_exception
+        tip_x_px, tip_y_px = yield from catch_exception_and_warn(
+            PinNotFoundException, wait_for_tip_to_be_found, pin_tip_detection
         )
 
         LOGGER.info(f"Tip is at x,y: {tip_x_px},{tip_y_px}")

--- a/src/mx_bluesky/hyperion/experiment_plans/pin_tip_centring_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/pin_tip_centring_plan.py
@@ -19,7 +19,7 @@ from mx_bluesky.hyperion.device_setup_plans.setup_oav import pre_centring_setup_
 from mx_bluesky.hyperion.device_setup_plans.smargon import (
     move_smargon_warn_on_out_of_range,
 )
-from mx_bluesky.hyperion.exceptions import WarningException
+from mx_bluesky.hyperion.exceptions import SampleException
 from mx_bluesky.hyperion.log import LOGGER
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
@@ -68,7 +68,7 @@ def move_pin_into_view(
         max_steps (int, optional): The number of steps to search with. Defaults to 2.
 
     Raises:
-        WarningException: Error if the pin tip is never found
+        SampleException: Error if the pin tip is never found
 
     Returns:
         Tuple[int, int]: The location of the pin tip in pixels
@@ -105,7 +105,7 @@ def move_pin_into_view(
     tip_xy_px = yield from trigger_and_return_pin_tip(pin_tip_device)
 
     if not pin_tip_valid(tip_xy_px):
-        raise WarningException(
+        raise SampleException(
             "Pin tip centring failed - pin too long/short/bent and out of range"
         )
     else:

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
@@ -218,24 +218,28 @@ def robot_load_and_change_energy_plan(
     yield from prepare_for_robot_load(
         composite.aperture_scatterguard, composite.smargon
     )
-    yield from bpp.run_wrapper(
-        robot_load_and_snapshots(
-            composite,
-            sample_location,
-            params.snapshot_directory,
-            params.thawing_time,
-            params.demand_energy_ev,
-        ),
-        md={
-            "subplan_name": CONST.PLAN.ROBOT_LOAD,
-            "metadata": {
-                "visit": params.visit,
-                "sample_id": params.sample_id,
-                "sample_puck": sample_location.puck,
-                "sample_pin": sample_location.pin,
+
+    yield from bpp.set_run_key_wrapper(
+        bpp.run_wrapper(
+            robot_load_and_snapshots(
+                composite,
+                sample_location,
+                params.snapshot_directory,
+                params.thawing_time,
+                params.demand_energy_ev,
+            ),
+            md={
+                "subplan_name": CONST.PLAN.ROBOT_LOAD,
+                "metadata": {
+                    "visit": params.visit,
+                    "sample_id": params.sample_id,
+                    "sample_puck": sample_location.puck,
+                    "sample_pin": sample_location.pin,
+                },
+                "activate_callbacks": [
+                    "RobotLoadISPyBCallback",
+                ],
             },
-            "activate_callbacks": [
-                "RobotLoadISPyBCallback",
-            ],
-        },
+        ),
+        CONST.PLAN.ROBOT_LOAD_AND_SNAPSHOTS,
     )

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__init__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__init__.py
@@ -4,7 +4,3 @@ execution of an experimental plan.
 
 Callbacks used for the Hyperion fast grid scan are prefixed with 'FGS'.
 """
-
-from .__main__ import main
-
-__all__ = ["main"]

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -20,6 +20,9 @@ from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback 
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
 )
+from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
+    SampleHandlingCallback,
+)
 from mx_bluesky.hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
@@ -49,6 +52,7 @@ def setup_callbacks():
         RotationISPyBCallback(emit=zocalo),
         LogUidTaggingCallback(),
         RobotLoadISPyBCallback(),
+        SampleHandlingCallback(),
     ]
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/common/callback_util.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/common/callback_util.py
@@ -11,6 +11,9 @@ from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback 
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
 )
+from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
+    SampleHandlingCallback,
+)
 from mx_bluesky.hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
@@ -53,6 +56,7 @@ def create_load_centre_collect_callbacks() -> (
         RobotLoadISPyBCallback,
         RotationNexusFileCallback,
         RotationISPyBCallback,
+        SampleHandlingCallback,
     ]
 ):
     return (
@@ -61,4 +65,5 @@ def create_load_centre_collect_callbacks() -> (
         RobotLoadISPyBCallback(),
         RotationNexusFileCallback(),
         RotationISPyBCallback(emit=ZocaloCallback()),
+        SampleHandlingCallback(),
     )

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
@@ -89,6 +89,7 @@ class RobotLoadISPyBCallback(PlanReactiveCallback):
                 reason = doc.get("reason") or "OK"
 
             self.expeye_core.end_load(self.action_id, exit_status, reason)
+            assert self._metadata, "Metadata was not set for robot load."
             self.expeye_sample_handling.update_sample_status(
                 self._metadata["sample_id"],
                 BLSampleStatus.LOADED

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
@@ -81,15 +81,11 @@ class RobotLoadISPyBCallback(PlanReactiveCallback):
                 self.action_id is not None
             ), "ISPyB Robot load callback stop called unexpectedly"
             exit_status = doc.get("exit_status")
-            if not exit_status:
-                reason = "Exit status not available in stop document!"
-            elif not self._metadata:
-                reason = "Metadata not received before stop document."
-            else:
-                reason = doc.get("reason") or "OK"
+            assert exit_status, "Exit status not available in stop document!"
+            assert self._metadata, "Metadata not received before stop document."
+            reason = doc.get("reason") or "OK"
 
             self.expeye_core.end_load(self.action_id, exit_status, reason)
-            assert self._metadata, "Metadata was not set for robot load."
             self.expeye_sample_handling.update_sample_status(
                 self._metadata["sample_id"],
                 BLSampleStatus.LOADED

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/robot_load/ispyb_callback.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from event_model.documents import EventDescriptor
-
 from mx_bluesky.hyperion.external_interaction.callbacks.common.ispyb_mapping import (
     get_proposal_and_session_from_visit_string,
 )
@@ -11,7 +9,9 @@ from mx_bluesky.hyperion.external_interaction.callbacks.plan_reactive_callback i
     PlanReactiveCallback,
 )
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
-    ExpeyeInteraction,
+    BLSampleStatus,
+    ExpeyeCoreInteraction,
+    ExpeyeSampleHandlingInteraction,
     RobotActionID,
 )
 from mx_bluesky.hyperion.log import ISPYB_LOGGER
@@ -25,26 +25,29 @@ class RobotLoadISPyBCallback(PlanReactiveCallback):
     def __init__(self) -> None:
         ISPYB_LOGGER.debug("Initialising ISPyB Robot Load Callback")
         super().__init__(log=ISPYB_LOGGER)
+        self._metadata: dict | None = None
         self.run_uid: str | None = None
         self.descriptors: dict[str, EventDescriptor] = {}
         self.action_id: RobotActionID | None = None
-        self.expeye = ExpeyeInteraction()
+        self.expeye_core = ExpeyeCoreInteraction()
+        self.expeye_sample_handling = ExpeyeSampleHandlingInteraction()
 
     def activity_gated_start(self, doc: RunStart):
         ISPYB_LOGGER.debug("ISPyB robot load callback received start document.")
         if doc.get("subplan_name") == CONST.PLAN.ROBOT_LOAD:
             ISPYB_LOGGER.debug(f"ISPyB robot load callback received: {doc}")
             self.run_uid = doc.get("uid")
-            assert isinstance(metadata := doc.get("metadata"), dict)
+            self._metadata = doc.get("metadata")
+            assert isinstance(self._metadata, dict)
             proposal, session = get_proposal_and_session_from_visit_string(
-                metadata["visit"]
+                self._metadata["visit"]
             )
-            self.action_id = self.expeye.start_load(
+            self.action_id = self.expeye_core.start_load(
                 proposal,
                 session,
-                metadata["sample_id"],
-                metadata["sample_puck"],
-                metadata["sample_pin"],
+                self._metadata["sample_id"],
+                self._metadata["sample_puck"],
+                self._metadata["sample_pin"],
             )
         return super().activity_gated_start(doc)
 
@@ -65,7 +68,7 @@ class RobotLoadISPyBCallback(PlanReactiveCallback):
             oav_snapshot = doc["data"]["oav-snapshot-last_saved_path"]
             webcam_snapshot = doc["data"]["webcam-last_saved_path"]
             # I03 uses webcam/oav snapshots in place of before/after snapshots
-            self.expeye.update_barcode_and_snapshots(
+            self.expeye_core.update_barcode_and_snapshots(
                 self.action_id, barcode, webcam_snapshot, oav_snapshot
             )
 
@@ -77,10 +80,20 @@ class RobotLoadISPyBCallback(PlanReactiveCallback):
             assert (
                 self.action_id is not None
             ), "ISPyB Robot load callback stop called unexpectedly"
-            exit_status = (
-                doc.get("exit_status") or "Exit status not available in stop document!"
+            exit_status = doc.get("exit_status")
+            if not exit_status:
+                reason = "Exit status not available in stop document!"
+            elif not self._metadata:
+                reason = "Metadata not received before stop document."
+            else:
+                reason = doc.get("reason") or "OK"
+
+            self.expeye_core.end_load(self.action_id, exit_status, reason)
+            self.expeye_sample_handling.update_sample_status(
+                self._metadata["sample_id"],
+                BLSampleStatus.LOADED
+                if exit_status == "success"
+                else BLSampleStatus.ERROR_BEAMLINE,
             )
-            reason = doc.get("reason") or "OK"
-            self.expeye.end_load(self.action_id, exit_status, reason)
             self.action_id = None
         return super().activity_gated_stop(doc)

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -17,7 +17,7 @@ from mx_bluesky.hyperion.external_interaction.callbacks.plan_reactive_callback i
 )
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
     BLSampleStatus,
-    ExpeyeSampleHandlingInteraction,
+    ExpeyeInteraction,
 )
 from mx_bluesky.hyperion.log import ISPYB_LOGGER
 from mx_bluesky.hyperion.parameters.constants import CONST
@@ -72,7 +72,7 @@ class SampleHandlingCallback(PlanReactiveCallback):
         return doc
 
     def _record_exception(self, exception_type: str):
-        expeye = ExpeyeSampleHandlingInteraction()
+        expeye = ExpeyeInteraction()
         assert self._sample_id, "Unable to record exception due to no sample ID"
         sample_status = self._decode_sample_status(exception_type)
         expeye.update_sample_status(self._sample_id, sample_status)

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -1,0 +1,73 @@
+import dataclasses
+from abc import ABC
+from collections.abc import Generator
+from datetime import time
+from typing import Any
+
+import bluesky.plan_stubs as bps
+from bluesky import Msg
+from bluesky.protocols import Readable, Reading
+from event_model import DataKey, Event, EventDescriptor, RunStart
+
+from mx_bluesky.hyperion.external_interaction.callbacks.plan_reactive_callback import (
+    PlanReactiveCallback,
+)
+from mx_bluesky.hyperion.log import ISPYB_LOGGER
+from mx_bluesky.hyperion.parameters.constants import CONST
+
+
+@dataclasses.dataclass
+class AbstractEvent(Readable, ABC):
+    def _reading_from_value(self, value):
+        return Reading(timestamp=time.time(), value=value)
+
+    def read(self) -> dict[str, Reading]:
+        return {f.name: getattr(self, f.name) for f in dataclasses.fields(self)}
+
+    def describe(self) -> dict[str, DataKey]:
+        return {
+            f.name: DataKey(dtype=f.type, shape=[], source="")
+            for f in dataclasses.fields(self)
+        }
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+
+@dataclasses.dataclass
+class ExceptionEvent(AbstractEvent):
+    exception_type: str
+
+
+def exception_interceptor(exception: Exception) -> Generator[Msg, Any, Any]:
+    yield from bps.create(CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION)
+    event = ExceptionEvent(exception_type=exception.__class__.__name__)
+    yield from bps.read(event)
+    yield from bps.save()
+
+
+class SampleHandlingCallback(PlanReactiveCallback):
+    def __init__(self):
+        super().__init__(log=ISPYB_LOGGER)
+        self._sample_id: int | None = None
+        self._descriptor: str | None = None
+
+    def activity_gated_start(self, doc: RunStart):
+        if not self._sample_id:
+            self._sample_id = doc["metadata"]["sample_id"]
+
+    def activity_gated_descriptor(self, doc: EventDescriptor) -> EventDescriptor | None:
+        if doc["name"] == CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION:
+            self._descriptor = doc["uid"]
+        return super().activity_gated_descriptor(doc)
+
+    def activity_gated_event(self, doc: Event) -> Event | None:
+        if doc["descriptor"] == self._descriptor:
+            exception_type = doc["data"]["exception_type"]
+            self._record_exception(exception_type)
+        return doc
+
+    def _record_exception(self, exception_type: str):
+        # TODO
+        pass

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -10,6 +10,9 @@ from bluesky.utils import make_decorator
 from event_model import Event, EventDescriptor, RunStart
 
 from mx_bluesky.hyperion.exceptions import SampleException
+from mx_bluesky.hyperion.experiment_plans.flyscan_xray_centre_plan import (
+    CrystalNotFoundException,
+)
 from mx_bluesky.hyperion.external_interaction.callbacks.common.abstract_event import (
     AbstractEvent,
 )
@@ -79,6 +82,6 @@ class SampleHandlingCallback(PlanReactiveCallback):
 
     def _decode_sample_status(self, exception_type: str) -> BLSampleStatus:
         match exception_type:
-            case SampleException.__name__:
+            case SampleException.__name__ | CrystalNotFoundException.__name__:
                 return BLSampleStatus.ERROR_SAMPLE
         return BLSampleStatus.ERROR_BEAMLINE

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -4,9 +4,8 @@ from functools import partial
 from typing import Any
 
 import bluesky.plan_stubs as bps
-from bluesky import Msg
 from bluesky.preprocessors import contingency_wrapper
-from bluesky.utils import make_decorator
+from bluesky.utils import Msg, make_decorator
 from event_model import Event, EventDescriptor, RunStart
 
 from mx_bluesky.hyperion.exceptions import SampleException
@@ -61,7 +60,7 @@ class SampleHandlingCallback(PlanReactiveCallback):
             self._sample_id = sample_id
 
     def activity_gated_descriptor(self, doc: EventDescriptor) -> EventDescriptor | None:
-        if doc["name"] == CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION:
+        if doc.get("name") == CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION:
             self._descriptor = doc["uid"]
         return super().activity_gated_descriptor(doc)
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -8,10 +8,7 @@ from bluesky.preprocessors import contingency_wrapper
 from bluesky.utils import Msg, make_decorator
 from event_model import Event, EventDescriptor, RunStart
 
-from mx_bluesky.hyperion.exceptions import SampleException
-from mx_bluesky.hyperion.experiment_plans.flyscan_xray_centre_plan import (
-    CrystalNotFoundException,
-)
+from mx_bluesky.hyperion.exceptions import CrystalNotFoundException, SampleException
 from mx_bluesky.hyperion.external_interaction.callbacks.common.abstract_event import (
     AbstractEvent,
 )

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -46,7 +46,8 @@ sample_handling_callback_decorator = make_decorator(
 
 
 class SampleHandlingCallback(PlanReactiveCallback):
-    """Intercepts"""
+    """Intercepts exceptions from experiment plans and updates the ISPyB BLSampleStatus
+    field according to the type of exception raised."""
 
     def __init__(self):
         super().__init__(log=ISPYB_LOGGER)

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -53,13 +53,16 @@ if TYPE_CHECKING:
 
 
 def ispyb_activation_wrapper(plan_generator: MsgGenerator, parameters):
-    return bpp.run_wrapper(
-        plan_generator,
-        md={
-            "activate_callbacks": ["GridscanISPyBCallback"],
-            "subplan_name": CONST.PLAN.GRID_DETECT_AND_DO_GRIDSCAN,
-            "hyperion_parameters": parameters.model_dump_json(),
-        },
+    return bpp.set_run_key_wrapper(
+        bpp.run_wrapper(
+            plan_generator,
+            md={
+                "activate_callbacks": ["GridscanISPyBCallback"],
+                "subplan_name": CONST.PLAN.GRID_DETECT_AND_DO_GRIDSCAN,
+                "hyperion_parameters": parameters.model_dump_json(),
+            },
+        ),
+        CONST.PLAN.ISPYB_ACTIVATION,
     )
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/exceptions.py
+++ b/src/mx_bluesky/hyperion/external_interaction/exceptions.py
@@ -1,13 +1,4 @@
-from mx_bluesky.hyperion.exceptions import WarningException
-
-
 class ISPyBDepositionNotMade(Exception):
     """Raised when the ISPyB or Zocalo callbacks can't access ISPyB deposition numbers."""
-
-    pass
-
-
-class NoCentreFoundException(WarningException):
-    """Error for if zocalo is unable to find the centre during a gridscan."""
 
     pass

--- a/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
+++ b/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
@@ -156,7 +156,7 @@ class ExpeyeSampleHandlingInteraction:
 
     def __init__(self):
         base_uri, token = _get_base_url_and_token()
-        self._uri = base_uri + "/sample-handling"
+        self._uri = base_uri
         self._auth = BearerAuth(token)
 
     def update_sample_status(

--- a/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
+++ b/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
@@ -125,7 +125,7 @@ class ExpeyeCoreInteraction:
         data = {
             "endTimestamp": get_current_time_string(),
             "status": run_status,
-            "message": reason[:255] if reason else None,
+            "message": reason[:255] if reason else "",
         }
         _send_and_get_response(self.auth, url, data, patch)
 

--- a/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
+++ b/src/mx_bluesky/hyperion/external_interaction/ispyb/exp_eye_store.py
@@ -134,9 +134,14 @@ class BLSampleStatus(StrEnum):
     # The sample has been loaded
     LOADED = "LOADED"
     # Problem with the sample e.g. pin too long/short
-    ERROR_SAMPLE = "ERROR - sample error"
+    ERROR_SAMPLE = "ERROR - sample"
     # Any other general error
-    ERROR_BEAMLINE = "ERROR - beamline error"
+    ERROR_BEAMLINE = "ERROR - beamline"
+
+
+assert all(
+    len(value) <= 20 for value in BLSampleStatus
+), "Column size limit of 20 for BLSampleStatus"
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,12 +283,12 @@ def smargon(RE: RunEngine) -> Generator[Smargon, None, None]:
     set_mock_value(smargon.x.user_readback, 0.0)
     set_mock_value(smargon.y.user_readback, 0.0)
     set_mock_value(smargon.z.user_readback, 0.0)
-    set_mock_value(smargon.x.high_limit_travel, 4)
-    set_mock_value(smargon.x.low_limit_travel, -4)
-    set_mock_value(smargon.y.high_limit_travel, 4)
-    set_mock_value(smargon.y.low_limit_travel, -4)
-    set_mock_value(smargon.z.high_limit_travel, 4)
-    set_mock_value(smargon.z.low_limit_travel, -4)
+    set_mock_value(smargon.x.high_limit_travel, 2)
+    set_mock_value(smargon.x.low_limit_travel, -2)
+    set_mock_value(smargon.y.high_limit_travel, 2)
+    set_mock_value(smargon.y.low_limit_travel, -2)
+    set_mock_value(smargon.z.high_limit_travel, 2)
+    set_mock_value(smargon.z.low_limit_travel, -2)
 
     with (
         patch_async_motor(smargon.omega),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,12 +283,12 @@ def smargon(RE: RunEngine) -> Generator[Smargon, None, None]:
     set_mock_value(smargon.x.user_readback, 0.0)
     set_mock_value(smargon.y.user_readback, 0.0)
     set_mock_value(smargon.z.user_readback, 0.0)
-    set_mock_value(smargon.x.high_limit_travel, 2)
-    set_mock_value(smargon.x.low_limit_travel, -2)
-    set_mock_value(smargon.y.high_limit_travel, 2)
-    set_mock_value(smargon.y.low_limit_travel, -2)
-    set_mock_value(smargon.z.high_limit_travel, 2)
-    set_mock_value(smargon.z.low_limit_travel, -2)
+    set_mock_value(smargon.x.high_limit_travel, 4)
+    set_mock_value(smargon.x.low_limit_travel, -4)
+    set_mock_value(smargon.y.high_limit_travel, 4)
+    set_mock_value(smargon.y.low_limit_travel, -4)
+    set_mock_value(smargon.z.high_limit_travel, 4)
+    set_mock_value(smargon.z.low_limit_travel, -4)
 
     with (
         patch_async_motor(smargon.omega),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,6 @@ from dodal.devices.synchrotron import Synchrotron, SynchrotronMode
 from dodal.devices.thawer import Thawer
 from dodal.devices.undulator import Undulator
 from dodal.devices.util.test_utils import patch_motor
-from dodal.devices.util.test_utils import patch_motor as oa_patch_motor
 from dodal.devices.webcam import Webcam
 from dodal.devices.xbpm_feedback import XBPMFeedback
 from dodal.devices.zebra import ArmDemand, Zebra
@@ -431,9 +430,9 @@ def set_up_dcm(dcm):
     set_mock_value(dcm.energy_in_kev.user_readback, 12.7)
     set_mock_value(dcm.pitch_in_mrad.user_readback, 1)
     set_mock_value(dcm.crystal_metadata_d_spacing, 3.13475)
-    oa_patch_motor(dcm.roll_in_mrad)
-    oa_patch_motor(dcm.pitch_in_mrad)
-    oa_patch_motor(dcm.offset_in_mm)
+    patch_motor(dcm.roll_in_mrad)
+    patch_motor(dcm.pitch_in_mrad)
+    patch_motor(dcm.offset_in_mm)
     return dcm
 
 
@@ -459,9 +458,9 @@ def vfm(RE):
 def lower_gonio(RE):
     lower_gonio = i03.lower_gonio(fake_with_ophyd_sim=True)
     with (
-        oa_patch_motor(lower_gonio.x),
-        oa_patch_motor(lower_gonio.y),
-        oa_patch_motor(lower_gonio.z),
+        patch_motor(lower_gonio.x),
+        patch_motor(lower_gonio.y),
+        patch_motor(lower_gonio.z),
     ):
         yield lower_gonio
 

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp import ClientResponse
+
 from dodal.beamlines import i03
 from dodal.devices.oav.oav_parameters import OAVConfig
 from ophyd_async.core import set_mock_value

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp import ClientResponse
-
 from dodal.beamlines import i03
 from dodal.devices.oav.oav_parameters import OAVConfig
 from ophyd_async.core import set_mock_value

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -170,7 +170,7 @@ def compare_actual_and_expected(
         if isinstance(v, float):
             actual_v = actual == pytest.approx(v)
         elif isinstance(v, str) and v.startswith("regex:"):
-            actual_v = re.match(v.removeprefix("regex:"), actual)  # type: ignore
+            actual_v = re.match(v.removeprefix("regex:"), str(actual))  # type: ignore
         else:
             actual_v = actual == v
         if not actual_v:

--- a/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
+++ b/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
@@ -7,8 +7,7 @@ from requests import get
 
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
     BLSampleStatus,
-    ExpeyeCoreInteraction,
-    ExpeyeSampleHandlingInteraction,
+    ExpeyeInteraction,
 )
 from mx_bluesky.hyperion.parameters.constants import CONST
 
@@ -42,7 +41,7 @@ def test_start_and_end_robot_load(message: str, expected_message: str):
     """
     BARCODE = "test_barcode"
 
-    expeye = ExpeyeCoreInteraction()
+    expeye = ExpeyeInteraction()
 
     robot_action_id = expeye.start_load("cm37235", 2, SAMPLE_ID, 40, 3)
 
@@ -61,8 +60,8 @@ def test_start_and_end_robot_load(message: str, expected_message: str):
 
     expeye.end_load(robot_action_id, "fail", message)
 
-    get_robot_data_url = f"{expeye.base_url}/robot-actions/{robot_action_id}"
-    response = get(get_robot_data_url, auth=expeye.auth)
+    get_robot_data_url = f"{expeye._base_url}/robot-actions/{robot_action_id}"
+    response = get(get_robot_data_url, auth=expeye._auth)
 
     assert response.ok
     response = response.json()
@@ -75,7 +74,7 @@ def test_start_and_end_robot_load(message: str, expected_message: str):
 
 @pytest.mark.s03
 def test_update_sample_updates_the_sample_status():
-    sample_handling = ExpeyeSampleHandlingInteraction()
+    sample_handling = ExpeyeInteraction()
     output_sample = sample_handling.update_sample_status(
         SAMPLE_ID, BLSampleStatus.ERROR_SAMPLE
     )

--- a/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
+++ b/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
@@ -1,27 +1,48 @@
 import os
 from time import sleep
+from unittest.mock import patch
 
 import pytest
 from requests import get
 
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
-    ExpeyeInteraction,
+    BLSampleStatus,
+    ExpeyeCoreInteraction,
+    ExpeyeSampleHandlingInteraction,
 )
 from mx_bluesky.hyperion.parameters.constants import CONST
 
+CONTAINER_ID = 288588
+SAMPLE_ID = 5289780
+
+
+@pytest.fixture(autouse=True)
+def use_dev_ispyb():
+    with patch.dict(
+        os.environ, {"ISPYB_CONFIG_PATH": CONST.SIM.DEV_ISPYB_DATABASE_CFG}
+    ):
+        yield
+
 
 @pytest.mark.s03
-def test_start_and_end_robot_load():
+@pytest.mark.parametrize(
+    "message, expected_message",
+    [
+        ("Oh no!", "Oh no!"),
+        (
+            "Long message that will be truncated " + ("*" * 255),
+            "Long message that will be truncated " + ("*" * 219),
+        ),
+    ],
+)
+def test_start_and_end_robot_load(message: str, expected_message: str):
     """To confirm this test is successful go to
     https://ispyb-test.diamond.ac.uk/dc/visit/cm37235-2 and see that data is added
     when it's run.
     """
-    os.environ["ISPYB_CONFIG_PATH"] = CONST.SIM.DEV_ISPYB_DATABASE_CFG
-
-    SAMPLE_ID = 5289780
     BARCODE = "test_barcode"
 
-    expeye = ExpeyeInteraction()
+    expeye = ExpeyeCoreInteraction()
 
     robot_action_id = expeye.start_load("cm37235", 2, SAMPLE_ID, 40, 3)
 
@@ -38,15 +59,26 @@ def test_start_and_end_robot_load():
 
     sleep(0.5)
 
-    expeye.end_load(robot_action_id, "fail", "Oh no!")
+    expeye.end_load(robot_action_id, "fail", message)
 
     get_robot_data_url = f"{expeye.base_url}/robot-actions/{robot_action_id}"
     response = get(get_robot_data_url, auth=expeye.auth)
 
     assert response.ok
-
     response = response.json()
     assert response["robotActionId"] == robot_action_id
     assert response["status"] == "ERROR"
     assert response["sampleId"] == SAMPLE_ID
     assert response["sampleBarcode"] == BARCODE
+    assert response["message"] == expected_message
+
+
+@pytest.mark.s03
+def test_update_sample_updates_the_sample_status():
+    sample_handling = ExpeyeSampleHandlingInteraction()
+    output_sample = sample_handling.update_sample_status(
+        SAMPLE_ID, BLSampleStatus.ERROR_SAMPLE
+    )
+    expected_status = "ERROR - sample error"
+    assert output_sample.bl_sample_status == expected_status
+    assert output_sample.container_id == CONTAINER_ID

--- a/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
+++ b/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
@@ -79,6 +79,6 @@ def test_update_sample_updates_the_sample_status():
     output_sample = sample_handling.update_sample_status(
         SAMPLE_ID, BLSampleStatus.ERROR_SAMPLE
     )
-    expected_status = "ERROR - sample error"
+    expected_status = "ERROR - sample"
     assert output_sample.bl_sample_status == expected_status
     assert output_sample.container_id == CONTAINER_ID

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -186,8 +186,8 @@ def test_execute_load_centre_collect_full_plan(
     ispyb_gridscan_cb = GridscanISPyBCallback()
     ispyb_rotation_cb = RotationISPyBCallback()
     robot_load_cb = RobotLoadISPyBCallback()
-    robot_load_cb.expeye = MagicMock()
-    robot_load_cb.expeye.start_load.return_value = 1234
+    robot_load_cb.expeye_core = MagicMock()
+    robot_load_cb.expeye_core.start_load.return_value = 1234
     set_mock_value(
         load_centre_collect_composite.undulator_dcm.undulator.current_gap, 1.11
     )
@@ -202,14 +202,16 @@ def test_execute_load_centre_collect_full_plan(
         )
     )
 
-    assert robot_load_cb.expeye.start_load.called_once_with("cm37235", 4, 5461074, 2, 6)
-    assert robot_load_cb.expeye.update_barcode_and_snapshots(
+    assert robot_load_cb.expeye_core.start_load.called_once_with(
+        "cm37235", 4, 5461074, 2, 6
+    )
+    assert robot_load_cb.expeye_core.update_barcode_and_snapshots(
         1234,
         "BARCODE",
         "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots/160705_webcam_after_load.png",
         "/tmp/snapshot1.png",
     )
-    assert robot_load_cb.expeye.end_load(1234, "success", "OK")
+    assert robot_load_cb.expeye_core.end_load(1234, "success", "OK")
 
     # Compare gridscan collection
     compare_actual_and_expected(

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -207,7 +207,7 @@ def use_dev_ispyb():
 
 
 @pytest.mark.s03
-def test_execute_load_centre_collect_full_plan(
+def test_execute_load_centre_collect_full(
     load_centre_collect_composite: LoadCentreCollectComposite,
     load_centre_collect_params: LoadCentreCollect,
     oav_parameters_for_rotation: OAVParameters,
@@ -328,7 +328,7 @@ def test_load_centre_collect_updates_bl_sample_status_robot_load_fail(
         pytest.raises(TimeoutError, match="Simulated timeout"),
     ):
         RE(
-            load_centre_collect_full_plan(
+            load_centre_collect_full(
                 load_centre_collect_composite,
                 load_centre_collect_params,
                 oav_parameters_for_rotation,
@@ -358,7 +358,7 @@ def test_load_centre_collect_updates_bl_sample_status_pin_tip_detection_fail(
         WarningException, match="Pin tip centring failed - pin too long/short.*"
     ):
         RE(
-            load_centre_collect_full_plan(
+            load_centre_collect_full(
                 load_centre_collect_composite,
                 load_centre_collect_params,
                 oav_parameters_for_rotation,
@@ -406,7 +406,7 @@ def test_load_centre_collect_updates_bl_sample_status_grid_detection_fail_tip_no
 
     with pytest.raises(WarningException, match="No pin found after 5.0 seconds"):
         RE(
-            load_centre_collect_full_plan(
+            load_centre_collect_full(
                 load_centre_collect_composite,
                 load_centre_collect_params,
                 oav_parameters_for_rotation,
@@ -433,7 +433,7 @@ def test_load_centre_collect_updates_bl_sample_status_gridscan_no_diffraction(
 
     with pytest.raises(CrystalNotFoundException):
         RE(
-            load_centre_collect_full_plan(
+            load_centre_collect_full(
                 composite_with_no_diffraction,
                 load_centre_collect_params,
                 oav_parameters_for_rotation,
@@ -466,7 +466,7 @@ def test_load_centre_collect_updates_bl_sample_status_rotation_failure(
         pytest.raises(TimeoutError, match="Simulated timeout"),
     ):
         RE(
-            load_centre_collect_full_plan(
+            load_centre_collect_full(
                 load_centre_collect_composite,
                 load_centre_collect_params,
                 oav_parameters_for_rotation,

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -187,16 +187,14 @@ SAMPLE_ID = 5461074
 @pytest.fixture
 def composite_with_no_diffraction(
     load_centre_collect_composite: LoadCentreCollectComposite,
-) -> LoadCentreCollectComposite:
+) -> Generator[LoadCentreCollectComposite, Any, None]:
     zocalo = load_centre_collect_composite.zocalo
 
     @AsyncStatus.wrap
     async def mock_zocalo_complete():
         await zocalo._put_results([], {"dcid": 0, "dcgid": 0})
 
-    with (
-        patch.object(zocalo, "trigger", side_effect=mock_zocalo_complete),
-    ):
+    with patch.object(zocalo, "trigger", side_effect=mock_zocalo_complete):
         yield load_centre_collect_composite
 
 
@@ -306,7 +304,7 @@ def test_execute_load_centre_collect_full_plan(
         ispyb_rotation_cb.ispyb_ids.data_collection_ids[0],
         "Sample position (µm): (-2309, -591, 341) Hyperion Rotation Scan -   Aperture: ApertureValue.SMALL. ",
     )
-    assert fetch_blsample(SAMPLE_ID).blSampleStatus == "LOADED"
+    assert fetch_blsample(SAMPLE_ID).blSampleStatus == "LOADED"  # type: ignore
 
 
 @pytest.mark.s03
@@ -401,8 +399,8 @@ def test_load_centre_collect_updates_bl_sample_status_grid_detection_fail_tip_no
                 PinTipDetection.INVALID_POSITION,
             )
             trigger = load_centre_collect_composite.pin_tip_detection.trigger
-            trigger.return_value = NullStatus()
-            trigger.side_effect = None
+            trigger.return_value = NullStatus()  # type:ignore
+            trigger.side_effect = None  # type: ignore
 
     RE.subscribe(wait_for_first_oav_grid)
 

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -220,8 +220,10 @@ def test_execute_load_centre_collect_full(
     ispyb_gridscan_cb = GridscanISPyBCallback()
     ispyb_rotation_cb = RotationISPyBCallback()
     robot_load_cb = RobotLoadISPyBCallback()
-    robot_load_cb.expeye_core = MagicMock()
-    robot_load_cb.expeye_core.start_load.return_value = 1234
+    # robot_load_cb.expeye = MagicMock()
+    robot_load_cb.expeye.start_load = MagicMock(return_value=1234)
+    robot_load_cb.expeye.end_load = MagicMock()
+    robot_load_cb.expeye.update_barcode_and_snapshots = MagicMock()
     set_mock_value(
         load_centre_collect_composite.undulator_dcm.undulator.current_gap, 1.11
     )
@@ -236,16 +238,15 @@ def test_execute_load_centre_collect_full(
         )
     )
 
-    assert robot_load_cb.expeye_core.start_load.called_once_with(
-        "cm37235", 4, 5461074, 2, 6
-    )
-    assert robot_load_cb.expeye_core.update_barcode_and_snapshots(
-        1234,
-        "BARCODE",
-        "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots/160705_webcam_after_load.png",
-        "/tmp/snapshot1.png",
-    )
-    assert robot_load_cb.expeye_core.end_load(1234, "success", "OK")
+    robot_load_cb.expeye.start_load.assert_called_once_with("cm37235", 4, 5461074, 2, 6)
+    # TODO re-enable this https://github.com/DiamondLightSource/mx-bluesky/issues/690
+    # robot_load_cb.expeye.update_barcode_and_snapshots.assert_called_once_with(
+    #     1234,
+    #     "BARCODE",
+    #     "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots/160705_webcam_after_load.png",
+    #     "/tmp/snapshot1.png",
+    # )
+    robot_load_cb.expeye.end_load.assert_called_once_with(1234, "success", "OK")
 
     # Compare gridscan collection
     compare_actual_and_expected(

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -199,7 +199,7 @@ def composite_with_no_diffraction(
 
 
 @pytest.fixture(autouse=True)
-def use_real_ispyb():
+def use_dev_ispyb():
     with patch.dict(
         os.environ, values={"ISPYB_CONFIG_PATH": CONST.SIM.DEV_ISPYB_DATABASE_CFG}
     ):

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -203,7 +203,7 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
 )
 @patch(
     "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
-    MagicMock()
+    MagicMock(),
 )
 def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_then_ispyb_deposited(
     start_load: MagicMock,

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -189,26 +189,14 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
-)
-@patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.update_barcode_and_snapshots"
-)
-@patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.start_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction"
 )
 @patch(
     "mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.set_energy_plan",
     MagicMock(return_value=iter([])),
 )
-@patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
-    MagicMock(),
-)
 def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_then_ispyb_deposited(
-    start_load: MagicMock,
-    update_barcode_and_snapshots: MagicMock,
-    end_load: MagicMock,
+    exp_eye: MagicMock,
     robot_load_and_energy_change_composite: RobotLoadAndEnergyChangeComposite,
     robot_load_and_energy_change_params: RobotLoadAndEnergyChange,
 ):
@@ -228,7 +216,7 @@ def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_t
     RE.subscribe(RobotLoadISPyBCallback())
 
     action_id = 1098
-    start_load.return_value = action_id
+    exp_eye.return_value.start_load.return_value = action_id
 
     RE(
         robot_load_and_change_energy_plan(
@@ -236,11 +224,11 @@ def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_t
         )
     )
 
-    start_load.assert_called_once_with("cm31105", 4, 12345, 40, 3)
-    update_barcode_and_snapshots.assert_called_once_with(
+    exp_eye.return_value.start_load.assert_called_once_with("cm31105", 4, 12345, 40, 3)
+    exp_eye.return_value.update_barcode_and_snapshots.assert_called_once_with(
         action_id, "BARCODE", "test_webcam_snapshot", "test_oav_snapshot"
     )
-    end_load.assert_called_once_with(action_id, "success", "OK")
+    exp_eye.return_value.end_load.assert_called_once_with(action_id, "success", "OK")
 
 
 @patch("mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.datetime")

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -201,10 +201,10 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
     "mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.set_energy_plan",
     MagicMock(return_value=iter([])),
 )
-# @patch(
-#     "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
-#     MagicMock()
-# )
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    MagicMock()
+)
 def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_then_ispyb_deposited(
     start_load: MagicMock,
     update_barcode_and_snapshots: MagicMock,

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -201,6 +201,10 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
     "mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.set_energy_plan",
     MagicMock(return_value=iter([])),
 )
+# @patch(
+#     "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+#     MagicMock()
+# )
 def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_then_ispyb_deposited(
     start_load: MagicMock,
     update_barcode_and_snapshots: MagicMock,

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -189,13 +189,13 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.end_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.update_barcode_and_snapshots"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.update_barcode_and_snapshots"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.start_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.start_load"
 )
 @patch(
     "mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.set_energy_plan",

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/robot_load/test_robot_load_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/robot_load/test_robot_load_ispyb_callback.py
@@ -12,6 +12,7 @@ from ophyd_async.core import set_mock_value
 from mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback import (
     RobotLoadISPyBCallback,
 )
+from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import BLSampleStatus
 from mx_bluesky.hyperion.parameters.constants import CONST
 
 VISIT = "cm31105-4"
@@ -36,10 +37,14 @@ metadata = {
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.end_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.start_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.start_load"
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    new=MagicMock(),
 )
 def test_given_start_doc_with_expected_data_then_data_put_in_ispyb(
     start_load: MagicMock,
@@ -60,10 +65,14 @@ def test_given_start_doc_with_expected_data_then_data_put_in_ispyb(
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.end_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.start_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.start_load"
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    new=MagicMock(),
 )
 def test_given_failing_plan_then_exception_detail(
     start_load: MagicMock,
@@ -88,7 +97,11 @@ def test_given_failing_plan_then_exception_detail(
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.end_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    new=MagicMock(),
 )
 def test_given_end_called_but_no_start_then_exception_raised(end_load):
     callback = RobotLoadISPyBCallback()
@@ -98,14 +111,33 @@ def test_given_end_called_but_no_start_then_exception_raised(end_load):
     end_load.assert_not_called()
 
 
+@bpp.run_decorator(md=metadata)
+def successful_robot_load_plan(robot: BartRobot, oav: OAV, webcam: Webcam):
+    yield from bps.create(name=CONST.DESCRIPTORS.ROBOT_LOAD)
+    yield from bps.read(robot.barcode)
+    yield from bps.read(oav.snapshot)  # type: ignore # See: https://github.com/bluesky/bluesky/issues/1809
+    yield from bps.read(webcam)
+    yield from bps.save()
+
+
+@bpp.run_decorator(md=metadata)
+def unsuccessful_robot_load_plan():
+    yield from []
+    raise AssertionError("Test failure")
+
+
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.end_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.end_load"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.start_load"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.start_load"
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeInteraction.update_barcode_and_snapshots"
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction.update_barcode_and_snapshots"
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    new=MagicMock(),
 )
 def test_given_plan_reads_barcode_then_data_put_in_ispyb(
     update_barcode_and_snapshots: MagicMock,
@@ -122,18 +154,59 @@ def test_given_plan_reads_barcode_then_data_put_in_ispyb(
     set_mock_value(oav.snapshot.last_saved_path, "test_oav_snapshot")
     set_mock_value(webcam.last_saved_path, "test_webcam_snapshot")
 
-    @bpp.run_decorator(md=metadata)
-    def my_plan():
-        yield from bps.create(name=CONST.DESCRIPTORS.ROBOT_LOAD)
-        yield from bps.read(robot.barcode)
-        yield from bps.read(oav.snapshot)  # type: ignore # See: https://github.com/bluesky/bluesky/issues/1809
-        yield from bps.read(webcam)
-        yield from bps.save()
-
-    RE(my_plan())
+    RE(successful_robot_load_plan(robot, oav, webcam))
 
     start_load.assert_called_once_with("cm31105", 4, SAMPLE_ID, SAMPLE_PUCK, SAMPLE_PIN)
     update_barcode_and_snapshots.assert_called_once_with(
         ACTION_ID, "BARCODE", "test_webcam_snapshot", "test_oav_snapshot"
     )
     end_load.assert_called_once_with(ACTION_ID, "success", "OK")
+
+
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction",
+    new=MagicMock(),
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    autospec=True,
+)
+def test_robot_load_complete_triggers_bl_sample_status_loaded(
+    mock_sample_handling,
+    RE: RunEngine,
+    robot: BartRobot,
+    oav: OAV,
+    webcam: Webcam,
+):
+    RE.subscribe(RobotLoadISPyBCallback())
+
+    RE(successful_robot_load_plan(robot, oav, webcam))
+
+    mock_sample_handling.return_value.update_sample_status.assert_called_with(
+        SAMPLE_ID, BLSampleStatus.LOADED
+    )
+
+
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeCoreInteraction",
+    new=MagicMock(),
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback.ExpeyeSampleHandlingInteraction",
+    autospec=True,
+)
+def test_robot_load_fails_triggers_bl_sample_status_error(
+    mock_sample_handling,
+    RE: RunEngine,
+    robot: BartRobot,
+    oav: OAV,
+    webcam: Webcam,
+):
+    RE.subscribe(RobotLoadISPyBCallback())
+
+    with pytest.raises(AssertionError, match="Test failure"):
+        RE(unsuccessful_robot_load_plan())
+
+    mock_sample_handling.return_value.update_sample_status.assert_called_with(
+        SAMPLE_ID, BLSampleStatus.ERROR_BEAMLINE
+    )

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -324,8 +324,3 @@ def test_comment_correct_after_hardware_read(
             "wavelength": 1.1164718451643736,
         },
     )
-
-
-def test_end_deposition_updates_bl_sample_id_with_status_on_failure():
-    # assert False, "TODO"
-    pass

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -324,3 +324,8 @@ def test_comment_correct_after_hardware_read(
             "wavelength": 1.1164718451643736,
         },
     )
+
+
+def test_end_deposition_updates_bl_sample_id_with_status_on_failure():
+    # assert False, "TODO"
+    pass

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+from bluesky import RunEngine
+from bluesky.preprocessors import contingency_decorator, run_decorator
+
+from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
+    SampleHandlingCallback,
+    exception_interceptor,
+)
+
+TEST_SAMPLE_ID = 123456
+
+
+@run_decorator(md={"sample_id": TEST_SAMPLE_ID})
+@contingency_decorator(except_plan=exception_interceptor, auto_raise=True)
+def plan_with_general_exception():
+    yield from []
+    raise AssertionError("Test failure")
+
+
+def test_sample_handling_callback_intercepts_general_exception(RE: RunEngine):
+    callback = SampleHandlingCallback()
+    RE.subscribe(callback)
+
+    with patch.object(callback, "_record_exception") as record_exception:
+        RE(plan_with_general_exception())
+
+        record_exception.assert_called_once_with("AssertionError")

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -58,7 +58,7 @@ def test_sample_handling_callback_intercepts_general_exception(
     with (
         patch(
             "mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback"
-            ".ExpeyeSampleHandlingInteraction",
+            ".ExpeyeInteraction",
             return_value=mock_expeye,
         ),
         pytest.raises(exception_type),

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch
 
 import pytest
-from bluesky import RunEngine
 from bluesky.preprocessors import run_decorator
+from bluesky.run_engine import RunEngine
 
 from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
     SampleHandlingCallback,

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -1,28 +1,48 @@
 from unittest.mock import patch
 
+import pytest
 from bluesky import RunEngine
 from bluesky.preprocessors import contingency_decorator, run_decorator
 
 from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
     SampleHandlingCallback,
-    exception_interceptor,
+    exception_handling_decorator,
 )
 
 TEST_SAMPLE_ID = 123456
 
 
-@run_decorator(md={"sample_id": TEST_SAMPLE_ID})
-@contingency_decorator(except_plan=exception_interceptor, auto_raise=True)
+@run_decorator(md={"metadata": {"sample_id": TEST_SAMPLE_ID},
+                   "activate_callbacks": ["SampleHandlingCallback"]})
+@exception_handling_decorator()
 def plan_with_general_exception():
     yield from []
     raise AssertionError("Test failure")
+
+@exception_handling_decorator()
+@run_decorator(md={"metadata": {"sample_id": TEST_SAMPLE_ID},
+                   "activate_callbacks": ["SampleHandlingCallback"]})
+def plan_with_normal_completion():
+    yield from []
 
 
 def test_sample_handling_callback_intercepts_general_exception(RE: RunEngine):
     callback = SampleHandlingCallback()
     RE.subscribe(callback)
 
-    with patch.object(callback, "_record_exception") as record_exception:
+    with (patch.object(callback, "_record_exception") as record_exception,
+        pytest.raises(AssertionError)):
         RE(plan_with_general_exception())
 
-        record_exception.assert_called_once_with("AssertionError")
+    record_exception.assert_called_once_with("AssertionError")
+
+
+def test_sample_handling_callback_closes_run_normally(RE: RunEngine):
+    callback = SampleHandlingCallback()
+    RE.subscribe(callback)
+
+    with (patch.object(callback, "_record_exception") as record_exception,
+        ):
+        RE(plan_with_normal_completion())
+
+    record_exception.assert_not_called()

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -1,13 +1,18 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from bluesky.preprocessors import run_decorator
 from bluesky.run_engine import RunEngine
 
+from mx_bluesky.hyperion.exceptions import SampleException
+from mx_bluesky.hyperion.experiment_plans.flyscan_xray_centre_plan import (
+    CrystalNotFoundException,
+)
 from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
     SampleHandlingCallback,
     sample_handling_callback_decorator,
 )
+from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import BLSampleStatus
 
 TEST_SAMPLE_ID = 123456
 
@@ -19,9 +24,9 @@ TEST_SAMPLE_ID = 123456
     }
 )
 @sample_handling_callback_decorator()
-def plan_with_general_exception():
+def plan_with_general_exception(exception_type: type):
     yield from []
-    raise AssertionError("Test failure")
+    raise exception_type("Test failure")
 
 
 @run_decorator(
@@ -35,17 +40,33 @@ def plan_with_normal_completion():
     yield from []
 
 
-def test_sample_handling_callback_intercepts_general_exception(RE: RunEngine):
+@pytest.mark.parametrize(
+    "exception_type, expected_sample_status",
+    [
+        [AssertionError, BLSampleStatus.ERROR_BEAMLINE],
+        [SampleException, BLSampleStatus.ERROR_SAMPLE],
+        [CrystalNotFoundException, BLSampleStatus.ERROR_SAMPLE],
+    ],
+)
+def test_sample_handling_callback_intercepts_general_exception(
+    RE: RunEngine, exception_type: type, expected_sample_status: BLSampleStatus
+):
     callback = SampleHandlingCallback()
     RE.subscribe(callback)
 
+    mock_expeye = MagicMock()
     with (
-        patch.object(callback, "_record_exception") as record_exception,
-        pytest.raises(AssertionError),
+        patch(
+            "mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback"
+            ".ExpeyeSampleHandlingInteraction",
+            return_value=mock_expeye,
+        ),
+        pytest.raises(exception_type),
     ):
-        RE(plan_with_general_exception())
-
-    record_exception.assert_called_once_with("AssertionError")
+        RE(plan_with_general_exception(exception_type))
+    mock_expeye.update_sample_status.assert_called_once_with(
+        TEST_SAMPLE_ID, expected_sample_status
+    )
 
 
 def test_sample_handling_callback_closes_run_normally(RE: RunEngine):

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -2,26 +2,35 @@ from unittest.mock import patch
 
 import pytest
 from bluesky import RunEngine
-from bluesky.preprocessors import contingency_decorator, run_decorator
+from bluesky.preprocessors import run_decorator
 
 from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
     SampleHandlingCallback,
-    exception_handling_decorator,
+    sample_handling_callback_decorator,
 )
 
 TEST_SAMPLE_ID = 123456
 
 
-@run_decorator(md={"metadata": {"sample_id": TEST_SAMPLE_ID},
-                   "activate_callbacks": ["SampleHandlingCallback"]})
-@exception_handling_decorator()
+@run_decorator(
+    md={
+        "metadata": {"sample_id": TEST_SAMPLE_ID},
+        "activate_callbacks": ["SampleHandlingCallback"],
+    }
+)
+@sample_handling_callback_decorator()
 def plan_with_general_exception():
     yield from []
     raise AssertionError("Test failure")
 
-@exception_handling_decorator()
-@run_decorator(md={"metadata": {"sample_id": TEST_SAMPLE_ID},
-                   "activate_callbacks": ["SampleHandlingCallback"]})
+
+@run_decorator(
+    md={
+        "metadata": {"sample_id": TEST_SAMPLE_ID},
+        "activate_callbacks": ["SampleHandlingCallback"],
+    }
+)
+@sample_handling_callback_decorator()
 def plan_with_normal_completion():
     yield from []
 
@@ -30,8 +39,10 @@ def test_sample_handling_callback_intercepts_general_exception(RE: RunEngine):
     callback = SampleHandlingCallback()
     RE.subscribe(callback)
 
-    with (patch.object(callback, "_record_exception") as record_exception,
-        pytest.raises(AssertionError)):
+    with (
+        patch.object(callback, "_record_exception") as record_exception,
+        pytest.raises(AssertionError),
+    ):
         RE(plan_with_general_exception())
 
     record_exception.assert_called_once_with("AssertionError")
@@ -41,8 +52,9 @@ def test_sample_handling_callback_closes_run_normally(RE: RunEngine):
     callback = SampleHandlingCallback()
     RE.subscribe(callback)
 
-    with (patch.object(callback, "_record_exception") as record_exception,
-        ):
+    with (
+        patch.object(callback, "_record_exception") as record_exception,
+    ):
         RE(plan_with_normal_completion())
 
     record_exception.assert_not_called()

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -38,7 +38,7 @@ def test_main_function(
 
 
 def test_setup_callbacks():
-    current_number_of_callbacks = 6
+    current_number_of_callbacks = 7
     cbs = setup_callbacks()
     assert len(cbs) == current_number_of_callbacks
     assert len(set(cbs)) == current_number_of_callbacks

--- a/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
+++ b/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
@@ -5,7 +5,7 @@ import pytest
 from mx_bluesky.hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
     BearerAuth,
-    ExpeyeInteraction,
+    ExpeyeCoreInteraction,
     _get_base_url_and_token,
 )
 
@@ -20,7 +20,7 @@ def test_get_url_and_token_returns_expected_data():
 def test_when_start_load_called_then_correct_expected_url_posted_to_with_expected_data(
     mock_post,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.start_load("test", 3, 700, 10, 5)
 
     mock_post.assert_called_once()
@@ -41,7 +41,7 @@ def test_when_start_load_called_then_correct_expected_url_posted_to_with_expecte
 @patch("mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store.post")
 def test_when_start_called_then_returns_id(mock_post):
     mock_post.return_value.json.return_value = {"robotActionId": 190}
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     robot_id = expeye_interactor.start_load("test", 3, 700, 10, 5)
     assert robot_id == 190
 
@@ -50,7 +50,7 @@ def test_when_start_called_then_returns_id(mock_post):
 def test_when_start_load_called_then_use_correct_token(
     mock_post,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.start_load("test", 3, 700, 10, 5)
 
     assert isinstance(auth := mock_post.call_args.kwargs["auth"], BearerAuth)
@@ -61,7 +61,7 @@ def test_when_start_load_called_then_use_correct_token(
 def test_given_server_does_not_respond_when_start_load_called_then_error(mock_post):
     mock_post.return_value.ok = False
 
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     with pytest.raises(ISPyBDepositionNotMade):
         expeye_interactor.start_load("test", 3, 700, 10, 5)
 
@@ -70,7 +70,7 @@ def test_given_server_does_not_respond_when_start_load_called_then_error(mock_po
 def test_when_end_load_called_with_success_then_correct_expected_url_posted_to_with_expected_data(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.end_load(3, "success", "")
 
     mock_patch.assert_called_once()
@@ -87,7 +87,7 @@ def test_when_end_load_called_with_success_then_correct_expected_url_posted_to_w
 def test_when_end_load_called_with_failure_then_correct_expected_url_posted_to_with_expected_data(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.end_load(3, "fail", "bad")
 
     mock_patch.assert_called_once()
@@ -104,7 +104,7 @@ def test_when_end_load_called_with_failure_then_correct_expected_url_posted_to_w
 def test_when_end_load_called_then_use_correct_token(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.end_load(3, "success", "")
 
     assert isinstance(auth := mock_patch.call_args.kwargs["auth"], BearerAuth)
@@ -115,7 +115,7 @@ def test_when_end_load_called_then_use_correct_token(
 def test_given_server_does_not_respond_when_end_load_called_then_error(mock_patch):
     mock_patch.return_value.ok = False
 
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     with pytest.raises(ISPyBDepositionNotMade):
         expeye_interactor.end_load(1, "", "")
 
@@ -124,7 +124,7 @@ def test_given_server_does_not_respond_when_end_load_called_then_error(mock_patc
 def test_when_update_barcode_called_with_success_then_correct_expected_url_posted_to_with_expected_data(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeInteraction()
+    expeye_interactor = ExpeyeCoreInteraction()
     expeye_interactor.update_barcode_and_snapshots(
         3, "test", "/tmp/before.jpg", "/tmp/after.jpg"
     )

--- a/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
+++ b/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
@@ -5,7 +5,9 @@ import pytest
 from mx_bluesky.hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
     BearerAuth,
+    BLSampleStatus,
     ExpeyeCoreInteraction,
+    ExpeyeSampleHandlingInteraction,
     _get_base_url_and_token,
 )
 
@@ -138,3 +140,15 @@ def test_when_update_barcode_called_with_success_then_correct_expected_url_poste
         "xtalSnapshotAfter": "/tmp/after.jpg",
     }
     assert mock_patch.call_args.kwargs["json"] == expected_data
+
+
+@patch("mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store.patch")
+def test_update_sample_status(
+    mock_patch,
+):
+    expeye = ExpeyeSampleHandlingInteraction()
+    expected_json = {"blSampleStatus": "LOADED"}
+    expeye.update_sample_status(12345, BLSampleStatus.LOADED)
+    mock_patch.assert_called_with(
+        "http://blah/samples/12345", auth=ANY, json=expected_json
+    )

--- a/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
+++ b/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
@@ -68,6 +68,7 @@ def test_given_server_does_not_respond_when_start_load_called_then_error(mock_po
 
 @patch("mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store.patch")
 def test_when_end_load_called_with_success_then_correct_expected_url_posted_to_with_expected_data(
+    # mocks HTTP PATCH
     mock_patch,
 ):
     expeye_interactor = ExpeyeCoreInteraction()

--- a/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
+++ b/tests/unit_tests/hyperion/external_interaction/ispyb/test_expeye_interaction.py
@@ -6,8 +6,7 @@ from mx_bluesky.hyperion.external_interaction.exceptions import ISPyBDepositionN
 from mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store import (
     BearerAuth,
     BLSampleStatus,
-    ExpeyeCoreInteraction,
-    ExpeyeSampleHandlingInteraction,
+    ExpeyeInteraction,
     _get_base_url_and_token,
 )
 
@@ -22,7 +21,7 @@ def test_get_url_and_token_returns_expected_data():
 def test_when_start_load_called_then_correct_expected_url_posted_to_with_expected_data(
     mock_post,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.start_load("test", 3, 700, 10, 5)
 
     mock_post.assert_called_once()
@@ -43,7 +42,7 @@ def test_when_start_load_called_then_correct_expected_url_posted_to_with_expecte
 @patch("mx_bluesky.hyperion.external_interaction.ispyb.exp_eye_store.post")
 def test_when_start_called_then_returns_id(mock_post):
     mock_post.return_value.json.return_value = {"robotActionId": 190}
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     robot_id = expeye_interactor.start_load("test", 3, 700, 10, 5)
     assert robot_id == 190
 
@@ -52,7 +51,7 @@ def test_when_start_called_then_returns_id(mock_post):
 def test_when_start_load_called_then_use_correct_token(
     mock_post,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.start_load("test", 3, 700, 10, 5)
 
     assert isinstance(auth := mock_post.call_args.kwargs["auth"], BearerAuth)
@@ -63,7 +62,7 @@ def test_when_start_load_called_then_use_correct_token(
 def test_given_server_does_not_respond_when_start_load_called_then_error(mock_post):
     mock_post.return_value.ok = False
 
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     with pytest.raises(ISPyBDepositionNotMade):
         expeye_interactor.start_load("test", 3, 700, 10, 5)
 
@@ -73,7 +72,7 @@ def test_when_end_load_called_with_success_then_correct_expected_url_posted_to_w
     # mocks HTTP PATCH
     mock_patch,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.end_load(3, "success", "")
 
     mock_patch.assert_called_once()
@@ -90,7 +89,7 @@ def test_when_end_load_called_with_success_then_correct_expected_url_posted_to_w
 def test_when_end_load_called_with_failure_then_correct_expected_url_posted_to_with_expected_data(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.end_load(3, "fail", "bad")
 
     mock_patch.assert_called_once()
@@ -107,7 +106,7 @@ def test_when_end_load_called_with_failure_then_correct_expected_url_posted_to_w
 def test_when_end_load_called_then_use_correct_token(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.end_load(3, "success", "")
 
     assert isinstance(auth := mock_patch.call_args.kwargs["auth"], BearerAuth)
@@ -118,7 +117,7 @@ def test_when_end_load_called_then_use_correct_token(
 def test_given_server_does_not_respond_when_end_load_called_then_error(mock_patch):
     mock_patch.return_value.ok = False
 
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     with pytest.raises(ISPyBDepositionNotMade):
         expeye_interactor.end_load(1, "", "")
 
@@ -127,7 +126,7 @@ def test_given_server_does_not_respond_when_end_load_called_then_error(mock_patc
 def test_when_update_barcode_called_with_success_then_correct_expected_url_posted_to_with_expected_data(
     mock_patch,
 ):
-    expeye_interactor = ExpeyeCoreInteraction()
+    expeye_interactor = ExpeyeInteraction()
     expeye_interactor.update_barcode_and_snapshots(
         3, "test", "/tmp/before.jpg", "/tmp/after.jpg"
     )
@@ -146,7 +145,7 @@ def test_when_update_barcode_called_with_success_then_correct_expected_url_poste
 def test_update_sample_status(
     mock_patch,
 ):
-    expeye = ExpeyeSampleHandlingInteraction()
+    expeye = ExpeyeInteraction()
     expected_json = {"blSampleStatus": "LOADED"}
     expeye.update_sample_status(12345, BLSampleStatus.LOADED)
     mock_patch.assert_called_with(


### PR DESCRIPTION
Fixes #595 
Requires #606 

The `blSampleStatus` field in ispyb will now be updated on successful robot load to `LOADED`, when the `load_centre_collect` plan is used.

In the event of the pin not being found or no diffraction, `blSampleStatus` will be updated to `ERROR - sample` to indicate an issue with the sample
If any other error occurs, `blSampleStatus` will be updated to `ERROR - beamline` to indicate a general problem with the beamline.

On normal completion the `blSampleStatus` will be left at `LOADED`