### PR TITLE
Deployment script deletes old deployments

### DIFF
--- a/utility_scripts/deploy/deploy_mx_bluesky.py
+++ b/utility_scripts/deploy/deploy_mx_bluesky.py
@@ -10,7 +10,7 @@ import subprocess
 from typing import NamedTuple
 from uuid import uuid1
 
-from create_venv import run_process_and_print_output
+from create_venv import run_process_and_print_output, setup_venv
 from git import Repo
 from packaging.version import VERSION_PATTERN, Version
 
@@ -231,8 +231,7 @@ def main(beamline: str, options: Options):
                     mx_repo, path_to_create_venv, path_to_dls_dev_env, beamline
                 )
             else:
-                # setup_venv(path_to_dls_dev_env, mx_repo.deploy_location)
-                pass
+                setup_venv(path_to_dls_dev_env, mx_repo.deploy_location)
 
     # If on beamline I24 also deploy the screens to run ssx collections
     if beamline == "i24":

--- a/utility_scripts/deploy/deploy_mx_bluesky.py
+++ b/utility_scripts/deploy/deploy_mx_bluesky.py
@@ -163,7 +163,7 @@ def _prune_old_deployments(release_area: str):
             for deployment in sorted_deployments[MAX_DEPLOYMENTS:]
         }
 
-        # Removes old deployments with symlinks
+        # Excludes deployments that are symlinked
         for link in symlinks:
             link_path = os.path.dirname(os.readlink(os.path.join(release_area, link)))
             if link_path in full_path_old_deployments:

--- a/utility_scripts/deploy/deploy_mx_bluesky.py
+++ b/utility_scripts/deploy/deploy_mx_bluesky.py
@@ -331,7 +331,7 @@ def _parse_options() -> tuple[str, Options]:
         "-pd",
         "--prune-deployments",
         action="store_true",
-        help="Delete non-recent deployments.",
+        help="Delete non-recent, non-symlinked deployments, if more than four found.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
These changes add a --prune-deployments flag, keeping 4 most recent deployments, and deleting the excess if not symlinked to hyperion_stable or hyperion_latest, following #272 