### PR TITLE
Fix for pydantic 2.10

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -224,11 +224,11 @@ def save_screen_map() -> MsgGenerator:
     with open(litemap_path / "currentchip.map", "w") as f:
         SSX_LOGGER.debug("Printing only blocks with block_val == 1")
         for x in range(1, 82):
-            block_str = "ME14E-MO-IOC-01:GP%i" % (x + 10)
+            block_str = f"ME14E-MO-IOC-01:GP{x + 10:d}"
             block_val = int(caget(block_str))
             if block_val == 1:
-                SSX_LOGGER.info("%s %d" % (block_str, block_val))
-            line = "%02dstatus    P3%02d1 \t%s\n" % (x, x, block_val)
+                SSX_LOGGER.info(f"{block_str} {block_val:d}")
+            line = f"{x:02d}status    P3{x:02d}1 \t{block_val}\n"
             f.write(line)
     yield from bps.null()
 
@@ -515,7 +515,7 @@ def load_lite_map() -> MsgGenerator:
                     break
                 button_name = str(row) + str(column)
                 lab_num = x * 8 + z
-                label = "%02.d" % (lab_num + 1)
+                label = f"{lab_num + 1:02d}"
                 btn_names[button_name] = label
         block_dict = btn_names
     else:
@@ -673,15 +673,15 @@ def fiducial(point: int = 1, pmac: PMAC = inject("pmac")) -> MsgGenerator:
     output_param_path.mkdir(parents=True, exist_ok=True)
     SSX_LOGGER.info(f"Writing Fiducial File {output_param_path}/fiducial_{point}.txt")
     SSX_LOGGER.info("MTR\tRBV\tRAW\tCorr\tf_value")
-    SSX_LOGGER.info("MTR1\t%1.4f\t%i" % (rbv_1, mtr1_dir))
-    SSX_LOGGER.info("MTR2\t%1.4f\t%i" % (rbv_2, mtr2_dir))
-    SSX_LOGGER.info("MTR3\t%1.4f\t%i" % (rbv_3, mtr3_dir))
+    SSX_LOGGER.info(f"MTR1\t{rbv_1:1.4f}\t{mtr1_dir:d}")
+    SSX_LOGGER.info(f"MTR2\t{rbv_2:1.4f}\t{mtr2_dir:d}")
+    SSX_LOGGER.info(f"MTR3\t{rbv_3:1.4f}\t{mtr3_dir:d}")
 
     with open(output_param_path / f"fiducial_{point}.txt", "w") as f:
         f.write("MTR\tRBV\tCorr\n")
-        f.write("MTR1\t%1.4f\t%i\n" % (rbv_1, mtr1_dir))
-        f.write("MTR2\t%1.4f\t%i\n" % (rbv_2, mtr2_dir))
-        f.write("MTR3\t%1.4f\t%i" % (rbv_3, mtr3_dir))
+        f.write(f"MTR1\t{rbv_1:1.4f}\t{mtr1_dir:d}\n")
+        f.write(f"MTR2\t{rbv_2:1.4f}\t{mtr2_dir:d}\n")
+        f.write(f"MTR3\t{rbv_3:1.4f}\t{mtr3_dir:d}")
     SSX_LOGGER.info(f"Fiducial {point} set.")
     yield from bps.null()
 

--- a/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -9,6 +9,7 @@ from typing import Protocol
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import numpy as np
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky.callbacks import CallbackBase
 from bluesky.utils import MsgGenerator
