### PR TITLE
Fix system tests to work with new OAV snapshots

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -933,7 +933,7 @@ def assert_none_matching(
 
 
 def pin_tip_edge_data():
-    tip_x_px = 100
+    tip_x_px = 130
     tip_y_px = 200
     microns_per_pixel = 2.87  # from zoom levels .xml
     grid_width_px = int(400 / microns_per_pixel)

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -1,11 +1,18 @@
 import re
+from collections.abc import Callable, Awaitable
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from functools import partial
+from typing import Any, Callable, Coroutine
+from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
+from aiohttp import ClientResponse, ClientSession
+from bluesky.protocols import Status
+from ophyd import StatusBase
+
 from dodal.beamlines import i03
 from dodal.devices.oav.oav_parameters import OAVConfig
-from ophyd_async.core import AsyncStatus, set_mock_value
+from ophyd_async.core import AsyncStatus, set_mock_value, get_mock_put
 from requests import Response
 
 # Map all the case-sensitive column names from their normalised versions
@@ -141,48 +148,20 @@ def oav_for_system_test(test_config_files):
     set_mock_value(oav.grid_snapshot.top_left_y, 100)
     size_in_pixels = 0.1 * 1000 / 1.25
     set_mock_value(oav.grid_snapshot.box_width, size_in_pixels)
-    unpatched_snapshot_trigger = oav.grid_snapshot.trigger
 
-    async def mock_grid_snapshot_trigger():
-        await oav.grid_snapshot.last_path_full_overlay.set("test_1_y")
-        await oav.grid_snapshot.last_path_outer.set("test_2_y")
-        await oav.grid_snapshot.last_saved_path.set("test_3_y")
-        return unpatched_snapshot_trigger()
+    empty_response = AsyncMock(spec=ClientResponse)
+    empty_response.read.return_value = b""
 
-    # Plain snapshots
-    def next_snapshot():
-        next_snapshot_idx = 1
-        while True:
-            yield f"/tmp/snapshot{next_snapshot_idx}.png"
-            next_snapshot_idx += 1
-
-    empty_response = MagicMock(spec=Response)
-    empty_response.content = b""
     with (
         patch(
-            "dodal.devices.areadetector.plugins.MJPG.requests.get",
-            return_value=empty_response,
-        ),
+            "dodal.devices.areadetector.plugins.MJPG.ClientSession.get", autospec=True
+        ) as mock_get,
         patch("dodal.devices.areadetector.plugins.MJPG.Image.open"),
-        patch.object(oav.grid_snapshot, "post_processing"),
-        patch.object(
-            oav.grid_snapshot, "trigger", side_effect=mock_grid_snapshot_trigger
-        ),
-        patch.object(oav.snapshot.last_saved_path, "get") as mock_last_saved_path,
+        patch("dodal.devices.oav.snapshots.snapshot_with_beam_centre.draw_crosshair"),
     ):
