### PR TITLE
Fix rotation omega to match GDA behavior

### DIFF
--- a/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
@@ -15,6 +15,12 @@ from mx_bluesky.common.utils.utils import convert_eV_to_angstrom
 
 
 class AxisDirection(Enum):
+    """
+    Identifies whether the omega axis of rotation is on the positive x-axis or
+    negative x-axis as per the Nexus standard:
+    https://journals.iucr.org/m/issues/2020/05/00/ti5018/ti5018.pdf
+    """
+
     POSITIVE = 1
     NEGATIVE = -1
 

--- a/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
@@ -6,7 +6,6 @@ from enum import Enum
 
 import numpy as np
 from dodal.devices.detector import DetectorParams
-from dodal.devices.zebra import RotationDirection
 from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, EigerDetector, Goniometer
 from nexgen.nxs_utils.axes import TransformationType
 from numpy.typing import DTypeLike

--- a/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/nexus_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import UTC, datetime, timedelta
+from enum import Enum
 
 import numpy as np
 from dodal.devices.detector import DetectorParams
@@ -12,6 +13,11 @@ from numpy.typing import DTypeLike
 
 from mx_bluesky.common.utils.log import NEXUS_LOGGER
 from mx_bluesky.common.utils.utils import convert_eV_to_angstrom
+
+
+class AxisDirection(Enum):
+    POSITIVE = 1
+    NEGATIVE = -1
 
 
 def vds_type_based_on_bit_depth(detector_bit_depth: int) -> DTypeLike:
@@ -35,8 +41,8 @@ def create_goniometer_axes(
     x_y_z_increments: tuple[float, float, float] = (0.0, 0.0, 0.0),
     chi: float = 0.0,
     phi: float = 0.0,
-    rotation_direction: RotationDirection = RotationDirection.NEGATIVE,
-):
+    omega_axis_direction: AxisDirection = AxisDirection.NEGATIVE,
+) -> Goniometer:
     """Returns a Nexgen 'Goniometer' object with the dependency chain of I03's Smargon
     goniometer. If scan points is provided these values will be used in preference to
     those from the params object.
@@ -50,13 +56,17 @@ def create_goniometer_axes(
         x_y_z_increments:    optionally, specify the increments between each image for
                              the x, y, and z axes. Will be ignored if scan_points
                              is provided.
+        omega_axis_direction:      The direction of the omega axis, this determines the
+                             coordinate space parity
+    Returns:
+        The created Goniometer object
     """
     gonio_axes = [
         Axis(
             "omega",
             ".",
             TransformationType.ROTATION,
-            (1.0 * rotation_direction.multiplier, 0.0, 0.0),
+            (1.0 * omega_axis_direction.value, 0.0, 0.0),
             omega_start,
         ),
         Axis(

--- a/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import math
 from pathlib import Path
 
-from dodal.devices.zebra import RotationDirection
 from dodal.utils import get_beamline_name
 from nexgen.nxs_utils import Attenuator, Beam, Detector, Goniometer, Source
 from nexgen.nxs_write.nxmx_writer import NXmxFileWriter
@@ -16,9 +15,10 @@ from numpy.typing import DTypeLike
 from scanspec.core import AxesPoints
 
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
+    AxisDirection,
     create_detector_parameters,
     create_goniometer_axes,
-    get_start_and_predicted_end_time, AxisDirection,
+    get_start_and_predicted_end_time,
 )
 from mx_bluesky.common.parameters.components import DiffractionExperimentWithSample
 

--- a/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
@@ -18,7 +18,7 @@ from scanspec.core import AxesPoints
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
     create_detector_parameters,
     create_goniometer_axes,
-    get_start_and_predicted_end_time,
+    get_start_and_predicted_end_time, AxisDirection,
 )
 from mx_bluesky.common.parameters.components import DiffractionExperimentWithSample
 
@@ -39,7 +39,7 @@ class NexusWriter:
         # detector arming event:
         full_num_of_images: int | None = None,
         meta_data_run_number: int | None = None,
-        rotation_direction: RotationDirection = RotationDirection.NEGATIVE,
+        axis_direction: AxisDirection = AxisDirection.NEGATIVE,
     ) -> None:
         self.beam: Beam | None = None
         self.attenuator: Attenuator | None = None
@@ -69,7 +69,7 @@ class NexusWriter:
             self.scan_points,
             chi=chi_start_deg,
             phi=phi_start_deg,
-            rotation_direction=rotation_direction,
+            omega_axis_direction=axis_direction,
         )
 
     def create_nexus_file(self, bit_depth: DTypeLike):

