### PR TITLE
Remove setting timeouts incorrectly in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -741,11 +741,12 @@ async def fake_fgs_composite(
     zocalo,
     dcm,
     panda,
+    backlight,
 ):
     fake_composite = FlyScanXRayCentreComposite(
         aperture_scatterguard=aperture_scatterguard,
         attenuator=attenuator,
-        backlight=i03.backlight(fake_with_ophyd_sim=True),
+        backlight=backlight,
         dcm=dcm,
         # We don't use the eiger fixture here because .unstage() is used in some tests
         eiger=i03.eiger(fake_with_ophyd_sim=True),
@@ -767,7 +768,6 @@ async def fake_fgs_composite(
     fake_composite.eiger.stage = MagicMock(return_value=done_status)
     # unstage should be mocked on a per-test basis because several rely on unstage
     fake_composite.eiger.set_detector_parameters(test_fgs_params.detector_params)
-    fake_composite.eiger.ALL_FRAMES_TIMEOUT = 2  # type: ignore
     fake_composite.eiger.stop_odin_when_all_frames_collected = MagicMock()
     fake_composite.eiger.odin.check_and_wait_for_odin_state = lambda timeout: True
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -1041,9 +1041,6 @@ class TestFlyscanXrayCentrePlan:
         fake_fgs_composite.eiger.disarm_detector = MagicMock()
         fake_fgs_composite.eiger.disable_roi_mode = MagicMock()
 
-        # Without the complete finishing we will not get all the images
-        fake_fgs_composite.eiger.ALL_FRAMES_TIMEOUT = 0.1  # type: ignore
-
         with pytest.raises(CompleteException):
             RE(
                 run_gridscan(


### PR DESCRIPTION
Similar to https://github.com/DiamondLightSource/dodal/pull/903.

On removing setting the timeouts the tests still passed at the same speed so turns out we're not using them at all. However, it did highlight that `test_detect_grid_and_do_gridscan` was a bit flaky. This was because we were using the "real" backlight positioner, which takes some time to move in/out. Previous tests were doing the move and not waiting on it, then this test would fail on the check. Fixed by using the fake one that moves instantly.

To test:
* Confirm tests still pass at and take roughly the same time as on main