### PR TITLE
651 energy change fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.8a5",
     "bluesky >= 1.13.0a4",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@86ff155832e6f9bfab0e678b888e9b962ae7ed0c",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]
 
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -121,13 +121,6 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     yield from dcm_roll_adjuster(DCM_GROUP)
     LOGGER.info("Waiting for DCM roll adjust to complete...")
 
-    # DCM offset
-    # wait for other DCM motions and energy change to complete before changing offset
-    yield from bps.wait(DCM_GROUP, timeout=30)
-    offset_mm = undulator_dcm.dcm_fixed_offset_mm
-    LOGGER.info(f"Adjusting DCM offset to {offset_mm} mm")
-    yield from bps.abs_set(dcm.offset_in_mm, offset_mm, wait=True)
-
     #
     # Adjust vfm mirror stripe and mirror voltages
     #

--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -19,6 +19,7 @@ from mx_bluesky.hyperion.utils.utils import (
 
 MIRROR_VOLTAGE_GROUP = "MIRROR_VOLTAGE_GROUP"
 DCM_GROUP = "DCM_GROUP"
+YAW_LAT_TIMEOUT_S = 30
 
 
 def _apply_and_wait_for_voltages_to_settle(
@@ -46,14 +47,12 @@ def _apply_and_wait_for_voltages_to_settle(
         for voltage_channel, required_voltage in zip(
             channels.values(), required_voltages, strict=True
         ):
-            LOGGER.debug(
+            LOGGER.info(
                 f"Applying and waiting for voltage {voltage_channel.name} = {required_voltage}"
             )
             yield from bps.abs_set(
-                voltage_channel, required_voltage, group=MIRROR_VOLTAGE_GROUP
+                voltage_channel, required_voltage, group=MIRROR_VOLTAGE_GROUP, wait=True
             )
-
-    yield from bps.wait(group=MIRROR_VOLTAGE_GROUP)
 
 
 def adjust_mirror_stripe(
@@ -61,13 +60,20 @@ def adjust_mirror_stripe(
 ):
     """Feedback should be OFF prior to entry, in order to prevent
     feedback from making unnecessary corrections while beam is being adjusted."""
-    stripe = mirror.energy_to_stripe(energy_kev)
+    stripe, yaw, lat = mirror.energy_to_stripe(energy_kev)
 
     LOGGER.info(
         f"Adjusting mirror stripe for {energy_kev}keV selecting {stripe} stripe"
     )
     yield from bps.abs_set(mirror.stripe, stripe, wait=True)
     yield from bps.trigger(mirror.apply_stripe)
+
+    # yaw, lat cannot be done simultaneously
+    LOGGER.info(f"Adjusting {mirror.name} lat to {lat}")
+    yield from bps.abs_set(mirror.x_mm, lat, wait=True, timeout=YAW_LAT_TIMEOUT_S)
+
+    LOGGER.info(f"Adjusting {mirror.name} yaw to {yaw}")
+    yield from bps.abs_set(mirror.yaw_mrad, yaw, wait=True, timeout=YAW_LAT_TIMEOUT_S)
 
     LOGGER.info("Adjusting mirror voltages...")
     yield from _apply_and_wait_for_voltages_to_settle(stripe, mirror_voltages)
@@ -109,31 +115,16 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     yield from dcm_roll_adjuster(DCM_GROUP)
     LOGGER.info("Waiting for DCM roll adjust to complete...")
 
-    # DCM Perp pitch
+    # DCM offset
+    # wait for other DCM motions and energy change to complete before changing offset
+    yield from bps.wait(DCM_GROUP, timeout=30)
     offset_mm = undulator_dcm.dcm_fixed_offset_mm
     LOGGER.info(f"Adjusting DCM offset to {offset_mm} mm")
-    yield from bps.abs_set(dcm.offset_in_mm, offset_mm, group=DCM_GROUP)
+    yield from bps.abs_set(dcm.offset_in_mm, offset_mm, wait=True)
 
     #
-    # Adjust mirrors
+    # Adjust vfm mirror stripe and mirror voltages
     #
-
-    # No need to change HFM
-
-    # Assumption is focus mode is already set to "sample"
-    # not sure how we check this
 
     # VFM Stripe selection
     yield from adjust_mirror_stripe(energy_kev, vfm, mirror_voltages)
-    yield from bps.wait(DCM_GROUP)
-
-    # VFM Adjust - for I03 this table always returns the same value
-    vfm_lut = vfm.bragg_to_lat_lookup_table_path
-    assert vfm_lut is not None
-    vfm_x_adjuster = lookup_table_adjuster(
-        linear_interpolation_lut(vfm_lut),
-        vfm.x_mm,
-        bragg_deg,
-    )
-    LOGGER.info("Waiting for VFM Lat (Horizontal Translation) to complete...")
-    yield from vfm_x_adjuster()

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -100,6 +100,10 @@ def load_centre_collect_full(
                 multi_rotation.rotation_scans.append(combination)
         multi_rotation = MultiRotationScan.model_validate(multi_rotation)
 
+        assert (
+            multi_rotation.demand_energy_ev
+            == parameters.robot_load_then_centre.demand_energy_ev
+        ), "Setting a different energy for gridscan and rotation is not supported"
         yield from multi_rotation_scan(composite, multi_rotation, oav_params)
 
     yield from plan_with_callback_subs()

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
@@ -128,11 +128,7 @@ def do_robot_load(
         group="robot_load",
     )
 
-    if demand_energy_ev:
-        yield from set_energy_plan(
-            demand_energy_ev / 1000,
-            cast(SetEnergyComposite, composite),
-        )
+    yield from set_energy_plan(demand_energy_ev, cast(SetEnergyComposite, composite))
 
     yield from bps.wait("robot_load")
 

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
@@ -177,21 +177,19 @@ def robot_load_then_xray_centre(
     doing_chi_change = parameters.chi_start_deg is not None
 
     if doing_sample_load:
+        LOGGER.info("Pin not loaded, loading and centring")
         plan = _robot_load_then_flyscan_plan(
             composite,
             parameters,
         )
-        LOGGER.info("Pin not loaded, loading and centring")
     else:
         # Robot load normally sets the energy so we should do this explicitly if no load is
         # being done
         demand_energy_ev = parameters.demand_energy_ev
         LOGGER.info(f"Setting the energy to {demand_energy_ev}eV")
-        if demand_energy_ev:
-            yield from set_energy_plan(
-                demand_energy_ev / 1000,
-                cast(SetEnergyComposite, composite),
-            )
+        yield from set_energy_plan(
+            demand_energy_ev, cast(SetEnergyComposite, composite)
+        )
 
         if doing_chi_change:
             plan = _flyscan_plan_from_robot_load_params(composite, parameters)

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_then_centre_plan.py
@@ -56,6 +56,10 @@ from mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy import (
     pin_already_loaded,
     robot_load_and_change_energy_plan,
 )
+from mx_bluesky.hyperion.experiment_plans.set_energy_plan import (
+    SetEnergyComposite,
+    set_energy_plan,
+)
 from mx_bluesky.hyperion.parameters.constants import CONST
 
 
@@ -178,12 +182,23 @@ def robot_load_then_xray_centre(
             parameters,
         )
         LOGGER.info("Pin not loaded, loading and centring")
-    elif doing_chi_change:
-        plan = _flyscan_plan_from_robot_load_params(composite, parameters)
-        LOGGER.info("Pin already loaded but chi changed so centring")
     else:
-        LOGGER.info("Pin already loaded and chi not changed so doing nothing")
-        return
+        # Robot load normally sets the energy so we should do this explicitly if no load is
+        # being done
+        demand_energy_ev = parameters.demand_energy_ev
+        LOGGER.info(f"Setting the energy to {demand_energy_ev}eV")
+        if demand_energy_ev:
+            yield from set_energy_plan(
+                demand_energy_ev / 1000,
+                cast(SetEnergyComposite, composite),
+            )
+
+        if doing_chi_change:
+            plan = _flyscan_plan_from_robot_load_params(composite, parameters)
+            LOGGER.info("Pin already loaded but chi changed so centring")
+        else:
+            LOGGER.info("Pin already loaded and chi not changed so doing nothing")
+            return
 
     detector_params = yield from fill_in_energy_if_not_supplied(
         composite.dcm, parameters.detector_params

--- a/src/mx_bluesky/hyperion/experiment_plans/set_energy_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/set_energy_plan.py
@@ -48,12 +48,13 @@ def _set_energy_plan(
 
 
 def set_energy_plan(
-    energy_kev,
+    energy_ev: float | None,
     composite: SetEnergyComposite,
 ):
-    yield from transmission_and_xbpm_feedback_for_collection_wrapper(
-        _set_energy_plan(energy_kev, composite),
-        composite.xbpm_feedback,
-        composite.attenuator,
-        DESIRED_TRANSMISSION_FRACTION,
-    )
+    if energy_ev:
+        yield from transmission_and_xbpm_feedback_for_collection_wrapper(
+            _set_energy_plan(energy_ev / 1000, composite),
+            composite.xbpm_feedback,
+            composite.attenuator,
+            DESIRED_TRANSMISSION_FRACTION,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,10 +426,11 @@ def xbpm_feedback(done_status):
     beamline_utils.clear_devices()
 
 
-def set_up_dcm(dcm):
+def set_up_dcm(dcm, sim_run_engine: RunEngineSimulator):
     set_mock_value(dcm.energy_in_kev.user_readback, 12.7)
     set_mock_value(dcm.pitch_in_mrad.user_readback, 1)
     set_mock_value(dcm.crystal_metadata_d_spacing, 3.13475)
+    sim_run_engine.add_read_handler_for(dcm.crystal_metadata_d_spacing, 3.13475)
     patch_motor(dcm.roll_in_mrad)
     patch_motor(dcm.pitch_in_mrad)
     patch_motor(dcm.offset_in_mm)
@@ -437,9 +438,9 @@ def set_up_dcm(dcm):
 
 
 @pytest.fixture
-def dcm(RE):
+def dcm(RE, sim_run_engine):
     dcm = i03.dcm(fake_with_ophyd_sim=True)
-    set_up_dcm(dcm)
+    set_up_dcm(dcm, sim_run_engine)
     yield dcm
 
 
@@ -478,9 +479,9 @@ def mirror_voltages():
 
 
 @pytest.fixture
-def undulator_dcm(RE, dcm):
+def undulator_dcm(RE, sim_run_engine, dcm):
     undulator_dcm = i03.undulator_dcm(fake_with_ophyd_sim=True)
-    set_up_dcm(undulator_dcm.dcm)
+    set_up_dcm(undulator_dcm.dcm, sim_run_engine)
     undulator_dcm.roll_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
     undulator_dcm.pitch_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
     yield undulator_dcm

--- a/tests/test_data/parameter_json_files/load_centre_collect_params_top_n_by_max_count.json
+++ b/tests/test_data/parameter_json_files/load_centre_collect_params_top_n_by_max_count.json
@@ -24,7 +24,7 @@
     "comment": "Hyperion Rotation Scan - ",
     "file_name": "protk",
     "storage_directory": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/",
-    "demand_energy_ev": 11200,
+    "demand_energy_ev": 11100,
     "exposure_time_s": 0.004,
     "rotation_increment_deg": 0.1,
     "transmission_frac": 0.05,

--- a/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
@@ -107,9 +107,6 @@ def test_adjust_dcm_pitch_roll_vfm_from_lut(
     mirror_voltages: MirrorVoltages,
     sim_run_engine: RunEngineSimulator,
 ):
-    sim_run_engine.add_read_handler_for(
-        undulator_dcm.dcm.crystal_metadata_d_spacing, 3.13475
-    )
     sim_run_engine.add_handler_for_callback_subscribes()
 
     messages = sim_run_engine.simulate_plan(

--- a/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_dcm_pitch_roll_mirror_adjuster.py
@@ -129,19 +129,6 @@ def test_adjust_dcm_pitch_roll_vfm_from_lut(
     )
     messages = assert_message_and_return_remaining(
         messages[1:],
-        lambda msg: msg.command == "wait" and msg.kwargs["group"] == "DCM_GROUP",
-    )
-    messages = assert_message_and_return_remaining(
-        messages[1:],
-        lambda msg: msg.command == "set"
-        and msg.obj.name == "dcm-offset_in_mm"
-        and msg.args == (25.6,),
-    )
-    messages = assert_message_and_return_remaining(
-        messages[1:], lambda msg: msg.command == "wait"
-    )
-    messages = assert_message_and_return_remaining(
-        messages[1:],
         lambda msg: msg.command == "set"
         and msg.obj.name == "vfm-stripe"
         and msg.args == (MirrorStripe.RHODIUM,),

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -69,29 +69,6 @@ def test_when_plan_run_with_requested_energy_specified_energy_change_executes(
     )
 
 
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy.set_energy_plan",
-    MagicMock(return_value=iter([Msg("set_energy_plan")])),
-)
-def test_robot_load_and_energy_change_doesnt_set_energy_if_not_specified(
-    robot_load_and_energy_change_composite: RobotLoadAndEnergyChangeComposite,
-    robot_load_and_energy_change_params_no_energy: RobotLoadAndEnergyChange,
-    sim_run_engine: RunEngineSimulator,
-):
-    sim_run_engine.add_handler(
-        "locate",
-        lambda msg: {"readback": 11.105},
-        "dcm-energy_in_kev",
-    )
-    messages = sim_run_engine.simulate_plan(
-        robot_load_and_change_energy_plan(
-            robot_load_and_energy_change_composite,
-            robot_load_and_energy_change_params_no_energy,
-        )
-    )
-    assert not any(msg for msg in messages if msg.command == "set_energy_plan")
-
-
 def run_simulating_smargon_wait(
     robot_load_then_centre_params,
     robot_load_composite,

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
@@ -476,7 +476,7 @@ def test_robot_load_then_centre_sets_energy_when_chi_change_and_no_robot_load(
     )
 
     messages = assert_message_and_return_remaining(
-        messages, lambda msg: msg.command == "set_energy_plan" and msg.args[0] == 11.1
+        messages, lambda msg: msg.command == "set_energy_plan" and msg.args[0] == 11100
     )
     messages = assert_message_and_return_remaining(
         messages, lambda msg: msg.command == "centre_plan"
@@ -504,29 +504,5 @@ def test_robot_load_then_centre_sets_energy_when_no_robot_load_no_chi_change(
         )
     )
     messages = assert_message_and_return_remaining(
-        messages, lambda msg: msg.command == "set_energy_plan" and msg.args[0] == 11.1
+        messages, lambda msg: msg.command == "set_energy_plan" and msg.args[0] == 11100
     )
-
-
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.pin_centre_then_flyscan_plan",
-    MagicMock(side_effect=mock_pin_centre_then_flyscan_plan),
-)
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.set_energy_plan",
-    MagicMock(
-        side_effect=lambda energy, _: iter([Msg("set_energy_plan", None, energy)])
-    ),
-)
-def test_robot_load_then_centre_given_no_energy_specified_and_sample_loaded_does_not_set_energy(
-    sim_run_engine: RunEngineSimulator,
-    robot_load_composite: RobotLoadThenCentreComposite,
-    robot_load_then_centre_params_no_energy: RobotLoadThenCentre,
-    sample_is_loaded,
-):
-    messages = sim_run_engine.simulate_plan(
-        robot_load_then_centre(
-            robot_load_composite, robot_load_then_centre_params_no_energy
-        )
-    )
-    assert_none_matching(messages, lambda msg: msg.command == "set_energy_plan")

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
@@ -41,6 +41,19 @@ def robot_load_then_centre_params_no_energy(robot_load_then_centre_params):
     return robot_load_then_centre_params
 
 
+@pytest.fixture
+def sample_is_loaded(sim_run_engine, robot_load_then_centre_params):
+    sample_location = SampleLocation(2, 6)
+    robot_load_then_centre_params.sample_puck = sample_location.puck
+    robot_load_then_centre_params.sample_pin = sample_location.pin
+    mock_current_sample(sim_run_engine, sample_location)
+
+
+@pytest.fixture
+def sample_is_not_loaded(sim_run_engine, sample_is_loaded):
+    mock_current_sample(sim_run_engine, SampleLocation(1, 1))
+
+
 def mock_pin_centre_then_flyscan_plan(_, __):
     yield from _fire_xray_centre_result_event([FLYSCAN_RESULT_MED, FLYSCAN_RESULT_LOW])
 
@@ -251,15 +264,11 @@ def test_given_sample_already_loaded_and_chi_not_changed_when_robot_load_called_
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
     sim_run_engine: RunEngineSimulator,
+    sample_is_loaded,
 ):
     sim_run_engine.add_handler_for_callback_subscribes()
     sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
-    sample_location = SampleLocation(2, 6)
-    robot_load_then_centre_params.sample_puck = sample_location.puck
-    robot_load_then_centre_params.sample_pin = sample_location.pin
     robot_load_then_centre_params.chi_start_deg = None
-
-    mock_current_sample(sim_run_engine, sample_location)
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -305,15 +314,11 @@ def test_given_sample_already_loaded_and_chi_is_changed_when_robot_load_called_t
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
     sim_run_engine: RunEngineSimulator,
+    sample_is_loaded,
 ):
     sim_run_engine.add_handler_for_callback_subscribes()
     sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
-    sample_location = SampleLocation(2, 6)
-    robot_load_then_centre_params.sample_puck = sample_location.puck
-    robot_load_then_centre_params.sample_pin = sample_location.pin
     robot_load_then_centre_params.chi_start_deg = 30
-
-    mock_current_sample(sim_run_engine, sample_location)
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -368,14 +373,11 @@ def test_given_sample_not_loaded_and_chi_not_changed_when_robot_load_called_then
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
     sim_run_engine: RunEngineSimulator,
+    sample_is_not_loaded,
 ):
     sim_run_engine.add_handler_for_callback_subscribes()
     sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
-    robot_load_then_centre_params.sample_puck = 2
-    robot_load_then_centre_params.sample_pin = 6
     robot_load_then_centre_params.chi_start_deg = None
-
-    mock_current_sample(sim_run_engine, SampleLocation(1, 1))
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -414,14 +416,11 @@ def test_given_sample_not_loaded_and_chi_changed_when_robot_load_called_then_eig
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
     sim_run_engine: RunEngineSimulator,
+    sample_is_not_loaded,
 ):
     sim_run_engine.add_handler_for_callback_subscribes()
     sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
-    robot_load_then_centre_params.sample_puck = 2
-    robot_load_then_centre_params.sample_pin = 6
     robot_load_then_centre_params.chi_start_deg = 30
-
-    mock_current_sample(sim_run_engine, SampleLocation(1, 1))
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -465,13 +464,9 @@ def test_robot_load_then_centre_sets_energy_when_chi_change_and_no_robot_load(
     sim_run_engine: RunEngineSimulator,
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
+    sample_is_loaded,
 ):
-    sample_location = SampleLocation(2, 6)
-    robot_load_then_centre_params.sample_puck = sample_location.puck
-    robot_load_then_centre_params.sample_pin = sample_location.pin
     robot_load_then_centre_params.chi_start_deg = 30
-
-    mock_current_sample(sim_run_engine, sample_location)
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -498,13 +493,9 @@ def test_robot_load_then_centre_sets_energy_when_no_robot_load_no_chi_change(
     sim_run_engine: RunEngineSimulator,
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
+    sample_is_loaded,
 ):
-    sample_location = SampleLocation(2, 6)
-    robot_load_then_centre_params.sample_puck = sample_location.puck
-    robot_load_then_centre_params.sample_pin = sample_location.pin
     robot_load_then_centre_params.chi_start_deg = None
-
-    mock_current_sample(sim_run_engine, sample_location)
 
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
@@ -531,12 +522,8 @@ def test_robot_load_then_centre_given_no_energy_specified_and_sample_loaded_does
     sim_run_engine: RunEngineSimulator,
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params_no_energy: RobotLoadThenCentre,
+    sample_is_loaded,
 ):
-    sample_location = SampleLocation(2, 6)
-    robot_load_then_centre_params_no_energy.sample_puck = sample_location.puck
-    robot_load_then_centre_params_no_energy.sample_pin = sample_location.pin
-    mock_current_sample(sim_run_engine, sample_location)
-
     messages = sim_run_engine.simulate_plan(
         robot_load_then_centre(
             robot_load_composite, robot_load_then_centre_params_no_energy

--- a/tests/unit_tests/hyperion/experiment_plans/test_set_energy_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_set_energy_plan.py
@@ -35,7 +35,9 @@ def test_set_energy(
     sim_run_engine,
     set_energy_composite,
 ):
-    messages = sim_run_engine.simulate_plan(set_energy_plan(11.1, set_energy_composite))
+    messages = sim_run_engine.simulate_plan(
+        set_energy_plan(11100, set_energy_composite)
+    )
     messages = assert_message_and_return_remaining(
         messages,
         lambda msg: msg.command == "set"
@@ -74,3 +76,16 @@ def test_set_energy(
         and msg.obj.name == "attenuator"
         and msg.args == (1.0,),
     )
+
+
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.set_energy_plan.dcm_pitch_roll_mirror_adjuster.adjust_dcm_pitch_roll_vfm_from_lut",
+    return_value=iter([Msg("adjust_dcm_pitch_roll_vfm_from_lut")]),
+)
+def test_set_energy_does_nothing_if_no_energy_specified(
+    mock_dcm_pra,
+    sim_run_engine,
+    set_energy_composite,
+):
+    messages = sim_run_engine.simulate_plan(set_energy_plan(None, set_energy_composite))
+    assert not messages


### PR DESCRIPTION
This fixes energy change issues discovered during beamline testing #651 

See also DiamondLightSource/dodal#918

1. Energy changes should now result in the VFM yaw and lateral position (x-offset) being set depending on the mirror stripe.
Previously the yaw was unset and the lateral position adjusted according to a lookup-table that was effectively single-valued.
2. The energy change, and individual DCM changes are now serialized because they cannot be done in parallel
3. The timeouts for the yaw, lat operations are increased to 30s from 10s
4. Mirror voltage changes are now serialized instead of being attempted in parallel
5. Energy changes are now done in `robot_load_then_centre` regardless of whether a robot load and/or chi change is performed or not

### Instructions to reviewer on how to test:
1. Energy changes work on beamline
2. Unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
