### PR TITLE
Reduce filesystem access when validating parameters

### DIFF
--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from abc import abstractmethod
 from collections.abc import Sequence
 from enum import StrEnum
@@ -152,7 +153,9 @@ class DiffractionExperiment(
 
     @model_validator(mode="before")
     @classmethod
-    def validate_snapshot_directory(cls, values):
+    def validate_directories(cls, values):
+        os.makedirs(values["storage_directory"], exist_ok=True)
+
         values["snapshot_directory"] = values.get(
             "snapshot_directory",
             Path(values["storage_directory"], "snapshots").as_posix(),

--- a/src/mx_bluesky/hyperion/parameters/gridscan.py
+++ b/src/mx_bluesky/hyperion/parameters/gridscan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from dodal.devices.detector import (
     DetectorParams,
 )
@@ -42,7 +40,6 @@ class HyperionGridCommon(GridCommon, WithHyperionFeatures):
         assert (
             self.detector_distance_mm is not None
         ), "Detector distance must be filled before generating DetectorParams"
-        os.makedirs(self.storage_directory, exist_ok=True)
         return DetectorParams(
             detector_size_constants=I03Constants.DETECTOR,
             expected_energy_ev=self.demand_energy_ev,

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Sequence
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import numpy
 import pytest
@@ -479,3 +479,27 @@ def _compare_rotation_scans(
         assert rotation_scan.y_start_um == expected["y_start_um"]
         assert rotation_scan.z_start_um == expected["z_start_um"]
         assert rotation_scan.nexus_vds_start_img == expected["nexus_vds_start_img"]
+
+
+@patch("mx_bluesky.common.parameters.components.os.makedirs")
+def test_load_centre_collect_creates_storage_directory_if_not_present(
+    mock_makedirs,
+):
+    params = raw_params_from_file(
+        "tests/test_data/parameter_json_files/good_test_load_centre_collect_params.json"
+    )
+    LoadCentreCollect(**params)
+
+    mock_makedirs.assert_has_calls(
+        [
+            call(
+                "/tmp/dls/i03/data/2024/cm31105-4/auto/123458/xraycentring",
+                exist_ok=True,
+            )
+        ],
+        any_order=True,
+    )
+    mock_makedirs.assert_has_calls(
+        [call("/tmp/dls/i03/data/2024/cm31105-4/auto/123458/", exist_ok=True)],
+        any_order=True,
+    )

--- a/tests/unit_tests/hyperion/parameters/test_parameter_model.py
+++ b/tests/unit_tests/hyperion/parameters/test_parameter_model.py
@@ -142,7 +142,7 @@ def test_feature_flags_overriden_if_supplied(minimal_3d_gridscan_params):
     assert test_params.features.use_panda_for_gridscan
 
 
-@patch("mx_bluesky.hyperion.parameters.gridscan.os")
+@patch("mx_bluesky.common.parameters.components.os")
 def test_gpu_enabled_if_use_gpu_or_compare_gpu_enabled(_, minimal_3d_gridscan_params):
     minimal_3d_gridscan_params["detector_distance_mm"] = 100
 


### PR DESCRIPTION
This moves the check/creation of the `storage_directory` folder from property access to `DiffractionExperiment` model validation.

This doesn't completely remove duplicated calls to `os.makedirs` but it does reduce it from ~22 to a hopefully more sane number.
But there will still be some duplications as we construct various intermediate parameter instances, all of which have the `storage_directory` parameter.

Fixes #527 
