### PR TITLE
Fix unit test borkage due to `pydantic-extra-types` change in 2.10.1

### DIFF
--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -103,12 +103,12 @@ class MxBlueskyParameters(BaseModel):
 
     @field_validator("parameter_model_version")
     @classmethod
-    def _validate_version(cls, version: Version):
+    def _validate_version(cls, version: SemanticVersion):
         assert (
-            version >= Version(major=PARAMETER_VERSION.major)
+            version >= SemanticVersion(major=PARAMETER_VERSION.major)
         ), f"Parameter version too old! This version of hyperion uses {PARAMETER_VERSION}"
         assert (
-            version <= Version(major=PARAMETER_VERSION.major + 1)
+            version <= SemanticVersion(major=PARAMETER_VERSION.major + 1)
         ), f"Parameter version too new! This version of hyperion uses {PARAMETER_VERSION}"
         return version
 


### PR DESCRIPTION
Note this change merges on top of #704 

`pydantic-extra-types` changed the inheritance hierarcy for `SemanticVersion` in the below change, which broke our unit tests
https://github.com/pydantic/pydantic-extra-types/pull/237

This change fixes the following unit test error:
```
ERROR tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py - TypeError: Expected str, bytes, dict, tuple, list, or SemanticVersion instance, but got <class 'semver.version.Version'>
ERROR tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py - TypeError: Expected str, bytes, dict, tuple, list, or SemanticVersion instance, but got <class 'semver.version.Version'>
ERROR tests/unit_tests/hyperion/external_interaction/callbacks - TypeError: Expected str, bytes, dict, tuple, list, or SemanticVersion instance, but got <class 'semver.version.Version'>
```