### PR TITLE
Error when inputting nonexistant feature flags

### DIFF
--- a/src/mx_bluesky/common/external_interaction/config_server.py
+++ b/src/mx_bluesky/common/external_interaction/config_server.py
@@ -29,7 +29,18 @@ class FeatureFlags(BaseModel, ABC):
     def mark_overridden_features(cls, values):
         assert isinstance(values, dict)
         values["overriden_features"] = values.copy()
+        cls.validate_overridden_features(values)
         return values
+
+    @classmethod
+    def validate_overridden_features(cls, values: dict):
+        """Validates overridden features to ensure they are defined in the model fields."""
+        defined_fields = cls.model_fields.keys()
+        invalid_features = [key for key in values.keys() if key not in defined_fields]
+
+        if invalid_features:
+            message = f"Invalid feature toggle(s) supplied: {invalid_features}. "
+            raise ValueError(message)
 
     def _get_flags(self):
         flags = type(self).get_config_server().best_effort_get_all_feature_flags()

--- a/src/mx_bluesky/common/external_interaction/config_server.py
+++ b/src/mx_bluesky/common/external_interaction/config_server.py
@@ -29,11 +29,11 @@ class FeatureFlags(BaseModel, ABC):
     def mark_overridden_features(cls, values):
         assert isinstance(values, dict)
         values["overriden_features"] = values.copy()
-        cls.validate_overridden_features(values)
+        cls._validate_overridden_features(values)
         return values
 
     @classmethod
-    def validate_overridden_features(cls, values: dict):
+    def _validate_overridden_features(cls, values: dict):
         """Validates overridden features to ensure they are defined in the model fields."""
         defined_fields = cls.model_fields.keys()
         invalid_features = [key for key in values.keys() if key not in defined_fields]

--- a/src/mx_bluesky/common/external_interaction/test_config_server.py
+++ b/src/mx_bluesky/common/external_interaction/test_config_server.py
@@ -1,0 +1,34 @@
+from functools import cache
+
+import pytest
+
+from mx_bluesky.common.external_interaction.config_server import FeatureFlags
+
+
+class MockConfigServer:
+    def best_effort_get_all_feature_flags(self):
+        return {
+            "feature_a": False,
+            "feature_b": False,
+        }
+
+
+class TestFeatureFlags(FeatureFlags):
+    @staticmethod
+    @cache
+    def get_config_server() -> MockConfigServer:  # type: ignore
+        return MockConfigServer()
+
+    feature_a: bool = False
+    feature_b: bool = False
+
+
+def test_valid_overridden_features():
+    flags = TestFeatureFlags(feature_a=True, feature_b=True)
+    assert flags.feature_a is True
+    assert flags.feature_b is True
+
+
+def test_invalid_overridden_features():
+    with pytest.raises(ValueError, match="Invalid feature toggle"):
+        TestFeatureFlags(invalid_feature=True)  # type: ignore

--- a/src/mx_bluesky/common/external_interaction/test_config_server.py
+++ b/src/mx_bluesky/common/external_interaction/test_config_server.py
@@ -13,7 +13,7 @@ class MockConfigServer:
         }
 
 
-class TestFeatureFlags(FeatureFlags):
+class FakeFeatureFlags(FeatureFlags):
     @staticmethod
     @cache
     def get_config_server() -> MockConfigServer:  # type: ignore
@@ -23,12 +23,16 @@ class TestFeatureFlags(FeatureFlags):
     feature_b: bool = False
 
 
-def test_valid_overridden_features():
-    flags = TestFeatureFlags(feature_a=True, feature_b=True)
-    assert flags.feature_a is True
-    assert flags.feature_b is True
+@pytest.fixture
+def fake_feature_flags():
+    return FakeFeatureFlags(feature_a=False, feature_b=False)
+
+
+def test_valid_overridden_features(fake_feature_flags: FakeFeatureFlags):
+    assert fake_feature_flags.feature_a is False
+    assert fake_feature_flags.feature_b is False
 
 
 def test_invalid_overridden_features():
     with pytest.raises(ValueError, match="Invalid feature toggle"):
-        TestFeatureFlags(invalid_feature=True)  # type: ignore
+        FakeFeatureFlags(feature_x=True)  # type: ignore


### PR DESCRIPTION
This should fix #620 by checking if the overridden feature flags are defined. Currently, I have this set to raise a ValueError with context of the incorrect passed feature, but maybe we want to simply warn and move on.