### PR TITLE
Set undulator gap after XBPM is stable

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/rotation_scan_plan.py
@@ -305,6 +305,10 @@ def _move_and_rotation(
     params: RotationScan,
     oav_params: OAVParameters,
 ):
+    if params.demand_energy_ev:
+        yield from bps.abs_set(
+            composite.undulator, params.demand_energy_ev / 1000, wait=True
+        )
     motor_time_to_speed = yield from bps.rd(composite.smargon.omega.acceleration_time)
     max_vel = yield from bps.rd(composite.smargon.omega.max_velocity)
     motion_values = calculate_motion_profile(params, motor_time_to_speed, max_vel)

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -702,3 +702,17 @@ def test_rotation_scan_correctly_triggers_zocalo_callback(
             ),
         )
     mock_zocalo_interactor.return_value.run_start.assert_called_once()
+
+
+def test_rotation_scan_set_undulator_gap_after_xbpm_stable(
+    rotation_scan_simulated_messages,
+    test_rotation_params: RotationScan,
+):
+    msgs = assert_message_and_return_remaining(
+        rotation_scan_simulated_messages,
+        lambda msg: msg.command == "trigger" and msg.obj.name == "xbpm_feedback",
+    )
+
+    msgs = assert_message_and_return_remaining(
+        msgs, lambda msg: msg.command == "set" and msg.obj.name == "undulator"
+    )


### PR DESCRIPTION
Should address #518, where Undulator gap is incorrect following beam dump.

the Undulator device checks if we are already at the correct gap when set; therefore, this PR sets the gap after XBPM is stable (in transmission_and_xbpm_feedback_for_collection_decorator), and before collection, without checking first.