--- a/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
@@ -128,13 +128,24 @@ def calculate_motion_profile(
     See https://github.com/DiamondLightSource/hyperion/wiki/rotation-scan-geometry
     for a simple pictorial explanation."""
 
-    direction = params.rotation_direction.multiplier
+    assert params.rotation_increment_deg > 0
+
+    direction = params.rotation_direction
+    start_scan_deg = params.omega_start_deg
+
+    if params.features.omega_flip:
+        # If omega_flip is True then the motor omega axis is inverted with respect to the
+        # hyperion coordinate system.
+        start_scan_deg = -start_scan_deg
+        # start_motion_deg = -start_motion_deg
+        # distance_to_move_deg = -distance_to_move_deg
+        direction = direction.POSITIVE if direction == direction.NEGATIVE else direction.NEGATIVE
+
     num_images = params.num_images
     shutter_time_s = params.shutter_opening_time_s
     image_width_deg = params.rotation_increment_deg
     exposure_time_s = params.exposure_time_s
     motor_time_to_speed_s *= ACCELERATION_MARGIN
-    start_scan_deg = params.omega_start_deg
 
     LOGGER.info("Calculating rotation scan motion profile:")
     LOGGER.info(
@@ -155,9 +166,9 @@ def calculate_motion_profile(
         f"{acceleration_offset_deg=} = {motor_time_to_speed_s=} * {speed_for_rotation_deg_s=}"
     )
 
-    start_motion_deg = start_scan_deg - (acceleration_offset_deg * direction)
+    start_motion_deg = start_scan_deg - (acceleration_offset_deg * direction.multiplier)
     LOGGER.info(
-        f"{start_motion_deg=} = {start_scan_deg=} - ({acceleration_offset_deg=} * {direction=})"
+        f"{start_motion_deg=} = {start_scan_deg=} - ({acceleration_offset_deg=} * {direction.multiplier=})"
     )
 
     shutter_opening_deg = speed_for_rotation_deg_s * shutter_time_s
@@ -175,7 +186,7 @@ def calculate_motion_profile(
 
     distance_to_move_deg = (
         scan_width_deg + shutter_opening_deg + acceleration_offset_deg * 2
-    ) * direction
+    ) * direction.multiplier
     LOGGER.info(
         f"{distance_to_move_deg=} = ({scan_width_deg=} + {shutter_opening_deg=} + {acceleration_offset_deg=} * 2) * {direction=})"
     )
@@ -185,7 +196,7 @@ def calculate_motion_profile(
         start_motion_deg=start_motion_deg,
         scan_width_deg=scan_width_deg,
         shutter_time_s=shutter_time_s,
-        direction=params.rotation_direction,
+        direction=direction,
         speed_for_rotation_deg_s=speed_for_rotation_deg_s,
         acceleration_offset_deg=acceleration_offset_deg,
         shutter_opening_deg=shutter_opening_deg,
@@ -346,6 +357,8 @@ def rotation_scan(
     parameters: RotationScan,
     oav_params: OAVParameters | None = None,
 ) -> MsgGenerator:
+    parameters.features.update_self_from_server()
+
     if not oav_params:
         oav_params = OAVParameters(context="xrayCentring")
 
@@ -396,6 +409,7 @@ def multi_rotation_scan(
     parameters: MultiRotationScan,
     oav_params: OAVParameters | None = None,
 ) -> MsgGenerator:
+    parameters.features.update_self_from_server()
     if not oav_params:
         oav_params = OAVParameters(context="xrayCentring")
     eiger: EigerDetector = composite.eiger

--- a/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
@@ -137,8 +137,6 @@ def calculate_motion_profile(
         # If omega_flip is True then the motor omega axis is inverted with respect to the
         # hyperion coordinate system.
         start_scan_deg = -start_scan_deg
-        # start_motion_deg = -start_motion_deg
-        # distance_to_move_deg = -distance_to_move_deg
         direction = (
             direction.POSITIVE
             if direction == direction.NEGATIVE

--- a/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
@@ -139,7 +139,11 @@ def calculate_motion_profile(
         start_scan_deg = -start_scan_deg
         # start_motion_deg = -start_motion_deg
         # distance_to_move_deg = -distance_to_move_deg
-        direction = direction.POSITIVE if direction == direction.NEGATIVE else direction.NEGATIVE
+        direction = (
+            direction.POSITIVE
+            if direction == direction.NEGATIVE
+            else direction.NEGATIVE
+        )
 
     num_images = params.num_images
     shutter_time_s = params.shutter_opening_time_s

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
@@ -9,8 +9,9 @@ from mx_bluesky.common.external_interaction.callbacks.common.plan_reactive_callb
     PlanReactiveCallback,
 )
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
+    AxisDirection,
     create_beam_and_attenuator_parameters,
-    vds_type_based_on_bit_depth, AxisDirection,
+    vds_type_based_on_bit_depth,
 )
 from mx_bluesky.common.external_interaction.nexus.write_nexus import NexusWriter
 from mx_bluesky.common.utils.log import NEXUS_LOGGER
@@ -101,5 +102,7 @@ class RotationNexusFileCallback(PlanReactiveCallback):
                 vds_start_index=parameters.nexus_vds_start_img,
                 full_num_of_images=self.full_num_of_images,
                 meta_data_run_number=self.meta_data_run_number,
-                axis_direction=AxisDirection.NEGATIVE if parameters.features.omega_flip else AxisDirection.POSITIVE,
+                axis_direction=AxisDirection.NEGATIVE
+                if parameters.features.omega_flip
+                else AxisDirection.POSITIVE,
             )

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
@@ -10,7 +10,7 @@ from mx_bluesky.common.external_interaction.callbacks.common.plan_reactive_callb
 )
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
     create_beam_and_attenuator_parameters,
-    vds_type_based_on_bit_depth,
+    vds_type_based_on_bit_depth, AxisDirection,
 )
 from mx_bluesky.common.external_interaction.nexus.write_nexus import NexusWriter
 from mx_bluesky.common.utils.log import NEXUS_LOGGER
@@ -101,5 +101,5 @@ class RotationNexusFileCallback(PlanReactiveCallback):
                 vds_start_index=parameters.nexus_vds_start_img,
                 full_num_of_images=self.full_num_of_images,
                 meta_data_run_number=self.meta_data_run_number,
-                rotation_direction=parameters.rotation_direction,
+                axis_direction=AxisDirection.NEGATIVE if parameters.features.omega_flip else AxisDirection.POSITIVE,
             )

--- a/src/mx_bluesky/hyperion/external_interaction/config_server.py
+++ b/src/mx_bluesky/hyperion/external_interaction/config_server.py
@@ -16,3 +16,4 @@ class HyperionFeatureFlags(FeatureFlags):
     use_panda_for_gridscan: bool = CONST.I03.USE_PANDA_FOR_GRIDSCAN
     compare_cpu_and_gpu_zocalo: bool = CONST.I03.COMPARE_CPU_AND_GPU_ZOCALO
     set_stub_offsets: bool = CONST.I03.SET_STUB_OFFSETS
+    omega_flip: bool = CONST.I03.OMEGA_FLIP

--- a/src/mx_bluesky/hyperion/external_interaction/config_server.py
+++ b/src/mx_bluesky/hyperion/external_interaction/config_server.py
@@ -8,6 +8,19 @@ from mx_bluesky.hyperion.parameters.constants import CONST
 
 
 class HyperionFeatureFlags(FeatureFlags):
+    """
+    Feature flags specific to Hyperion.
+
+    Attributes:
+        use_panda_for_gridscan:         If True then the PandA is used for gridscans, otherwise the zebra is used
+        compare_cpu_and_gpu_zocalo:     If True then GPU result processing is enabled alongside CPU, if False then
+            CPU only is used.
+        set_stub_offsets:               If True then set the stub offsets after moving to the crystal (ignored for
+            multi-centre)
+        omega_flip:                     If True then invert the smargon omega motor rotation commands with respect to
+         the hyperion request.
+    """
+
     @staticmethod
     @cache
     def get_config_server() -> ConfigServer:

--- a/src/mx_bluesky/hyperion/parameters/constants.py
+++ b/src/mx_bluesky/hyperion/parameters/constants.py
@@ -28,6 +28,7 @@ class I03Constants:
     SHUTTER_TIME_S = 0.06
     USE_PANDA_FOR_GRIDSCAN = False
     SET_STUB_OFFSETS = False
+    OMEGA_FLIP = True
 
     # Turns on GPU processing for zocalo and logs a comparison between GPU and CPU-
     # processed results. GPU results never used in analysis for now

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -26,6 +26,7 @@ from mx_bluesky.common.parameters.components import (
     SplitScan,
     WithScan,
 )
+from mx_bluesky.hyperion.parameters.components import WithHyperionFeatures
 from mx_bluesky.hyperion.parameters.constants import (
     CONST,
     I03Constants,
@@ -40,7 +41,7 @@ class RotationScanPerSweep(OptionalGonioAngleStarts, OptionalXyzStarts):
     nexus_vds_start_img: int = Field(default=0, ge=0)
 
 
-class RotationExperiment(DiffractionExperimentWithSample):
+class RotationExperiment(DiffractionExperimentWithSample, WithHyperionFeatures):
     shutter_opening_time_s: float = Field(default=CONST.I03.SHUTTER_TIME_S)
     rotation_increment_deg: float = Field(default=0.1, gt=0)
     ispyb_experiment_type: IspybExperimentType = Field(
@@ -91,13 +92,16 @@ class RotationExperiment(DiffractionExperimentWithSample):
             return aperture_position
 
 
-class RotationScan(WithScan, RotationScanPerSweep, RotationExperiment):
+class RotationScan(
+    WithScan, RotationScanPerSweep, RotationExperiment
+):
     @property
     def detector_params(self):
         return self._detector_params(self.omega_start_deg)
 
     @property
     def scan_points(self) -> AxesPoints:
+        """The scan points are defined in application space"""
         scan_spec = Line(
             axis="omega",
             start=self.omega_start_deg,

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -92,9 +92,7 @@ class RotationExperiment(DiffractionExperimentWithSample, WithHyperionFeatures):
             return aperture_position
 
 
-class RotationScan(
-    WithScan, RotationScanPerSweep, RotationExperiment
-):
+class RotationScan(WithScan, RotationScanPerSweep, RotationExperiment):
     @property
     def detector_params(self):
         return self._detector_params(self.omega_start_deg)

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -34,6 +34,18 @@ from mx_bluesky.hyperion.parameters.constants import (
 
 
 class RotationScanPerSweep(OptionalGonioAngleStarts, OptionalXyzStarts):
+    """
+    Describes a rotation scan about the specified axis.
+
+    Attributes:
+        rotation_axis: The rotation axis, by default this is the omega axis
+        omega_start_deg: The initial angle of the rotation in degrees (default 0)
+        scan_width_deg: The sweep of the rotation in degrees, this must be positive (default 360)
+        rotation_direction: Indicates the direction of rotation, if RotationDirection.POSITIVE
+            the final angle is obtained by adding scan_width_deg, otherwise by subtraction (default NEGATIVE)
+        nexus_vds_start_img: The frame number of the first frame captured during the rotation
+    """
+
     omega_start_deg: float = Field(default=0)  # type: ignore
     rotation_axis: RotationAxis = Field(default=RotationAxis.OMEGA)
     scan_width_deg: float = Field(default=360, gt=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,6 @@ from dodal.log import set_up_all_logging_handlers
 from event_model.documents import Event, EventDescriptor, RunStart, RunStop
 from ispyb.sp.mxacquisition import MXAcquisition
 from ophyd.sim import NullStatus
-
-from mx_bluesky.common.external_interaction.config_server import FeatureFlags
 from ophyd_async.core import (
     AsyncStatus,
     Device,
@@ -78,6 +76,7 @@ from scanspec.specs import Line
 from mx_bluesky.common.external_interaction.callbacks.common.logging_callback import (
     VerbosePlanExecutionLoggingCallback,
 )
+from mx_bluesky.common.external_interaction.config_server import FeatureFlags
 from mx_bluesky.common.parameters.constants import (
     DocDescriptorNames,
     EnvironmentConstants,
@@ -229,12 +228,12 @@ def patch_async_motor(
 
 
 @pytest.fixture(params=[False, True])
-def feature_flags_with_omega_flip(request):
+def feature_flags_update_with_omega_flip(request):
     def update_with_overrides(self):
         self.overriden_features["omega_flip"] = request.param
-        setattr(self, "omega_flip", request.param)
+        self.omega_flip = request.param
 
-    with (patch.object(FeatureFlags, "update_self_from_server", autospec=True) as update):
+    with patch.object(FeatureFlags, "update_self_from_server", autospec=True) as update:
         update.side_effect = update_with_overrides
         yield update
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -465,6 +465,7 @@ def test_ispyb_deposition_in_rotation_plan(
     fetch_comment: Callable[..., Any],
     fetch_datacollection_attribute: Callable[..., Any],
     fetch_datacollection_position_attribute: Callable[..., Any],
+    feature_flags_with_omega_flip,
 ):
     os.environ["ISPYB_CONFIG_PATH"] = CONST.SIM.DEV_ISPYB_DATABASE_CFG
     ispyb_cb = RotationISPyBCallback()

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -465,7 +465,7 @@ def test_ispyb_deposition_in_rotation_plan(
     fetch_comment: Callable[..., Any],
     fetch_datacollection_attribute: Callable[..., Any],
     fetch_datacollection_position_attribute: Callable[..., Any],
-    feature_flags_with_omega_flip,
+    feature_flags_update_with_omega_flip,
 ):
     os.environ["ISPYB_CONFIG_PATH"] = CONST.SIM.DEV_ISPYB_DATABASE_CFG
     ispyb_cb = RotationISPyBCallback()

--- a/tests/unit_tests/common/external_interaction/nexus/test_nexus_utils.py
+++ b/tests/unit_tests/common/external_interaction/nexus/test_nexus_utils.py
@@ -4,7 +4,9 @@ from numpy.typing import DTypeLike
 from scanspec.core import AxesPoints
 
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
-    vds_type_based_on_bit_depth, AxisDirection, create_goniometer_axes,
+    AxisDirection,
+    create_goniometer_axes,
+    vds_type_based_on_bit_depth,
 )
 
 
@@ -23,21 +25,21 @@ def scan_points(test_rotation_params) -> AxesPoints:
     return test_rotation_params.scan_points
 
 
-@pytest.mark.parametrize("omega_axis_direction, expected_axis_direction",
-                         [
-                             [AxisDirection.NEGATIVE, -1],
-                             [AxisDirection.POSITIVE, 1]
-                         ])
-def test_omega_axis_direction_determined_from_features(omega_axis_direction: AxisDirection,
-                                                       expected_axis_direction: float,
-                                                       scan_points: AxesPoints):
+@pytest.mark.parametrize(
+    "omega_axis_direction, expected_axis_direction",
+    [[AxisDirection.NEGATIVE, -1], [AxisDirection.POSITIVE, 1]],
+)
+def test_omega_axis_direction_determined_from_features(
+    omega_axis_direction: AxisDirection,
+    expected_axis_direction: float,
+    scan_points: AxesPoints,
+):
     omega_start = 0
     gonio = create_goniometer_axes(
-        omega_start,
-        scan_points,
-        (0, 0, 0),
-        0,
-        0,
-        omega_axis_direction
+        omega_start, scan_points, (0, 0, 0), 0, 0, omega_axis_direction
     )
-    assert gonio.axes_list[0].name == "omega" and gonio.axes_list[0].vector == (expected_axis_direction, 0, 0)
+    assert gonio.axes_list[0].name == "omega" and gonio.axes_list[0].vector == (
+        expected_axis_direction,
+        0,
+        0,
+    )

--- a/tests/unit_tests/common/external_interaction/nexus/test_nexus_utils.py
+++ b/tests/unit_tests/common/external_interaction/nexus/test_nexus_utils.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
 from numpy.typing import DTypeLike
+from scanspec.core import AxesPoints
 
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
-    vds_type_based_on_bit_depth,
+    vds_type_based_on_bit_depth, AxisDirection, create_goniometer_axes,
 )
 
 
@@ -15,3 +16,28 @@ def test_vds_type_is_expected_based_on_bit_depth(
     bit_depth: int, expected_type: DTypeLike
 ):
     assert vds_type_based_on_bit_depth(bit_depth) == expected_type
+
+
+@pytest.fixture
+def scan_points(test_rotation_params) -> AxesPoints:
+    return test_rotation_params.scan_points
+
+
+@pytest.mark.parametrize("omega_axis_direction, expected_axis_direction",
+                         [
+                             [AxisDirection.NEGATIVE, -1],
+                             [AxisDirection.POSITIVE, 1]
+                         ])
+def test_omega_axis_direction_determined_from_features(omega_axis_direction: AxisDirection,
+                                                       expected_axis_direction: float,
+                                                       scan_points: AxesPoints):
+    omega_start = 0
+    gonio = create_goniometer_axes(
+        omega_start,
+        scan_points,
+        (0, 0, 0),
+        0,
+        0,
+        omega_axis_direction
+    )
+    assert gonio.axes_list[0].name == "omega" and gonio.axes_list[0].vector == (expected_axis_direction, 0, 0)

--- a/tests/unit_tests/hyperion/experiment_plans/test_multi_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_multi_rotation_scan_plan.py
@@ -18,6 +18,7 @@ from dodal.devices.synchrotron import SynchrotronMode
 from ophyd_async.testing import set_mock_value
 
 from mx_bluesky.common.external_interaction.ispyb.ispyb_store import StoreInIspyb
+from mx_bluesky.common.external_interaction.nexus.nexus_utils import AxisDirection
 from mx_bluesky.hyperion.experiment_plans.rotation_scan_plan import (
     RotationScanComposite,
     calculate_motion_profile,
@@ -29,7 +30,6 @@ from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback 
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
 )
-from mx_bluesky.hyperion.external_interaction.nexus.nexus_utils import AxisDirection
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.rotation import MultiRotationScan, RotationScan
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_multi_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_multi_rotation_scan_plan.py
@@ -15,6 +15,9 @@ from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.synchrotron import SynchrotronMode
+from mx_bluesky.common.external_interaction.config_server import FeatureFlags
+from mx_bluesky.hyperion.external_interaction.config_server import HyperionFeatureFlags
+from mx_bluesky.hyperion.external_interaction.nexus.nexus_utils import AxisDirection
 from ophyd_async.testing import set_mock_value
 
 from mx_bluesky.common.external_interaction.ispyb.ispyb_store import StoreInIspyb
@@ -205,6 +208,7 @@ def test_full_multi_rotation_plan_docs_emitted(
             has_fields=["trigger_zocalo_on", "mx_bluesky_parameters"],
         )
         params = RotationScan(**json.loads(scan_docs[0][1]["mx_bluesky_parameters"]))
+        params.features.overriden_features = {}
         assert params == scan
         assert len(events := DocumentCapturer.get_matches(scan_docs, "event")) == 3
         DocumentCapturer.assert_events_and_data_in_order(
@@ -257,7 +261,9 @@ def test_full_multi_rotation_plan_nexus_writer_called_correctly(
         test_multi_rotation_params.single_rotation_scans,
         strict=False,
     ):
-        assert call.args[0] == rotation_params
+        callback_params = call.args[0]
+        callback_params.features.overriden_features = {}
+        assert callback_params == rotation_params
         assert call.kwargs == {
             "omega_start_deg": rotation_params.omega_start_deg,
             "chi_start_deg": rotation_params.chi_start_deg,
@@ -265,7 +271,7 @@ def test_full_multi_rotation_plan_nexus_writer_called_correctly(
             "vds_start_index": rotation_params.nexus_vds_start_img,
             "full_num_of_images": test_multi_rotation_params.num_images,
             "meta_data_run_number": first_run_number,
-            "rotation_direction": rotation_params.rotation_direction,
+            "axis_direction": AxisDirection.NEGATIVE if rotation_params.features.omega_flip else AxisDirection.POSITIVE,
         }
 
 
@@ -276,6 +282,7 @@ def test_full_multi_rotation_plan_nexus_writer_called_correctly(
 def test_full_multi_rotation_plan_nexus_files_written_correctly(
     _,
     RE: RunEngine,
+    feature_flags_with_omega_flip: HyperionFeatureFlags,
     test_multi_rotation_params: MultiRotationScan,
     fake_create_rotation_devices: RotationScanComposite,
     oav_parameters_for_rotation: OAVParameters,
@@ -385,7 +392,8 @@ def test_full_multi_rotation_plan_nexus_files_written_correctly(
                 h5py.Dataset,
             )
             assert isinstance(omega_vec := omega_transform.attrs["vector"], np.ndarray)
-            assert tuple(omega_vec) == (1.0 * scan.rotation_direction.multiplier, 0, 0)
+            omega_flip = feature_flags_with_omega_flip.mock_calls[0].args[0].omega_flip
+            assert tuple(omega_vec) == (-1.0 if omega_flip else 1.0, 0, 0)
 
 
 @patch(

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -743,7 +743,7 @@ def test_rotation_scan_fails_with_exception_when_no_beamstop(
     ],
 )
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.zocalo_callback.ZocaloTrigger",
+    "mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback.ZocaloTrigger",
     MagicMock(),
 )
 @patch(
@@ -808,7 +808,7 @@ def test_rotation_scan_plan_with_omega_flip_inverts_motor_movements_but_not_even
         )
     )
     event_params = RotationScan.model_validate_json(
-        rotation_outer_start_event.args[1]["hyperion_parameters"]
+        rotation_outer_start_event.args[1]["mx_bluesky_parameters"]
     )
     # event params are not transformed
     assert event_params.omega_start_deg == 30

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from itertools import takewhile
+from itertools import takewhile, dropwhile
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch, ANY, Mock
 
 import pytest
 from bluesky.run_engine import RunEngine
@@ -15,9 +15,9 @@ from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.xbpm_feedback import Pause
-from dodal.devices.zebra import PC_GATE, SOFT_IN1, Zebra
+from dodal.devices.zebra import PC_GATE, SOFT_IN1, Zebra, RotationDirection
 from dodal.devices.zebra_controlled_shutter import ZebraShutterControl
-from ophyd_async.testing import get_mock_put
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback import (
     ZocaloCallback,
@@ -723,3 +723,84 @@ def test_rotation_scan_fails_with_exception_when_no_beamstop(
                 oav_parameters_for_rotation,
             )
         )
+
+
+@pytest.mark.parametrize("omega_flip, rotation_direction, expected_start_angle, "
+                         "expected_start_angle_with_runup, expected_zebra_direction", [
+    # see https://github.com/DiamondLightSource/mx-bluesky/issues/247
+    # GDA behaviour is such that positive angles in the request result in 
+    # negative motor angles, but positive angles in the resulting nexus file
+    # Should replicate GDA Output exactly
+    [True, RotationDirection.POSITIVE, -30, -29.85, RotationDirection.NEGATIVE],
+    # Should replicate GDA Output, except with /entry/data/transformation/omega 
+    # +1, 0, 0 instead of -1, 0, 0
+    [False, RotationDirection.NEGATIVE, 30, 30.15, RotationDirection.NEGATIVE],
+    [True, RotationDirection.NEGATIVE, -30, -30.15, RotationDirection.POSITIVE],
+    [False, RotationDirection.POSITIVE, 30, 29.85, RotationDirection.POSITIVE],
+    
+])
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.zocalo_callback.ZocaloTrigger", MagicMock()
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan.setup_zebra_for_rotation"
+)
+def test_rotation_scan_plan_with_omega_flip_inverts_motor_movements_but_not_event_params(mock_setup_zebra_for_rotation: 
+            MagicMock,
+            omega_flip: bool,
+            rotation_direction: RotationDirection,
+            expected_start_angle: float,
+            expected_start_angle_with_runup: float,
+            expected_zebra_direction: RotationDirection,
+            test_rotation_params: RotationScan,
+            fake_create_rotation_devices:
+            RotationScanComposite,
+            oav_parameters_for_rotation:
+            OAVParameters, RE: RunEngine):
+    test_rotation_params.features.omega_flip = omega_flip
+    test_rotation_params.rotation_direction = rotation_direction
+    test_rotation_params.omega_start_deg = 30
+    mock_callback = Mock(spec=RotationISPyBCallback)
+    RE.subscribe(mock_callback)
+    omega_put = get_mock_put(fake_create_rotation_devices.smargon.omega.user_setpoint)
+    set_mock_value(fake_create_rotation_devices.smargon.omega.acceleration_time, 0.1)
+    with (
+        patch("bluesky.plan_stubs.wait", autospec=True),
+        patch(
+            "bluesky.preprocessors.__read_and_stash_a_motor",
+            fake_read,
+        ),
+    ):
+        RE(
+            rotation_scan(
+                fake_create_rotation_devices,
+                test_rotation_params,
+                oav_parameters_for_rotation,
+            ),
+        )
+
+    assert omega_put.mock_calls[0:5] == [
+            call(0, wait=True),
+            call(90, wait=True),
+            call(180, wait=True),
+            call(270, wait=True),
+            call(expected_start_angle_with_runup, wait=True)]
+    mock_setup_zebra_for_rotation.assert_called_once_with(
+        fake_create_rotation_devices.zebra,
+        fake_create_rotation_devices.sample_shutter,
+        start_angle=expected_start_angle,
+        scan_width=180,
+        direction=expected_zebra_direction,
+        shutter_opening_deg=ANY,
+        shutter_opening_s=ANY,
+        group="setup_zebra"
+    )
+    rotation_outer_start_event = next(dropwhile(lambda _: _.args[0] != "start" or _.args[1].get("subplan_name") != CONST.PLAN.ROTATION_OUTER, 
+                                 mock_callback.mock_calls))
+    event_params = RotationScan.model_validate_json(rotation_outer_start_event.args[1]["hyperion_parameters"])
+    # event params are not transformed
+    assert event_params.omega_start_deg == 30
+    assert event_params.rotation_direction == rotation_direction
+    assert event_params.rotation_increment_deg == 0.1
+    assert event_params.scan_width_deg == 180
+    assert event_params.features.omega_flip == omega_flip

--- a/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
 
@@ -16,7 +17,7 @@ from dodal.devices.fast_grid_scan import (
 )
 
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
-    create_beam_and_attenuator_parameters,
+    create_beam_and_attenuator_parameters, AxisDirection,
 )
 from mx_bluesky.common.external_interaction.nexus.write_nexus import NexusWriter
 from mx_bluesky.hyperion.parameters.gridscan import HyperionThreeDGridScan
@@ -239,6 +240,42 @@ def test_given_dummy_data_then_datafile_written_correctly(
             )
 
     assert_data_edge_at(nexus_writer_2.nexus_file, 419)
+
+
+@pytest.mark.parametrize("axis_direction, expected_vector",
+                         [
+                             [AxisDirection.NEGATIVE, [-1, 0, 0]],
+                             [AxisDirection.POSITIVE, [1, 0, 0]]
+                         ])
+def test_nexus_file_entry_data_omega_written_correctly_independent_of_omega_direction(
+        test_rotation_params,
+        axis_direction: AxisDirection,
+        expected_vector: list[float],
+        tmp_path: Path,
+):
+    test_rotation_params.storage_directory = str(tmp_path)
+    det_size = test_rotation_params.detector_params.detector_size_constants.det_size_pixels
+    shape = (test_rotation_params.num_images, det_size.width, det_size.height)
+    nexus_writer = NexusWriter(
+        test_rotation_params,
+        shape,
+        test_rotation_params.scan_points,
+        omega_start_deg=test_rotation_params.omega_start_deg,
+        chi_start_deg=test_rotation_params.chi_start_deg or 0,
+        phi_start_deg=test_rotation_params.phi_start_deg or 0,
+        vds_start_index=0,
+        meta_data_run_number=1,
+        axis_direction=axis_direction
+    )
+    nexus_writer.beam, nexus_writer.attenuator = create_beam_and_attenuator_parameters(
+        20, TEST_FLUX, 0.5
+    )
+
+    nexus_writer.create_nexus_file(np.uint16)
+    with h5py.File(nexus_writer.nexus_file, "r") as nexus_file:
+        assert all(nexus_file["/entry/data/omega"].attrs.get("vector") == expected_vector)
+        data = nexus_file["/entry/data/omega"][:]
+        assert all(data == test_rotation_params.scan_points["omega"])
 
 
 def assert_x_data_stride_correct(

--- a/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
@@ -17,7 +17,8 @@ from dodal.devices.fast_grid_scan import (
 )
 
 from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
-    create_beam_and_attenuator_parameters, AxisDirection,
+    AxisDirection,
+    create_beam_and_attenuator_parameters,
 )
 from mx_bluesky.common.external_interaction.nexus.write_nexus import NexusWriter
 from mx_bluesky.hyperion.parameters.gridscan import HyperionThreeDGridScan
@@ -242,19 +243,20 @@ def test_given_dummy_data_then_datafile_written_correctly(
     assert_data_edge_at(nexus_writer_2.nexus_file, 419)
 
 
-@pytest.mark.parametrize("axis_direction, expected_vector",
-                         [
-                             [AxisDirection.NEGATIVE, [-1, 0, 0]],
-                             [AxisDirection.POSITIVE, [1, 0, 0]]
-                         ])
+@pytest.mark.parametrize(
+    "axis_direction, expected_vector",
+    [[AxisDirection.NEGATIVE, [-1, 0, 0]], [AxisDirection.POSITIVE, [1, 0, 0]]],
+)
 def test_nexus_file_entry_data_omega_written_correctly_independent_of_omega_direction(
-        test_rotation_params,
-        axis_direction: AxisDirection,
-        expected_vector: list[float],
-        tmp_path: Path,
+    test_rotation_params,
+    axis_direction: AxisDirection,
+    expected_vector: list[float],
+    tmp_path: Path,
 ):
     test_rotation_params.storage_directory = str(tmp_path)
-    det_size = test_rotation_params.detector_params.detector_size_constants.det_size_pixels
+    det_size = (
+        test_rotation_params.detector_params.detector_size_constants.det_size_pixels
+    )
     shape = (test_rotation_params.num_images, det_size.width, det_size.height)
     nexus_writer = NexusWriter(
         test_rotation_params,
@@ -265,7 +267,7 @@ def test_nexus_file_entry_data_omega_written_correctly_independent_of_omega_dire
         phi_start_deg=test_rotation_params.phi_start_deg or 0,
         vds_start_index=0,
         meta_data_run_number=1,
-        axis_direction=axis_direction
+        axis_direction=axis_direction,
     )
     nexus_writer.beam, nexus_writer.attenuator = create_beam_and_attenuator_parameters(
         20, TEST_FLUX, 0.5
@@ -273,8 +275,10 @@ def test_nexus_file_entry_data_omega_written_correctly_independent_of_omega_dire
 
     nexus_writer.create_nexus_file(np.uint16)
     with h5py.File(nexus_writer.nexus_file, "r") as nexus_file:
-        assert all(nexus_file["/entry/data/omega"].attrs.get("vector") == expected_vector)
-        data = nexus_file["/entry/data/omega"][:]
+        assert all(
+            nexus_file["/entry/data/omega"].attrs.get("vector") == expected_vector
+        )
+        data = nexus_file["/entry/data/omega"][:]  # type: ignore
         assert all(data == test_rotation_params.scan_points["omega"])
 
 


### PR DESCRIPTION
These changes address #247 

* This introduces a new `omega_flip` feature flag that can be set. The default is True. `omega_flip` should be specified according to whether the goniometer omega rotation axis is consistent with the nexus file specification or not https://journals.iucr.org/m/issues/2020/05/00/ti5018/ti5018.pdf

* The `omega_flip` determines the `/entry/sample/transformations/omega` vector in the nexus file and sets it to (-1, 0, 0) if True (in line with GDA) or (+1, 0, 0) if False. It also inverts the motor motions for rotation scans. When `omega_flip` is False, the smargon omega and the omega values in the request have the same sign.
* The `rotation_direction` request parameter now indicates the direction of rotation with respect to the omega sweep specified in the Hyperion request (whereas before, `rotation_direction` was always set to `Negative` by GDA, and this changed the physical motor direction but not the start of the rotation. Everything else was reported as positive in the nexus files and ispyb.
* The intention of these changes is that this makes Hyperion behave identically with GDA, under the following conditions:
   * `omega_flip` is True
   * `rotation_direction` is Positive
* As currently, `rotation_direction` is hard-coded in GDA, an alternative setting that would arguably produce "nicer" output in nexus files would be `omega_flip` = False, `rotation_direction` = Positive, however the motion would be in the opposite sense and nexus output would have have different (positive) transformation omega vector, so this would need to be tested to make sure downstream analysis tools are happy with the output.
* This change doesn't affect gridscans or rotation snapshots - we may want to also make changes for rotation snapshots if we want the reported snapshot angles to be congruent with the rotation sweep.
* I'm not sure whether a `FeatureFlag` is the best way of presenting this setting, perhaps it may be better as a soft (or maybe even hard) signal that's exposed by the `smargon`. I am open to discussion on this.