### PR TITLE
Pinning pydantic extra types to 2.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "pydantic",
-    "pydantic-extra-types",
+    "pydantic-extra-types >= 2.10.1",
     "pyepics",
     "pyzmq",
     "requests",


### PR DESCRIPTION
Encountered the pydantic error `TypeError: SemanticVersion() takes no arguments` when running tests; this was due to pydantic-extra-types being at 2.10.0 instead of 2.10.1.
Request to pin this to => 2.10.1