### PR TITLE
Explicitly depend on dls-bluesky-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "ophyd-async >= 0.3a5",
     "bluesky >= 1.13.0a4",
     "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-bluesky-core",
 ]
 
 


### PR DESCRIPTION
Our unit tests are failing as we still have a dependency on `dls-bluesky-core` (https://github.com/DiamondLightSource/mx-bluesky/actions/runs/11860322306/job/33055330489?pr=630). We used to get this dependency through implicitly `blueapi` but the latest `blueapi` version no longer has it so we must add it explicitly. 

https://github.com/DiamondLightSource/mx-bluesky/pull/564 will remove this properly