### PR TITLE
References to undulator and dcm in underlator_dcm device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.8a5",
     "bluesky >= 1.13.0a4",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@4349f34577671c0090a843ccfde8af5f1657bb7b",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@987bc78925685dfa7237c58fd36e74060d73dbd4",
 ]
 
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/dcm_pitch_roll_mirror_adjuster.py
@@ -98,9 +98,11 @@ def adjust_dcm_pitch_roll_vfm_from_lut(
     feedback from making unnecessary corrections while beam is being adjusted."""
 
     # Adjust DCM Pitch
-    dcm = undulator_dcm.dcm
+    dcm = undulator_dcm.dcm_ref()
     LOGGER.info(f"Adjusting DCM and VFM for {energy_kev} keV")
-    d_spacing_a: float = yield from bps.rd(undulator_dcm.dcm.crystal_metadata_d_spacing)
+    d_spacing_a: float = yield from bps.rd(
+        undulator_dcm.dcm_ref().crystal_metadata_d_spacing
+    )
     bragg_deg = energy_to_bragg_angle(energy_kev, d_spacing_a)
     LOGGER.info(f"Target Bragg angle = {bragg_deg} degrees")
     dcm_pitch_adjuster = lookup_table_adjuster(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,7 +480,7 @@ def mirror_voltages():
 @pytest.fixture
 def undulator_dcm(RE, sim_run_engine, dcm):
     undulator_dcm = i03.undulator_dcm(fake_with_ophyd_sim=True)
-    set_up_dcm(undulator_dcm.dcm, sim_run_engine)
+    set_up_dcm(undulator_dcm.dcm_ref(), sim_run_engine)
     undulator_dcm.roll_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
     undulator_dcm.pitch_energy_table_path = "tests/test_data/test_daq_configuration/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
     yield undulator_dcm

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -226,7 +226,7 @@ def test_execute_load_centre_collect_full(
     robot_load_cb.expeye.end_load = MagicMock()
     robot_load_cb.expeye.update_barcode_and_snapshots = MagicMock()
     set_mock_value(
-        load_centre_collect_composite.undulator_dcm.undulator.current_gap, 1.11
+        load_centre_collect_composite.undulator_dcm.undulator_ref().current_gap, 1.11
     )
     RE.subscribe(ispyb_gridscan_cb)
     RE.subscribe(ispyb_rotation_cb)


### PR DESCRIPTION
PR [957](https://github.com/DiamondLightSource/dodal/pull/957) in dodal uses `Reference` to reference undulator and dcm devices in undulator_dcm composite. This PR amends mx-bluesky references to undulator_dcm.