### PR TITLE
parse the RunStop reason field instead of using events, following discussion with bluesky

### DIFF
--- a/src/mx_bluesky/common/utils/exceptions.py
+++ b/src/mx_bluesky/common/utils/exceptions.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable, Generator
 from typing import TypeVar
 
@@ -22,7 +23,14 @@ class ISPyBDepositionNotMade(Exception):
 class SampleException(WarningException):
     """An exception which identifies an issue relating to the sample."""
 
-    pass
+    def __str__(self):
+        class_name = type(self).__name__
+        return f"[{class_name}]: {super().__str__()}"
+
+    @classmethod
+    def type_and_message_from_reason(cls, reason: str) -> tuple[str, str]:
+        match = re.match(r"\[(\S*)?]: (.*)", reason)
+        return (match.group(1), match.group(2)) if match else (None, None)
 
 
 T = TypeVar("T")

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -22,9 +22,6 @@ from mx_bluesky.hyperion.experiment_plans.rotation_scan_plan import (
     RotationScanComposite,
     multi_rotation_scan,
 )
-from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
-    sample_handling_callback_decorator,
-)
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.load_centre_collect import LoadCentreCollect
 from mx_bluesky.hyperion.utils.context import device_composite_from_context
@@ -62,7 +59,6 @@ def load_centre_collect_full(
             "activate_callbacks": ["SampleHandlingCallback"],
         }
     )
-    @sample_handling_callback_decorator()
     def plan_with_callback_subs():
         flyscan_event_handler = XRayCentreEventHandler()
         yield from subs_wrapper(

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -1,16 +1,5 @@
-import dataclasses
-from collections.abc import Generator
-from functools import partial
-from typing import Any
+from event_model import RunStart, RunStop
 
-import bluesky.plan_stubs as bps
-from bluesky.preprocessors import contingency_wrapper
-from bluesky.utils import Msg, make_decorator
-from event_model import Event, EventDescriptor, RunStart
-
-from mx_bluesky.common.external_interaction.callbacks.common.abstract_event import (
-    AbstractEvent,
-)
 from mx_bluesky.common.external_interaction.callbacks.common.plan_reactive_callback import (
     PlanReactiveCallback,
 )
@@ -20,26 +9,9 @@ from mx_bluesky.common.external_interaction.ispyb.exp_eye_store import (
 )
 from mx_bluesky.common.utils.exceptions import CrystalNotFoundException, SampleException
 from mx_bluesky.common.utils.log import ISPYB_ZOCALO_CALLBACK_LOGGER
-from mx_bluesky.hyperion.parameters.constants import CONST
 
 # TODO remove this event-raising shenanigans once
 # https://github.com/bluesky/bluesky/issues/1829 is addressed
-
-
-@dataclasses.dataclass(frozen=True)
-class _ExceptionEvent(AbstractEvent):
-    exception_type: str
-
-
-def _exception_interceptor(exception: Exception) -> Generator[Msg, Any, Any]:
-    yield from bps.create(CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION)
-    yield from bps.read(_ExceptionEvent(type(exception).__name__))
-    yield from bps.save()
-
-
-sample_handling_callback_decorator = make_decorator(
-    partial(contingency_wrapper, except_plan=_exception_interceptor)
-)
 
 
 class SampleHandlingCallback(PlanReactiveCallback):
@@ -57,16 +29,13 @@ class SampleHandlingCallback(PlanReactiveCallback):
             self.log.info(f"Recording sample ID at run start {sample_id}")
             self._sample_id = sample_id
 
-    def activity_gated_descriptor(self, doc: EventDescriptor) -> EventDescriptor | None:
-        if doc.get("name") == CONST.DESCRIPTORS.SAMPLE_HANDLING_EXCEPTION:
-            self._descriptor = doc["uid"]
-        return super().activity_gated_descriptor(doc)
-
-    def activity_gated_event(self, doc: Event) -> Event | None:
-        if doc["descriptor"] == self._descriptor:
-            exception_type = doc["data"]["exception_type"]
+    def activity_gated_stop(self, doc: RunStop) -> RunStop:
+        if doc["exit_status"] != "success":
+            exception_type, message = SampleException.type_and_message_from_reason(
+                doc["reason"]
+            )
             self.log.info(
-                f"Sample handling callback intercepted exception of type {exception_type}"
+                f"Sample handling callback intercepted exception of type {exception_type}: {message}"
             )
             self._record_exception(exception_type)
         return doc

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/sample_handling/sample_handling_callback.py
@@ -10,9 +10,6 @@ from mx_bluesky.common.external_interaction.ispyb.exp_eye_store import (
 from mx_bluesky.common.utils.exceptions import CrystalNotFoundException, SampleException
 from mx_bluesky.common.utils.log import ISPYB_ZOCALO_CALLBACK_LOGGER
 
-# TODO remove this event-raising shenanigans once
-# https://github.com/bluesky/bluesky/issues/1829 is addressed
-
 
 class SampleHandlingCallback(PlanReactiveCallback):
     """Intercepts exceptions from experiment plans and updates the ISPyB BLSampleStatus
@@ -32,7 +29,7 @@ class SampleHandlingCallback(PlanReactiveCallback):
     def activity_gated_stop(self, doc: RunStop) -> RunStop:
         if doc["exit_status"] != "success":
             exception_type, message = SampleException.type_and_message_from_reason(
-                doc["reason"]
+                doc.get("reason", "")
             )
             self.log.info(
                 f"Sample handling callback intercepted exception of type {exception_type}: {message}"

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/sample_handling/test_sample_handling_callback.py
@@ -11,7 +11,6 @@ from mx_bluesky.hyperion.experiment_plans.flyscan_xray_centre_plan import (
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.sample_handling.sample_handling_callback import (
     SampleHandlingCallback,
-    sample_handling_callback_decorator,
 )
 
 TEST_SAMPLE_ID = 123456
@@ -23,7 +22,6 @@ TEST_SAMPLE_ID = 123456
         "activate_callbacks": ["SampleHandlingCallback"],
     }
 )
-@sample_handling_callback_decorator()
 def plan_with_general_exception(exception_type: type):
     yield from []
     raise exception_type("Test failure")
@@ -35,7 +33,6 @@ def plan_with_general_exception(exception_type: type):
         "activate_callbacks": ["SampleHandlingCallback"],
     }
 )
-@sample_handling_callback_decorator()
 def plan_with_normal_completion():
     yield from []
 


### PR DESCRIPTION
Relates to #716 

Following a discussion with bluesky team, this PR removes the event handler introduced in 
https://github.com/DiamondLightSource/mx-bluesky/pull/606
in favour of parsing the `reason` field in the RunStop document