@@ -89,7 +90,7 @@ class CrystalNotFoundException(WarningException):
     pass
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class FlyScanXRayCentreComposite:
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import dataclasses
 from pathlib import Path
 
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
@@ -67,7 +67,7 @@ from mx_bluesky.hyperion.parameters.gridscan import (
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class GridDetectThenXRayCentreComposite:
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -1,8 +1,8 @@
-import dataclasses
 from collections.abc import Sequence
 
 from blueapi.core import BlueskyContext, MsgGenerator
 from bluesky.preprocessors import subs_wrapper
+import pydantic
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.smargon import Smargon
 
@@ -24,7 +24,7 @@ from mx_bluesky.hyperion.parameters.load_centre_collect import LoadCentreCollect
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class LoadCentreCollectComposite(RobotLoadThenCentreComposite, RotationScanComposite):
     """Composite that provides access to the required devices."""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -1,8 +1,8 @@
 from collections.abc import Sequence
 
+import pydantic
 from blueapi.core import BlueskyContext, MsgGenerator
 from bluesky.preprocessors import subs_wrapper
-import pydantic
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.smargon import Smargon
 

--- a/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import dataclasses
 import math
 from typing import TYPE_CHECKING
 
 import bluesky.plan_stubs as bps
 import numpy as np
+import pydantic
 from blueapi.core import BlueskyContext
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from dodal.devices.oav.oav_parameters import OAVParameters
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class OavGridDetectionComposite:
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/optimise_attenuation_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/optimise_attenuation_plan.py
@@ -1,9 +1,9 @@
-import dataclasses
 from enum import Enum
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import numpy as np
+import pydantic
 from blueapi.core import BlueskyContext
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.xspress3.xspress3 import Xspress3
@@ -22,7 +22,7 @@ class Direction(Enum):
     NEGATIVE = "negative"
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class OptimizeAttenuationComposite:
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/pin_tip_centring_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/pin_tip_centring_plan.py
@@ -1,7 +1,7 @@
-import dataclasses
 from collections.abc import Generator
 
 import bluesky.plan_stubs as bps
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky.utils import Msg
 from dodal.devices.backlight import Backlight
@@ -27,7 +27,7 @@ from mx_bluesky.hyperion.utils.context import device_composite_from_context
 DEFAULT_STEP_SIZE = 0.5
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class PinTipCentringComposite:
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 from collections.abc import Generator
 from datetime import datetime
 from pathlib import Path
@@ -8,6 +7,7 @@ from typing import cast
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky.utils import Msg
 from dodal.devices.aperturescatterguard import ApertureScatterguard, ApertureValue
@@ -33,7 +33,7 @@ from mx_bluesky.hyperion.log import LOGGER
 from mx_bluesky.hyperion.parameters.constants import CONST
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class RobotLoadAndEnergyChangeComposite:
     # SetEnergyComposite fields
     vfm: FocusingMirrorWithStripes

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import dataclasses
 from typing import cast
 
 import bluesky.preprocessors as bpp
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky.utils import MsgGenerator
 from dodal.devices.aperturescatterguard import ApertureScatterguard
@@ -59,7 +59,7 @@ from mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy import (
 from mx_bluesky.hyperion.parameters.constants import CONST
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class RobotLoadThenCentreComposite:
     # common fields
     xbpm_feedback: XBPMFeedback

--- a/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
@@ -4,6 +4,7 @@ import dataclasses
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
+import pydantic
 from blueapi.core import BlueskyContext
 from bluesky.utils import MsgGenerator
 from dodal.devices.aperturescatterguard import ApertureScatterguard
@@ -63,7 +64,7 @@ from mx_bluesky.hyperion.parameters.rotation import (
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class RotationScanComposite(OavSnapshotComposite):
     """All devices which are directly or indirectly required by this plan"""
 

--- a/src/mx_bluesky/hyperion/experiment_plans/set_energy_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/set_energy_plan.py
@@ -5,8 +5,7 @@
 * reenable feedback
 """
 
-import dataclasses
-
+import pydantic
 from bluesky import plan_stubs as bps
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.dcm import DCM
@@ -24,7 +23,7 @@ DESIRED_TRANSMISSION_FRACTION = 0.1
 UNDULATOR_GROUP = "UNDULATOR_GROUP"
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class SetEnergyComposite:
     vfm: FocusingMirrorWithStripes
     mirror_voltages: MirrorVoltages

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -120,7 +120,7 @@ class MultiRotationScan(RotationExperiment, SplitScan):
 
     def _single_rotation_scan(self, scan: RotationScanPerSweep) -> RotationScan:
         # self has everything from RotationExperiment
-        allowed_keys = RotationScan.model_fields.keys()
+        allowed_keys = RotationScan.model_fields.keys()  # type: ignore # mypy doesn't recognise this as a property...
         params_dump = self.model_dump()
         # provided `scan` has everything from RotationScanPerSweep
         scan_dump = scan.model_dump()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,11 @@ def zebra(RE):
 
 
 @pytest.fixture
+def zebra_shutter(RE):
+    return i03.sample_shutter(fake_with_ophyd_sim=True)
+
+
+@pytest.fixture
 def backlight():
     backlight = i03.backlight(fake_with_ophyd_sim=True)
     backlight.TIME_TO_MOVE_S = 0.001

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -255,12 +255,14 @@ def grid_detect_then_xray_centre_composite(
     flux,
     ophyd_pin_tip_detection,
     sample_shutter,
+    panda,
+    panda_fast_grid_scan,
 ):
     composite = GridDetectThenXRayCentreComposite(
         zebra_fast_grid_scan=fast_grid_scan,
         pin_tip_detection=ophyd_pin_tip_detection,
         backlight=backlight,
-        panda_fast_grid_scan=None,  # type: ignore
+        panda_fast_grid_scan=panda_fast_grid_scan,
         smargon=smargon,
         undulator=undulator_for_system_test,
         synchrotron=synchrotron,
@@ -272,7 +274,7 @@ def grid_detect_then_xray_centre_composite(
         aperture_scatterguard=aperture_scatterguard,
         zebra=zebra,
         eiger=eiger,
-        panda=None,  # type: ignore
+        panda=panda,
         robot=robot,
         oav=oav_for_system_test,
         dcm=dcm,

--- a/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_zebra_setup.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, call
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.protocols import Movable
-from dodal.beamlines import i03
 from dodal.devices.zebra import (
     AUTO_SHUTTER_GATE,
     AUTO_SHUTTER_INPUT_1,
@@ -29,16 +28,6 @@ from mx_bluesky.hyperion.device_setup_plans.setup_zebra import (
     setup_zebra_for_rotation,
     tidy_up_zebra_after_gridscan,
 )
-
-
-@pytest.fixture
-def zebra(RE):
-    return i03.zebra(fake_with_ophyd_sim=True)
-
-
-@pytest.fixture
-def zebra_shutter(RE):
-    return i03.sample_shutter(fake_with_ophyd_sim=True)
 
 
 async def _get_shutter_input_2(zebra: Zebra):

--- a/tests/unit_tests/hyperion/experiment_plans/conftest.py
+++ b/tests/unit_tests/hyperion/experiment_plans/conftest.py
@@ -10,14 +10,19 @@ from dodal.devices.aperturescatterguard import ApertureScatterguard, ApertureVal
 from dodal.devices.backlight import Backlight
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
-from dodal.devices.fast_grid_scan import ZebraFastGridScan
+from dodal.devices.fast_grid_scan import PandAFastGridScan, ZebraFastGridScan
+from dodal.devices.flux import Flux
 from dodal.devices.oav.oav_detector import OAV
+from dodal.devices.oav.pin_image_recognition import PinTipDetection
+from dodal.devices.robot import BartRobot
+from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import Synchrotron, SynchrotronMode
 from dodal.devices.zocalo import ZocaloResults, ZocaloTrigger
 from event_model import Event
 from ophyd.sim import NullStatus
 from ophyd_async.core import AsyncStatus, set_mock_value
+from ophyd_async.fastcs.panda import HDFPanda
 
 from mx_bluesky.hyperion.experiment_plans.common.xrc_result import XRayCentreResult
 from mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan import (
@@ -108,29 +113,36 @@ def grid_detect_devices(
     zocalo: ZocaloResults,
     synchrotron: Synchrotron,
     fast_grid_scan: ZebraFastGridScan,
+    zebra,
+    zebra_shutter,
+    xbpm_feedback,
+    attenuator,
+    undulator,
+    undulator_dcm,
+    dcm,
 ) -> GridDetectThenXRayCentreComposite:
     return GridDetectThenXRayCentreComposite(
         aperture_scatterguard=aperture_scatterguard,
-        attenuator=MagicMock(),
+        attenuator=attenuator,
         backlight=backlight,
         detector_motion=detector_motion,
         eiger=eiger,
         zebra_fast_grid_scan=fast_grid_scan,
-        flux=MagicMock(),
+        flux=MagicMock(spec=Flux),
         oav=oav,
-        pin_tip_detection=MagicMock(),
+        pin_tip_detection=MagicMock(spec=PinTipDetection),
         smargon=smargon,
         synchrotron=synchrotron,
-        s4_slit_gaps=MagicMock(),
-        undulator=MagicMock(),
-        xbpm_feedback=MagicMock(),
-        zebra=MagicMock(),
+        s4_slit_gaps=MagicMock(spec=S4SlitGaps),
+        undulator=undulator,
+        xbpm_feedback=xbpm_feedback,
+        zebra=zebra,
         zocalo=zocalo,
-        panda=MagicMock(),
-        panda_fast_grid_scan=MagicMock(),
-        dcm=MagicMock(),
-        robot=MagicMock(),
-        sample_shutter=MagicMock(),
+        panda=MagicMock(spec=HDFPanda),
+        panda_fast_grid_scan=MagicMock(spec=PandAFastGridScan),
+        dcm=dcm,
+        robot=MagicMock(spec=BartRobot),
+        sample_shutter=zebra_shutter,
     )
 
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_oav_snapshot_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_oav_snapshot_plan.py
@@ -1,7 +1,7 @@
-import dataclasses
 from datetime import datetime
 from unittest.mock import patch
 
+import pydantic
 import pytest
 from bluesky.simulators import assert_message_and_return_remaining
 from dodal.devices.aperturescatterguard import ApertureScatterguard
@@ -31,7 +31,7 @@ def oav_snapshot_params():
     )
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
 class CompositeImpl(OavSnapshotComposite):
     smargon: Smargon
     oav: OAV

--- a/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -318,13 +318,14 @@ def test_pin_centre_then_xray_centre_plan_goes_to_the_starting_chi_and_phi(
     sim_run_engine: RunEngineSimulator,
     test_pin_centre_then_xray_centre_params: PinTipCentreThenXrayCentre,
     test_config_files,
+    grid_detect_devices,
 ):
     mock_detect_grid_and_do_gridscan.return_value = iter(
         [Msg("detect_grid_and_do_gridscan")]
     )
     mock_pin_tip_centre_plan.return_value = iter([Msg("pin_tip_centre_plan")])
 
-    mock_composite = MagicMock()
+    mock_composite = grid_detect_devices
     mock_composite.smargon = smargon
 
     test_pin_centre_then_xray_centre_params.phi_start_deg = 30
@@ -332,7 +333,7 @@ def test_pin_centre_then_xray_centre_plan_goes_to_the_starting_chi_and_phi(
 
     msgs = sim_run_engine.simulate_plan(
         pin_centre_then_flyscan_plan(
-            mock_composite,
+            grid_detect_devices,
             test_pin_centre_then_xray_centre_params,
             test_config_files["oav_config_json"],
         )

--- a/tests/unit_tests/hyperion/experiment_plans/test_pin_tip_centring.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_pin_tip_centring.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from bluesky.plan_stubs import null
 from bluesky.run_engine import RunEngine, RunEngineResult
+from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.oav.pin_image_recognition.utils import SampleLocation
@@ -305,10 +306,10 @@ async def test_when_pin_tip_centre_plan_called_then_expected_plans_called(
     set_mock_value(smargon.omega.user_readback, 0)
     set_mock_value(oav.zoom_controller.level, "1.0")
     composite = PinTipCentringComposite(
-        backlight=MagicMock(),
+        backlight=MagicMock(spec=Backlight),
         oav=oav,
         smargon=smargon,
-        pin_tip_detection=MagicMock(),
+        pin_tip_detection=MagicMock(spec=PinTipDetection),
     )
     RE(pin_tip_centre_plan(composite, 50, test_config_files["oav_config_json"]))
 
@@ -360,9 +361,9 @@ def test_given_pin_tip_detect_using_ophyd_when_pin_tip_centre_plan_called_then_e
     RE: RunEngine,
 ):
     set_mock_value(smargon.omega.user_readback, 0)
-    mock_ophyd_pin_tip_detection = MagicMock()
+    mock_ophyd_pin_tip_detection = MagicMock(spec=PinTipDetection)
     composite = PinTipCentringComposite(
-        backlight=MagicMock(),
+        backlight=MagicMock(Backlight),
         oav=oav,
         smargon=smargon,
         pin_tip_detection=mock_ophyd_pin_tip_detection,

--- a/tests/unit_tests/hyperion/utils/test_context.py
+++ b/tests/unit_tests/hyperion/utils/test_context.py
@@ -1,6 +1,6 @@
-import dataclasses
 from unittest.mock import MagicMock
 
+import pydantic
 import pytest
 from ophyd.device import Device
 
@@ -52,7 +52,7 @@ def test_find_nonexistent_device_in_context_raises_error():
 def test_device_composite_from_context():
     context = MagicMock()
 
-    @dataclasses.dataclass
+    @pydantic.dataclasses.dataclass(config={"arbitrary_types_allowed": True})
     class _Composite:
         device1: _DeviceType1
         device2: _DeviceType2


### PR DESCRIPTION
- Changes our device composites to pydantic dataclasses with config which allows the devices to be used in the plan parameter model generated by BlueApi
- Updates where tests used plain MagicMocks which are now no longer accepted by the valiation. In most cases `spec=RealDeviceType` is sufficient, but when children are needed an ophyd-async `connect(mock=True)` is needed too as spec doesn't find those