-        it_next_snapshot = next_snapshot()
-
-        @AsyncStatus.wrap
-        async def mock_rotation_snapshot_trigger():
-            mock_last_saved_path.side_effect = lambda: next(it_next_snapshot)
-
-        with patch.object(
-            oav.snapshot,
-            "trigger",
-            side_effect=mock_rotation_snapshot_trigger,
-        ):
-            set_mock_value(oav.zoom_controller.level, "1.0")
-            yield oav
+        mock_get.return_value.__aenter__.return_value = empty_response
+        set_mock_value(oav.zoom_controller.level, "1.0")
+        yield oav
 
 
 def compare_actual_and_expected(
@@ -197,6 +176,8 @@ def compare_actual_and_expected(
             actual = float(actual)
         if isinstance(v, float):
             actual_v = actual == pytest.approx(v)
+        if isinstance(v, str) and v.startswith("regex:"):
+            actual_v = re.match(v.removeprefix("regex:"), actual)
         else:
             actual_v = actual == v
         if not actual_v:

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import ispyb.sqlalchemy
 import numpy
@@ -270,7 +270,7 @@ def grid_detect_then_xray_centre_composite(
             bottom_edge_array,
         )
         set_mock_value(
-            zocalo.bbox_sizes, numpy.array([[10, 10, 10]], dtype=numpy.uint64)
+            zocalo.bounding_box, numpy.array([[10, 10, 10]], dtype=numpy.uint64)
         )
         set_mock_value(
             ophyd_pin_tip_detection.triggered_tip, numpy.array([tip_x_px, tip_y_px])
@@ -314,8 +314,9 @@ def composite_for_rotation_scan(
     xbpm_feedback: XBPMFeedback,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
-    oav_for_system_test.zoom_controller.zrst.sim_put("1.0x")  # type: ignore
-    oav_for_system_test.zoom_controller.fvst.sim_put("5.0x")  # type: ignore
+    oav_for_system_test.zoom_controller.level.describe = AsyncMock(
+        return_value={"level": {"choices": ["1.0x", "5.0x", "7.5x"]}}
+    )
 
     fake_create_rotation_devices = RotationScanComposite(
         attenuator=attenuator,

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -484,10 +484,14 @@ def test_ispyb_deposition_in_rotation_plan(
     )
 
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {
-        "xtalSnapshotFullPath1": "/tmp/snapshot1.png",
-        "xtalSnapshotFullPath2": "/tmp/snapshot2.png",
-        "xtalSnapshotFullPath3": "/tmp/snapshot3.png",
-        "xtalSnapshotFullPath4": "/tmp/snapshot4.png",
+        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
+        ".png",
+        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
+        ".png",
+        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
+        ".png",
+        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
+        ".png",
     }
 
     compare_actual_and_expected(dcid, expected_values, fetch_datacollection_attribute)

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -115,9 +115,10 @@ GRID_DC_1_EXPECTED_VALUES = {
     "wavelength": 0.71,
     "xbeam": 75.6027,
     "ybeam": 79.4935,
-    "xtalsnapshotfullpath1": "test_1_y",
-    "xtalsnapshotfullpath2": "test_2_y",
-    "xtalsnapshotfullpath3": "test_3_y",
+    "xtalsnapshotfullpath1": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots/robot_load_centring_file_1_0_grid_overlay.png",
+    "xtalsnapshotfullpath2": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots"
+    "/robot_load_centring_file_1_0_outer_overlay.png",
+    "xtalsnapshotfullpath3": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots/robot_load_centring_file_1_0.png",
     "synchrotronmode": "User",
     "undulatorgap1": 1.11,
     "filetemplate": "robot_load_centring_file_1_master.h5",
@@ -131,6 +132,12 @@ GRID_DC_2_EXPECTED_VALUES = GRID_DC_1_EXPECTED_VALUES | {
     "datacollectionnumber": 2,
     "filetemplate": "robot_load_centring_file_2_master.h5",
     "numberofimages": 90,
+    "xtalsnapshotfullpath1": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots"
+    "/robot_load_centring_file_1_90_grid_overlay.png",
+    "xtalsnapshotfullpath2": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots"
+    "/robot_load_centring_file_1_90_outer_overlay.png",
+    "xtalsnapshotfullpath3": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/xraycentring/snapshots"
+    "/robot_load_centring_file_1_90.png",
 }
 
 ROTATION_DC_EXPECTED_VALUES = {
@@ -145,17 +152,23 @@ ROTATION_DC_EXPECTED_VALUES = {
     "synchrotronMode": SynchrotronMode.USER.value,
     "slitGapHorizontal": 0.123,
     "slitGapVertical": 0.234,
-    "xtalSnapshotFullPath1": "/tmp/snapshot2.png",
-    "xtalSnapshotFullPath2": "/tmp/snapshot3.png",
-    "xtalSnapshotFullPath3": "/tmp/snapshot4.png",
-    "xtalSnapshotFullPath4": "/tmp/snapshot5.png",
+    "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{6}_oav_snapshot_0\\.png",
+    "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_90\\.png",
+    "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_180\\.png",
+    "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_270\\.png",
 }
 
 ROTATION_DC_2_EXPECTED_VALUES = ROTATION_DC_EXPECTED_VALUES | {
-    "xtalSnapshotFullPath1": "/tmp/snapshot6.png",
-    "xtalSnapshotFullPath2": "/tmp/snapshot7.png",
-    "xtalSnapshotFullPath3": "/tmp/snapshot8.png",
-    "xtalSnapshotFullPath4": "/tmp/snapshot9.png",
+    "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{6}_oav_snapshot_0\\.png",
+    "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_90\\.png",
+    "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_180\\.png",
+    "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123457/snapshots/\\d{"
+    "6}_oav_snapshot_270\\.png",
 }
 
 
@@ -218,15 +231,15 @@ def test_execute_load_centre_collect_full_plan(
         fetch_datacollection_attribute,
         ispyb_gridscan_cb.ispyb_ids.data_collection_ids[0],
         "Hyperion: Xray centring - Diffraction grid scan of 30 by 4 "
-        "images in 20.0 um by 20.0 um steps. Top left (px): [100,152], "
-        "bottom right (px): [844,251]. Aperture: ApertureValue.SMALL. ",
+        "images in 20.0 um by 20.0 um steps. Top left (px): [130,152], "
+        "bottom right (px): [874,251]. Aperture: ApertureValue.SMALL. ",
     )
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_gridscan_cb.ispyb_ids.data_collection_ids[1],
         "Hyperion: Xray centring - Diffraction grid scan of 30 by 3 "
-        "images in 20.0 um by 20.0 um steps. Top left (px): [100,165], "
-        "bottom right (px): [844,239]. Aperture: ApertureValue.SMALL. ",
+        "images in 20.0 um by 20.0 um steps. Top left (px): [130,165], "
+        "bottom right (px): [874,239]. Aperture: ApertureValue.SMALL. ",
     )
 
     rotation_dcg_id = ispyb_rotation_cb.ispyb_ids.data_collection_group_id
@@ -250,5 +263,5 @@ def test_execute_load_centre_collect_full_plan(
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_rotation_cb.ispyb_ids.data_collection_ids[0],
-        "Sample position (µm): (675, 737, -381) Hyperion Rotation Scan -   Aperture: ApertureValue.SMALL. ",
+        "Sample position (µm): (-2309, -573, 370) Hyperion Rotation Scan -   Aperture: ApertureValue.SMALL. ",
     )


### PR DESCRIPTION
This fixes the `test_ispyb_dev_connection` and `test_load_centre_collect_full_plan` system tests to work against the new OAV changes