### PR TITLE
221 Document gridscan coordinate systems

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,8 @@ extensions = [
     "sphinx_design",
     # For markdown
     "myst_parser",
+    # For plantUML diagrams
+    "plantweb.directive",
 ]
 
 myst_enable_extensions = [

--- a/docs/developer/hyperion/reference/gridscan.puml
+++ b/docs/developer/hyperion/reference/gridscan.puml
@@ -1,0 +1,109 @@
+@startuml
+title Gridscan Parameter Relationships
+
+class DiffractionExperiment
+class DiffractionExperimentWithSample
+class GridCommon {
+    grid_width_um
+    exposure_time_s
+}
+class GridScanWithEdgeDetect {
+    box_size_um
+}
+class HyperionGridCommon {
+    enable_dev_shm
+}
+class HyperionThreeDGridScan {
+    x_step_size_um
+    y_step_size_um
+    z_step_size_um
+    y2_start_um
+    z2_start_um
+    --
+    grid_1_spec
+    grid_2_spec
+    scan_indices
+    scan_spec
+    scan_points
+    scan_points_first_grid
+    scan_points_second_grid
+    num_images
+    FGS_Params
+    panda_FGS_Params
+}
+class MxBlueSkyParameters
+class SpecifiedGrid
+class XyzStarts {
+    x_start_um
+    y_start_um
+    z_start_um
+}
+class OptionalXYZStarts {
+    x_start_um
+    y_start_um
+    z_start_um
+}
+class RotationScanPerSweep
+
+MxBlueSkyParameters <|-- DiffractionExperiment
+DiffractionExperiment <|-- DiffractionExperimentWithSample
+DiffractionExperimentWithSample <|-- GridCommon
+GridCommon <|-- GridScanWithEdgeDetect
+GridCommon <|-- HyperionGridCommon
+HyperionGridCommon <|-- HyperionThreeDGridScan
+SpecifiedGrid <|-- HyperionThreeDGridScan
+XyzStarts <|-- SpecifiedGrid
+OptionalXYZStarts <|-- RotationScanPerSweep
+class GridParamUpdate {
+    x_start_um
+    y_start_um
+    y2_start_um
+    z_start_um
+    z2_start_um
+    x_steps
+    y_steps
+    z_steps
+    x_step_size_um
+    y_step_size_um
+    z_step_size_um
+}
+
+class GridDetectionCallback {
+    get_grid_parameters() -> GridParamUpdate
+}
+    
+GridDetectionCallback --> GridParamUpdate : generates from event. Adds 0.5 to get box-centres
+GridParamUpdate --> HyperionThreeDGridScan : combines with GridScanWithEdgeDetect
+
+class experiment_plans {
+    grid_detect_then_xray_centre()
+    flyscan_xray_centre_no_move()
+    create_parameters_for_flyscan_xray_centre(GridScanWithEdgeDetect, GridParamUpdate) -> HyperionThreeDGridScan
+}
+
+class AbstractExperimentBase
+class AbstractExperimentWithBeamParams
+class GridScanParamsCommon {
+    x_steps
+    y_steps
+    z_steps
+    x_step_size_mm
+    y_step_size_mm
+    z_step_size_mm
+    x_start_mm
+    y1_start_mm
+    y2_start_mm
+    z1_start_mm
+    z2_start_mm
+}
+class PandAGridScanParams
+class ZebraGridScanParams
+
+AbstractExperimentBase <|-- AbstractExperimentWithBeamParams
+AbstractExperimentWithBeamParams <|-- GridScanParamsCommon
+GridScanParamsCommon <|-- PandAGridScanParams
+GridScanParamsCommon <|-- ZebraGridScanParams
+
+HyperionThreeDGridScan --> ZebraGridScanParams : generates
+HyperionThreeDGridScan --> PandAGridScanParams : generates
+@enduml

--- a/docs/developer/hyperion/reference/param-hierarchy.rst
+++ b/docs/developer/hyperion/reference/param-hierarchy.rst
@@ -2,3 +2,8 @@ Hyperion Parameter class hierarchy
 ==================================
 
 TODO: automate including the param hierarchy here
+
+How Gridscan Parameters are Obtained
+------------------------------------
+
+.. uml:: gridscan.puml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "mypy",
     "myst-parser",
     "pipdeptree",
+    "plantweb",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
     "pyright",

--- a/src/mx_bluesky/hyperion/experiment_plans/common/xrc_result.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/common/xrc_result.py
@@ -14,7 +14,16 @@ from mx_bluesky.common.parameters.components import (
 
 @dataclasses.dataclass
 class XRayCentreResult:
-    """Represents information about a hit from an X-ray centring."""
+    """
+    Represents information about a hit from an X-ray centring.
+
+    Attributes:
+        centre_of_mass_mm: coordinates in mm of the centre of mass
+        bounding_box_mm: coordinates in mm of opposite corners of the bounding box
+            containing the crystal
+        max_count: The maximum spot count encountered in any one grid box in the crystal
+        total_count: The total count across all boxes in the crystal.
+    """
 
     centre_of_mass_mm: np.ndarray
     bounding_box_mm: tuple[np.ndarray, np.ndarray]

--- a/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -290,6 +290,8 @@ def _xrc_result_in_boxes_to_result_in_mm(
     # the corners of the box in motor-space; we do not apply this correction
     # to the xray-centre as it is already in continuous space and the conversion has
     # been performed already
+    # In other words, xrc_result["bounding_box"] contains the position of the box centre,
+    # so we subtract half a box to get the corner of the box
     return XRayCentreResult(
         centre_of_mass_mm=xray_centre,
         bounding_box_mm=(

--- a/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -286,14 +286,18 @@ def _xrc_result_in_boxes_to_result_in_mm(
     xray_centre = fgs_params.grid_position_to_motor_position(
         np.array(xrc_result["centre_of_mass"])
     )
+    # A correction is applied to the bounding box to map discrete grid coordinates to
+    # the corners of the box in motor-space; we do not apply this correction
+    # to the xray-centre as it is already in continuous space and the conversion has
+    # been performed already
     return XRayCentreResult(
         centre_of_mass_mm=xray_centre,
         bounding_box_mm=(
             fgs_params.grid_position_to_motor_position(
-                np.array(xrc_result["bounding_box"][0])
+                np.array(xrc_result["bounding_box"][0]) - 0.5
             ),
             fgs_params.grid_position_to_motor_position(
-                np.array(xrc_result["bounding_box"][1])
+                np.array(xrc_result["bounding_box"][1]) - 0.5
             ),
         ),
         max_count=xrc_result["max_count"],

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/grid_detection_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/grid_detection_callback.py
@@ -9,6 +9,24 @@ from mx_bluesky.hyperion.log import LOGGER
 
 
 class GridParamUpdate(TypedDict):
+    """
+    Grid parameters extracted from the grid detection.
+    Positions are in motor-space.
+
+    Attributes:
+        x_start_um: x position of the centre of the first xy-gridscan box in microns
+        y_start_um: y position of the centre of the first xy-gridscan box in microns
+        y2_start_um: y position of the centre of the first xz-gridscan box in microns
+        z_start_um: z position of the centre of the first xy-gridscan box in microns
+        z2_start_um: z position of the centre of the first xz-gridscan box in microns
+        x_steps: Number of grid boxes in x-direction for xy- and xz- gridscans
+        y_steps: Number of grid boxes in y-direction for xy-gridscan
+        z_steps: Number of grid boxes in z-direction for xz-gridscan
+        x_step_size_um: x-dimension of the grid box
+        y_step_size_um: y-dimension of the grid box
+        z_step_size_um: z-dimension of the grid box
+    """
+
     x_start_um: float
     y_start_um: float
     y2_start_um: float

--- a/src/mx_bluesky/hyperion/external_interaction/ispyb/data_model.py
+++ b/src/mx_bluesky/hyperion/external_interaction/ispyb/data_model.py
@@ -70,6 +70,8 @@ class DataCollectionPositionInfo:
 
 @dataclass
 class DataCollectionGridInfo:
+    """This information is used by Zocalo gridscan per-image-analysis"""
+
     dx_in_mm: float
     dy_in_mm: float
     steps_x: int

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -359,7 +359,10 @@ class TestFlyscanXrayCentrePlan:
         actual = x_ray_centre_event_handler.xray_centre_results
         expected = XRayCentreResult(
             centre_of_mass_mm=np.array([0.05, 0.15, 0.25]),
-            bounding_box_mm=(np.array([0.2, 0.2, 0.2]), np.array([0.8, 0.8, 0.7])),
+            bounding_box_mm=(
+                np.array([0.15, 0.15, 0.15]),
+                np.array([0.75, 0.75, 0.65]),
+            ),
             max_count=105062,
             total_count=2387574,
         )


### PR DESCRIPTION
This addresses #221 and improves documentation about the reporting of the Zocalo Results 

See also DiamondLightSource/dodal#958

It also fixes an issue where the bounding box returned in the `XRayCentreResult` is off by 0.5 of a grid-box, however I don't think this impacts anything as this attribute isn't used yet.
