### PR TITLE
Update types for latest ophyd_async

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -703,7 +703,7 @@ async def panda(RE: RunEngine):
 
     set_mock_value(
         panda.data.datasets,
-        DatasetTable(name=["name"], hdf5_type=[PandaHdf5DatasetType.FLOAT_64]),
+        DatasetTable(name=["name"], dtype=[PandaHdf5DatasetType.FLOAT_64]),
     )
 
     return panda

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -90,9 +90,7 @@ ReWithSubs = tuple[RunEngine, tuple[GridscanNexusFileCallback, GridscanISPyBCall
 
 @pytest.fixture
 def fgs_composite_with_panda_pcap(fake_fgs_composite: FlyScanXRayCentreComposite):
-    capture_table = DatasetTable(
-        name=["name"], hdf5_type=[PandaHdf5DatasetType.FLOAT_64]
-    )
+    capture_table = DatasetTable(name=["name"], dtype=[PandaHdf5DatasetType.FLOAT_64])
     set_mock_value(fake_fgs_composite.panda.data.datasets, capture_table)
 
     return fake_fgs_composite


### PR DESCRIPTION
See https://github.com/DiamondLightSource/dodal/pull/899

To test:
* Update to latest `ophyd-async`:

```
pip uninstall ophyd-async
pip install ophyd-async==0.8.0a5
```
* Confirm tests still pass