### PR TITLE
Fix slow `fixed_target` test and add some documentation about profiling

### DIFF
--- a/docs/developer/general/how-to/profile-tests.rst
+++ b/docs/developer/general/how-to/profile-tests.rst
@@ -1,0 +1,84 @@
+Unit test performance
+=====================
+
+Ideally we want to keep the run-time of the unit tests down so that they are quick for developers to run locally. 
+Preferably they should run in under a minute.
+
+General Guidelines
+------------------
+
+Where a unit test waits for some event to happen, ``wait`` on the group to complete rather than adding a fixed 
+``sleep``.
+
+If testing a timeout, ensure that the timeout constant is either configurable or appropriately ``patch`` ed to a short 
+value e.g. 
+0.1s
+
+How to profile the unit tests
+=============================
+
+Sometimes tests can exhibit slowdowns for unknown reasons, in order to diagnose the cause it can be useful to profile
+the test code.
+
+The simplest way to find slow tests is to run ``pytest`` with the ``--durations`` option in order to find the slowest
+tests.
+
+e.g.
+
+.. code-block:: bash
+
+    pytest -m "not (s03 or dlstbx)" --durations=10
+
+in order to find the top 10 slowest tests
+
+You can then often step through in the debugger to find lines which execute slowly.
+
+
+More detailed profiling
+=======================
+
+Occasionally this is not sufficient. In which case more detailed profiling is necessary
+
+Generating profiler output
+--------------------------
+
+You can install ``pytest-profiling`` to run the tests and generate profiling output
+
+e.g.
+
+.. code-block:: bash
+
+    pip install pytest-profiling
+    pytest --profile tests/unit_tests/hyperion/external_interaction/test_write_rotation_nexus.py::test_given_detector_bit_depth_changes_then_vds_datatype_as_expected
+
+
+The output of this is quite brief but it will generate more detailed ``.prof`` files in the ``prof`` directory
+
+To browse these files you need something useful. Snakeviz is a tool that can be used to browse the output:
+
+.. code-block:: bash
+
+    cd prof
+    pip install snakeviz
+    snakeviz combined.prof
+
+An alternative tool is py-spy.
+
+e.g.
+
+.. code-block:: bash
+
+    pip install py-spy
+    py-spy record -o profile.svg -- pytest -s tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py::test_given_no_energy_supplied_when_robot_load_then_centre_current_energy_set_on_eiger
+
+This will generator an interactive SVG flamechart that can be opened in a browser to see hot methods.
+
+Alternatively something like
+
+.. code-block:: bash
+
+    py-spy top -- pytest -s tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py::test_given_no_energy_supplied_when_robot_load_then_centre_current_energy_set_on_eiger
+
+to view a ``top`` -like updating view of where time is being spent. You will probably need to temporarily annotate the 
+test with
+``@pytest.mark.parametrize`` in order to make the tests loop sufficient times in order to observe.

--- a/docs/developer/general/index.rst
+++ b/docs/developer/general/index.rst
@@ -33,6 +33,7 @@ Documentation is split into four categories, and each is also accessible from li
             how-to/update-tools
             how-to/create-a-release
             how-to/deploy-a-release
+            how-to/profile-tests
 
         +++
 

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
@@ -341,6 +341,7 @@ async def test_kick_off_and_complete_collection(
 @patch(
     "mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_Chip_Collect_py3v1.calculate_collection_timeout"
 )
+@patch("dodal.devices.i24.pmac.DEFAULT_TIMEOUT", 0.1)
 async def test_kickoff_and_complete_fails_if_scan_status_pv_does_not_change(
     fake_collection_time, pmac, dummy_params_without_pp, RE
 ):


### PR DESCRIPTION
This shaves off about 10s from the unit test execution time