### PR TITLE
Fix flaky backlight test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,7 +317,7 @@ def zebra(RE):
 def backlight():
     backlight = i03.backlight(fake_with_ophyd_sim=True)
     backlight.TIME_TO_MOVE_S = 0.001
-    return i03.backlight(fake_with_ophyd_sim=True)
+    return backlight
 
 
 @pytest.fixture
@@ -585,6 +585,7 @@ def fake_create_devices(
     zebra: Zebra,
     detector_motion: DetectorMotion,
     aperture_scatterguard: ApertureScatterguard,
+    backlight: Backlight,
 ):
     mock_omega_sets = MagicMock(return_value=NullStatus())
 
@@ -596,7 +597,7 @@ def fake_create_devices(
         "smargon": smargon,
         "zebra": zebra,
         "detector_motion": detector_motion,
-        "backlight": i03.backlight(fake_with_ophyd_sim=True),
+        "backlight": backlight,
         "ap_sg": aperture_scatterguard,
     }
     return devices

--- a/tests/unit_tests/hyperion/experiment_plans/test_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_grid_detect_then_xray_centre_plan.py
@@ -10,7 +10,7 @@ from bluesky.utils import Msg
 from dodal.devices.aperturescatterguard import ApertureValue
 from dodal.devices.backlight import BacklightPosition
 from dodal.devices.oav.oav_parameters import OAVParameters
-from ophyd_async.core import set_mock_value
+from ophyd_async.core import get_mock_put, set_mock_value
 
 from mx_bluesky.common.parameters.gridscan import GridScanWithEdgeDetect
 from mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan import (
@@ -114,7 +114,9 @@ async def test_detect_grid_and_do_gridscan(
     mock_grid_detection_plan.assert_called_once()
 
     # Check backlight was moved OUT
-    assert await composite.backlight.position.get_value() == BacklightPosition.OUT
+    get_mock_put(composite.backlight.position).assert_called_once_with(
+        BacklightPosition.OUT, wait=ANY
+    )
 
     # Check aperture was changed to SMALL
     assert (


### PR DESCRIPTION
Fixes #653

Rather than check that the backlight has finished moving now we just check that we told it to move, which should be a lot less flaky.

To test:
* Run the unit tests all through a few times and confirm they do not fail with the backlight timeout error