### PR TITLE
Fix system tests for oav zoom controller and load_centre_collect params

### DIFF
--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -154,6 +154,10 @@ def oav_for_system_test(test_config_files):
     ):
         mock_get.return_value.__aenter__.return_value = empty_response
         set_mock_value(oav.zoom_controller.level, "1.0")
+        zoom_levels_list = ["1.0x", "3.0x", "5.0x", "7.5x", "10.0x", "15.0x"]
+        oav.zoom_controller._get_allowed_zoom_levels = AsyncMock(
+            return_value=zoom_levels_list
+        )
         yield oav
 
 

--- a/tests/test_data/parameter_json_files/example_load_centre_collect_params.json
+++ b/tests/test_data/parameter_json_files/example_load_centre_collect_params.json
@@ -19,7 +19,7 @@
     "comment": "Hyperion Rotation Scan - ",
     "file_name": "protk",
     "storage_directory": "/tmp/dls/i03/data/2024/cm31105-4/auto/123457/",
-    "demand_energy_ev": 11200,
+    "demand_energy_ev": 11100,
     "exposure_time_s": 0.004,
     "rotation_increment_deg": 0.1,
     "snapshot_omegas_deg": [


### PR DESCRIPTION
This adds missing zoom levels to the oav zoom controller following #594 
It also updates the `demand_energy_ev` test data for system test parameters to be valid following #676 