### PR TITLE
Update MX beamlines to use new device factory - Part 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.8a5",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@28c4513dd21e53f9c39dabf954eb99c0ba79d8be",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@44f5ee68f902118efa0d2efcef39b490b87fe0a1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ markers = [
     "skip_in_pycharm: marks test as not working in pycharm testrunner",
 ]
 addopts = """
-    --tb=native -vv --doctest-modules --doctest-glob="*.rst"
+    --tb=native -vv --doctest-modules --doctest-glob="*.rst" --durations=10
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = [

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -4,6 +4,7 @@ import threading
 from collections.abc import Callable
 from dataclasses import asdict
 from queue import Queue
+from sys import argv
 from traceback import format_exception
 from typing import Any
 
@@ -352,6 +353,7 @@ def create_targets():
     )
     if not args.use_external_callbacks:
         setup_callback_logging(args.dev_mode)
+    LOGGER.info(f"Hyperion launched with args:{argv}")
     app, runner = create_app(
         skip_startup_connection=args.skip_startup_connection,
         use_external_callbacks=args.use_external_callbacks,

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -123,7 +123,7 @@ def fake_create_rotation_devices():
         zebra=zebra,
         robot=robot,
         oav=oav,
-        sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
+        sample_shutter=i03.sample_shutter(connect_immediately=True, mock=True),
         xbpm_feedback=xbpm_feedback,
     )
 

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -1,4 +1,3 @@
-import asyncio
 import gzip
 import json
 import os
@@ -86,13 +85,15 @@ def fake_create_rotation_devices():
     zebra = i03.zebra(fake_with_ophyd_sim=True)
     detector_motion = i03.detector_motion(fake_with_ophyd_sim=True)
     backlight = i03.backlight(fake_with_ophyd_sim=True)
-    attenuator = i03.attenuator()
+    attenuator = i03.attenuator(connect_immediately=True, mock=True)
     flux = i03.flux(fake_with_ophyd_sim=True)
     undulator = i03.undulator(fake_with_ophyd_sim=True)
-    aperture_scatterguard = i03.aperture_scatterguard()
+    aperture_scatterguard = i03.aperture_scatterguard(
+        connect_immediately=True, mock=True
+    )
     synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
     s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
-    dcm = i03.dcm(fake_with_ophyd_sim=True)
+    dcm = i03.dcm(connect_immediately=True, mock=True)
     robot = i03.robot(fake_with_ophyd_sim=True)
     oav = i03.oav(
         fake_with_ophyd_sim=True,
@@ -105,13 +106,6 @@ def fake_create_rotation_devices():
     set_mock_value(smargon.omega.max_velocity, 131)
     set_mock_value(dcm.energy_in_kev.user_readback, 12700)
 
-    async def connect_all():
-        await asyncio.gather(
-            aperture_scatterguard.connect(mock=True),
-            attenuator.connect(mock=True),
-        )
-
-    asyncio.run(connect_all())
     return RotationScanComposite(
         attenuator=attenuator,
         backlight=backlight,

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -86,13 +86,13 @@ def fake_create_rotation_devices():
     detector_motion = i03.detector_motion(connect_immediately=True, mock=True)
     backlight = i03.backlight(mock=True)
     attenuator = i03.attenuator(connect_immediately=True, mock=True)
-    flux = i03.flux(fake_with_ophyd_sim=True)
+    flux = i03.flux(connect_immediately=True, mock=True)
     undulator = i03.undulator(connect_immediately=True, mock=True)
     aperture_scatterguard = i03.aperture_scatterguard(
         connect_immediately=True, mock=True
     )
     synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
-    s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
+    s4_slit_gaps = i03.s4_slit_gaps(connect_immediately=True, mock=True)
     dcm = i03.dcm(connect_immediately=True, mock=True)
     robot = i03.robot(connect_immediately=True, mock=True)
     oav = i03.oav(

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -94,7 +94,7 @@ def fake_create_rotation_devices():
     synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
     s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
     dcm = i03.dcm(connect_immediately=True, mock=True)
-    robot = i03.robot(fake_with_ophyd_sim=True)
+    robot = i03.robot(connect_immediately=True, mock=True)
     oav = i03.oav(
         connect_immediately=True,
         mock=True,
@@ -102,7 +102,7 @@ def fake_create_rotation_devices():
             zoom_params_file=ZOOM_LEVELS_XML, display_config_file=DISPLAY_CONFIGURATION
         ),
     )
-    xbpm_feedback = i03.xbpm_feedback(fake_with_ophyd_sim=True)
+    xbpm_feedback = i03.xbpm_feedback(connect_immediately=True, mock=True)
 
     set_mock_value(smargon.omega.max_velocity, 131)
     set_mock_value(dcm.energy_in_kev.user_readback, 12700)

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -1,3 +1,4 @@
+import asyncio
 import gzip
 import json
 import os
@@ -85,10 +86,10 @@ def fake_create_rotation_devices():
     zebra = i03.zebra(fake_with_ophyd_sim=True)
     detector_motion = i03.detector_motion(fake_with_ophyd_sim=True)
     backlight = i03.backlight(fake_with_ophyd_sim=True)
-    attenuator = i03.attenuator(fake_with_ophyd_sim=True)
+    attenuator = i03.attenuator()
     flux = i03.flux(fake_with_ophyd_sim=True)
     undulator = i03.undulator(fake_with_ophyd_sim=True)
-    aperture_scatterguard = i03.aperture_scatterguard(fake_with_ophyd_sim=True)
+    aperture_scatterguard = i03.aperture_scatterguard()
     synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
     s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
     dcm = i03.dcm(fake_with_ophyd_sim=True)
@@ -104,6 +105,13 @@ def fake_create_rotation_devices():
     set_mock_value(smargon.omega.max_velocity, 131)
     set_mock_value(dcm.energy_in_kev.user_readback, 12700)
 
+    async def connect_all():
+        await asyncio.gather(
+            aperture_scatterguard.connect(mock=True),
+            attenuator.connect(mock=True),
+        )
+
+    asyncio.run(connect_all())
     return RotationScanComposite(
         attenuator=attenuator,
         backlight=backlight,

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -79,24 +79,25 @@ def fake_rotation_scan(
 
 
 def fake_create_rotation_devices():
-    beamstop = i03.beamstop(fake_with_ophyd_sim=True)
+    beamstop = i03.beamstop(connect_immediately=True, mock=True)
     eiger = i03.eiger(fake_with_ophyd_sim=True)
-    smargon = i03.smargon(fake_with_ophyd_sim=True)
-    zebra = i03.zebra(fake_with_ophyd_sim=True)
-    detector_motion = i03.detector_motion(fake_with_ophyd_sim=True)
-    backlight = i03.backlight(fake_with_ophyd_sim=True)
+    smargon = i03.smargon(connect_immediately=True, mock=True)
+    zebra = i03.zebra(connect_immediately=True, mock=True)
+    detector_motion = i03.detector_motion(connect_immediately=True, mock=True)
+    backlight = i03.backlight(mock=True)
     attenuator = i03.attenuator(connect_immediately=True, mock=True)
     flux = i03.flux(fake_with_ophyd_sim=True)
-    undulator = i03.undulator(fake_with_ophyd_sim=True)
+    undulator = i03.undulator(connect_immediately=True, mock=True)
     aperture_scatterguard = i03.aperture_scatterguard(
         connect_immediately=True, mock=True
     )
-    synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
+    synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
     s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
     dcm = i03.dcm(connect_immediately=True, mock=True)
     robot = i03.robot(fake_with_ophyd_sim=True)
     oav = i03.oav(
-        fake_with_ophyd_sim=True,
+        connect_immediately=True,
+        mock=True,
         params=OAVConfig(
             zoom_params_file=ZOOM_LEVELS_XML, display_config_file=DISPLAY_CONFIGURATION
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -503,7 +503,7 @@ def vfm(RE):
 
 @pytest.fixture
 def lower_gonio(RE):
-    lower_gonio = i03.lower_gonio(fake_with_ophyd_sim=True)
+    lower_gonio = i03.lower_gonio(connect_immediately=True, mock=True)
     with (
         patch_motor(lower_gonio.x),
         patch_motor(lower_gonio.y),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,7 +450,7 @@ def beamstop_i03(
     with patch(
         "dodal.beamlines.i03.get_beamline_parameters", return_value=beamline_parameters
     ):
-        beamstop = i03.beamstop(fake_with_ophyd_sim=True)
+        beamstop = i03.beamstop(connect_immediately=True, mock=True)
         patch_motor(beamstop.x_mm)
         patch_motor(beamstop.y_mm)
         patch_motor(beamstop.z_mm)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,8 +431,9 @@ def robot(done_status):
 
 
 @pytest.fixture
-def attenuator(RE):
-    attenuator = i03.attenuator(fake_with_ophyd_sim=True)
+async def attenuator(RE):
+    attenuator = i03.attenuator()
+    await attenuator.connect(mock=True)
     set_mock_value(attenuator.actual_transmission, 0.49118047952)
 
     @AsyncStatus.wrap
@@ -554,7 +555,7 @@ def sample_shutter(RE) -> Generator[ZebraShutter, Any, Any]:
 
 
 @pytest.fixture
-def aperture_scatterguard(RE):
+async def aperture_scatterguard(RE):
     positions = {
         ApertureValue.LARGE: AperturePosition(
             aperture_x=0,
@@ -605,7 +606,8 @@ def aperture_scatterguard(RE):
             ),
         ),
     ):
-        ap_sg = i03.aperture_scatterguard(fake_with_ophyd_sim=True)
+        ap_sg = i03.aperture_scatterguard()
+        await ap_sg.connect(mock=True)
     with (
         patch_async_motor(ap_sg.aperture.x),
         patch_async_motor(ap_sg.aperture.y),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,7 +342,7 @@ def zebra(RE):
 
 @pytest.fixture
 def zebra_shutter(RE):
-    return i03.sample_shutter(fake_with_ophyd_sim=True)
+    return i03.sample_shutter(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -550,7 +550,7 @@ def thawer(RE) -> Generator[Thawer, Any, Any]:
 
 @pytest.fixture
 def sample_shutter(RE) -> Generator[ZebraShutter, Any, Any]:
-    yield i03.sample_shutter(fake_with_ophyd_sim=True)
+    yield i03.sample_shutter(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -748,7 +748,7 @@ async def panda(RE: RunEngine):
                 await sig.connect(mock=True)
                 setattr(device, name, sig)
 
-    panda = i03.panda(fake_with_ophyd_sim=True)
+    panda = i03.panda(connect_immediately=True, mock=True)
     await set_mock_blocks(
         panda,
         {
@@ -829,7 +829,7 @@ async def fake_fgs_composite(
             connect_immediately=True, mock=True
         ),
         robot=i03.robot(fake_with_ophyd_sim=True),
-        sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
+        sample_shutter=i03.sample_shutter(connect_immediately=True, mock=True),
     )
 
     fake_composite.eiger.stage = MagicMock(return_value=done_status)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,7 +423,7 @@ def ophyd_pin_tip_detection():
 @pytest.fixture
 def robot(done_status):
     RunEngine()  # A RE is needed to start the bluesky loop
-    robot = i03.robot(fake_with_ophyd_sim=True)
+    robot = i03.robot(connect_immediately=True, mock=True)
     set_mock_value(robot.barcode, "BARCODE")
     robot.set = MagicMock(return_value=done_status)
     return robot
@@ -466,7 +466,7 @@ def beamstop_i03(
 
 @pytest.fixture
 def xbpm_feedback(done_status):
-    xbpm = i03.xbpm_feedback(fake_with_ophyd_sim=True)
+    xbpm = i03.xbpm_feedback(connect_immediately=True, mock=True)
     xbpm.trigger = MagicMock(return_value=done_status)  # type: ignore
     yield xbpm
     beamline_utils.clear_devices()
@@ -538,14 +538,14 @@ def undulator_dcm(RE, sim_run_engine, dcm):
 
 @pytest.fixture
 def webcam(RE) -> Generator[Webcam, Any, Any]:
-    webcam = i03.webcam(fake_with_ophyd_sim=True)
+    webcam = i03.webcam(connect_immediately=True, mock=True)
     with patch.object(webcam, "_get_and_write_image"):
         yield webcam
 
 
 @pytest.fixture
 def thawer(RE) -> Generator[Thawer, Any, Any]:
-    yield i03.thawer(fake_with_ophyd_sim=True)
+    yield i03.thawer(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -708,7 +708,7 @@ def fake_create_rotation_devices(
 
 @pytest.fixture
 def zocalo(done_status):
-    zoc = i03.zocalo(fake_with_ophyd_sim=True)
+    zoc = i03.zocalo(connect_immediately=True, mock=True)
     zoc.stage = MagicMock(return_value=done_status)
     zoc.unstage = MagicMock(return_value=done_status)
     return zoc
@@ -828,7 +828,7 @@ async def fake_fgs_composite(
         panda_fast_grid_scan=i03.panda_fast_grid_scan(
             connect_immediately=True, mock=True
         ),
-        robot=i03.robot(fake_with_ophyd_sim=True),
+        robot=i03.robot(connect_immediately=True, mock=True),
         sample_shutter=i03.sample_shutter(connect_immediately=True, mock=True),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,7 @@ def eiger(done_status):
 
 @pytest.fixture
 def smargon(RE: RunEngine) -> Generator[Smargon, None, None]:
-    smargon = i03.smargon(fake_with_ophyd_sim=True)
+    smargon = i03.smargon(connect_immediately=True, mock=True)
     # Initial positions, needed for stub_offsets
     set_mock_value(smargon.stub_offsets.center_at_current_position.disp, 0)
     set_mock_value(smargon.x.user_readback, 0.0)
@@ -330,7 +330,7 @@ def smargon(RE: RunEngine) -> Generator[Smargon, None, None]:
 
 @pytest.fixture
 def zebra(RE):
-    zebra = i03.zebra(fake_with_ophyd_sim=True)
+    zebra = i03.zebra(connect_immediately=True, mock=True)
 
     def mock_side(demand: ArmDemand):
         set_mock_value(zebra.pc.arm.armed, demand.value)
@@ -347,26 +347,26 @@ def zebra_shutter(RE):
 
 @pytest.fixture
 def backlight():
-    backlight = i03.backlight(fake_with_ophyd_sim=True)
+    backlight = i03.backlight(connect_immediately=True, mock=True)
     backlight.TIME_TO_MOVE_S = 0.001
     return backlight
 
 
 @pytest.fixture
 def fast_grid_scan():
-    return i03.zebra_fast_grid_scan(fake_with_ophyd_sim=True)
+    return i03.zebra_fast_grid_scan(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
 def detector_motion(RE):
-    det = i03.detector_motion(fake_with_ophyd_sim=True)
+    det = i03.detector_motion(connect_immediately=True, mock=True)
     with patch_async_motor(det.z):
         yield det
 
 
 @pytest.fixture
 def undulator():
-    return i03.undulator(fake_with_ophyd_sim=True)
+    return i03.undulator(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -376,7 +376,7 @@ def s4_slit_gaps():
 
 @pytest.fixture
 def synchrotron(RE):
-    synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
+    synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
     set_mock_value(synchrotron.synchrotron_mode, SynchrotronMode.USER)
     set_mock_value(synchrotron.top_up_start_countdown, 10)
     return synchrotron
@@ -387,7 +387,7 @@ def oav(test_config_files, RE):
     parameters = OAVConfig(
         test_config_files["zoom_params_file"], test_config_files["display_config"]
     )
-    oav = i03.oav(fake_with_ophyd_sim=True, params=parameters)
+    oav = i03.oav(connect_immediately=True, mock=True, params=parameters)
 
     zoom_levels_list = ["1.0x", "3.0x", "5.0x", "7.5x", "10.0x", "15.0x"]
     oav.zoom_controller._get_allowed_zoom_levels = AsyncMock(
@@ -411,14 +411,13 @@ def flux():
 
 @pytest.fixture
 def pin_tip():
-    return i03.pin_tip_detection(fake_with_ophyd_sim=True)
+    return i03.pin_tip_detection(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
 def ophyd_pin_tip_detection():
     RunEngine()  # A RE is needed to start the bluesky loop
-    pin_tip_detection = i03.pin_tip_detection(fake_with_ophyd_sim=True)
-    return pin_tip_detection
+    return i03.pin_tip_detection(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -493,7 +492,7 @@ def dcm(RE, sim_run_engine):
 
 @pytest.fixture
 def vfm(RE):
-    vfm = i03.vfm(fake_with_ophyd_sim=True)
+    vfm = i03.vfm(connect_immediately=True, mock=True)
     vfm.bragg_to_lat_lookup_table_path = (
         "tests/test_data/test_beamline_vfm_lat_converter.txt"
     )
@@ -515,7 +514,7 @@ def lower_gonio(RE):
 
 @pytest.fixture
 def mirror_voltages():
-    voltages = i03.mirror_voltages(fake_with_ophyd_sim=True)
+    voltages = i03.mirror_voltages(mock=True)
     voltages.voltage_lookup_table_path = "tests/test_data/test_mirror_focus.json"
     for vc in voltages.vertical_voltages.values():
         vc.set = MagicMock(return_value=NullStatus())
@@ -528,7 +527,8 @@ def mirror_voltages():
 @pytest.fixture
 def undulator_dcm(RE, sim_run_engine, dcm):
     undulator_dcm = i03.undulator_dcm(
-        fake_with_ophyd_sim=True,
+        connect_immediately=True,
+        mock=True,
         daq_configuration_path="tests/test_data/test_daq_configuration",
     )
     set_up_dcm(undulator_dcm.dcm_ref(), sim_run_engine)
@@ -788,7 +788,7 @@ def mock_gridscan_kickoff_complete(gridscan: FastGridScanCommon):
 
 @pytest.fixture
 def panda_fast_grid_scan(RE):
-    return i03.panda_fast_grid_scan(fake_with_ophyd_sim=True)
+    return i03.panda_fast_grid_scan(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -813,17 +813,21 @@ async def fake_fgs_composite(
         dcm=dcm,
         # We don't use the eiger fixture here because .unstage() is used in some tests
         eiger=i03.eiger(fake_with_ophyd_sim=True),
-        zebra_fast_grid_scan=i03.zebra_fast_grid_scan(fake_with_ophyd_sim=True),
+        zebra_fast_grid_scan=i03.zebra_fast_grid_scan(
+            connect_immediately=True, mock=True
+        ),
         flux=i03.flux(fake_with_ophyd_sim=True),
         s4_slit_gaps=i03.s4_slit_gaps(fake_with_ophyd_sim=True),
         smargon=smargon,
-        undulator=i03.undulator(fake_with_ophyd_sim=True),
+        undulator=i03.undulator(connect_immediately=True, mock=True),
         synchrotron=synchrotron,
         xbpm_feedback=xbpm_feedback,
-        zebra=i03.zebra(fake_with_ophyd_sim=True),
+        zebra=i03.zebra(connect_immediately=True, mock=True),
         zocalo=zocalo,
         panda=panda,
-        panda_fast_grid_scan=i03.panda_fast_grid_scan(fake_with_ophyd_sim=True),
+        panda_fast_grid_scan=i03.panda_fast_grid_scan(
+            connect_immediately=True, mock=True
+        ),
         robot=i03.robot(fake_with_ophyd_sim=True),
         sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,8 +432,7 @@ def robot(done_status):
 
 @pytest.fixture
 async def attenuator(RE):
-    attenuator = i03.attenuator()
-    await attenuator.connect(mock=True)
+    attenuator = i03.attenuator(connect_immediately=True, mock=True)
     set_mock_value(attenuator.actual_transmission, 0.49118047952)
 
     @AsyncStatus.wrap
@@ -487,7 +486,7 @@ def set_up_dcm(dcm, sim_run_engine: RunEngineSimulator):
 
 @pytest.fixture
 def dcm(RE, sim_run_engine):
-    dcm = i03.dcm(fake_with_ophyd_sim=True)
+    dcm = i03.dcm(connect_immediately=True, mock=True)
     set_up_dcm(dcm, sim_run_engine)
     yield dcm
 
@@ -606,8 +605,7 @@ async def aperture_scatterguard(RE):
             ),
         ),
     ):
-        ap_sg = i03.aperture_scatterguard()
-        await ap_sg.connect(mock=True)
+        ap_sg = i03.aperture_scatterguard(connect_immediately=True, mock=True)
     with (
         patch_async_motor(ap_sg.aperture.x),
         patch_async_motor(ap_sg.aperture.y),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,7 +371,7 @@ def undulator():
 
 @pytest.fixture
 def s4_slit_gaps():
-    return i03.s4_slit_gaps(fake_with_ophyd_sim=True)
+    return i03.s4_slit_gaps(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -406,7 +406,7 @@ def oav(test_config_files, RE):
 
 @pytest.fixture
 def flux():
-    return i03.flux(fake_with_ophyd_sim=True)
+    return i03.flux(connect_immediately=True, mock=True)
 
 
 @pytest.fixture
@@ -816,8 +816,8 @@ async def fake_fgs_composite(
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(
             connect_immediately=True, mock=True
         ),
-        flux=i03.flux(fake_with_ophyd_sim=True),
-        s4_slit_gaps=i03.s4_slit_gaps(fake_with_ophyd_sim=True),
+        flux=i03.flux(connect_immediately=True, mock=True),
+        s4_slit_gaps=i03.s4_slit_gaps(connect_immediately=True, mock=True),
         smargon=smargon,
         undulator=i03.undulator(connect_immediately=True, mock=True),
         synchrotron=synchrotron,

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -130,7 +130,7 @@ def oav_for_system_test(test_config_files):
     parameters = OAVConfig(
         test_config_files["zoom_params_file"], test_config_files["display_config"]
     )
-    oav = i03.oav(fake_with_ophyd_sim=True, params=parameters)
+    oav = i03.oav(connect_immediately=True, mock=True, params=parameters)
     set_mock_value(oav.cam.array_size_x, 1024)
     set_mock_value(oav.cam.array_size_y, 768)
 

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
@@ -5,7 +6,6 @@ from unittest.mock import MagicMock, patch
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import pytest
-import pytest_asyncio
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
 from dodal.devices.aperturescatterguard import ApertureValue
@@ -66,7 +66,7 @@ def reset_positions(smargon: Smargon):
     yield from bps.mv(smargon.x, -1, smargon.y, -1, smargon.z, -1)  # type: ignore # See: https://github.com/bluesky/bluesky/issues/1809
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def fxc_composite():
     with (
         patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection"),
@@ -94,6 +94,11 @@ async def fxc_composite():
         zebra=i03.zebra(),
         zocalo=zocalo,
         sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
+    )
+
+    await asyncio.gather(
+        composite.aperture_scatterguard.connect(mock=True),
+        composite.attenuator.connect(mock=True),
     )
 
     await composite.robot.barcode._backend.put("ABCDEFGHIJ")  # type: ignore

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -79,18 +79,20 @@ async def fxc_composite():
         aperture_scatterguard=i03.aperture_scatterguard(
             connect_immediately=True, mock=True
         ),
-        backlight=i03.backlight(),
+        backlight=i03.backlight(mock=True),
         dcm=i03.dcm(fake_with_ophyd_sim=True),
         eiger=i03.eiger(),
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(),
         flux=i03.flux(fake_with_ophyd_sim=True),
         robot=i03.robot(fake_with_ophyd_sim=True),
         panda=i03.panda(fake_with_ophyd_sim=True),
-        panda_fast_grid_scan=i03.panda_fast_grid_scan(fake_with_ophyd_sim=True),
+        panda_fast_grid_scan=i03.panda_fast_grid_scan(
+            connect_immediately=True, mock=True
+        ),
         s4_slit_gaps=i03.s4_slit_gaps(),
         smargon=i03.smargon(),
         undulator=i03.undulator(),
-        synchrotron=i03.synchrotron(fake_with_ophyd_sim=True),
+        synchrotron=i03.synchrotron(connect_immediately=True, mock=True),
         xbpm_feedback=i03.xbpm_feedback(fake_with_ophyd_sim=True),
         zebra=i03.zebra(),
         zocalo=zocalo,

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -1,4 +1,3 @@
-import asyncio
 import uuid
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
@@ -76,8 +75,10 @@ async def fxc_composite():
         zocalo = i03.zocalo()
 
     composite = FlyScanXRayCentreComposite(
-        attenuator=i03.attenuator(),
-        aperture_scatterguard=i03.aperture_scatterguard(),
+        attenuator=i03.attenuator(connect_immediately=True, mock=True),
+        aperture_scatterguard=i03.aperture_scatterguard(
+            connect_immediately=True, mock=True
+        ),
         backlight=i03.backlight(),
         dcm=i03.dcm(fake_with_ophyd_sim=True),
         eiger=i03.eiger(),
@@ -94,11 +95,6 @@ async def fxc_composite():
         zebra=i03.zebra(),
         zocalo=zocalo,
         sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
-    )
-
-    await asyncio.gather(
-        composite.aperture_scatterguard.connect(mock=True),
-        composite.attenuator.connect(mock=True),
     )
 
     await composite.robot.barcode._backend.put("ABCDEFGHIJ")  # type: ignore

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -84,7 +84,7 @@ async def fxc_composite():
         eiger=i03.eiger(),
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(),
         flux=i03.flux(fake_with_ophyd_sim=True),
-        robot=i03.robot(fake_with_ophyd_sim=True),
+        robot=i03.robot(connect_immediately=True, mock=True),
         panda=i03.panda(connect_immediately=True, mock=True),
         panda_fast_grid_scan=i03.panda_fast_grid_scan(
             connect_immediately=True, mock=True
@@ -93,7 +93,7 @@ async def fxc_composite():
         smargon=i03.smargon(),
         undulator=i03.undulator(),
         synchrotron=i03.synchrotron(connect_immediately=True, mock=True),
-        xbpm_feedback=i03.xbpm_feedback(fake_with_ophyd_sim=True),
+        xbpm_feedback=i03.xbpm_feedback(connect_immediately=True, mock=True),
         zebra=i03.zebra(),
         zocalo=zocalo,
         sample_shutter=i03.sample_shutter(connect_immediately=True, mock=True),

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -85,7 +85,7 @@ async def fxc_composite():
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(),
         flux=i03.flux(fake_with_ophyd_sim=True),
         robot=i03.robot(fake_with_ophyd_sim=True),
-        panda=i03.panda(fake_with_ophyd_sim=True),
+        panda=i03.panda(connect_immediately=True, mock=True),
         panda_fast_grid_scan=i03.panda_fast_grid_scan(
             connect_immediately=True, mock=True
         ),
@@ -96,7 +96,7 @@ async def fxc_composite():
         xbpm_feedback=i03.xbpm_feedback(fake_with_ophyd_sim=True),
         zebra=i03.zebra(),
         zocalo=zocalo,
-        sample_shutter=i03.sample_shutter(fake_with_ophyd_sim=True),
+        sample_shutter=i03.sample_shutter(connect_immediately=True, mock=True),
     )
 
     await composite.robot.barcode._backend.put("ABCDEFGHIJ")  # type: ignore

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -31,7 +31,7 @@ async def test_getting_data_for_ispyb():
     )
     synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
     slit_gaps = S4SlitGaps(f"{CONST.SIM.BEAMLINE}-AL-SLITS-04:", name="slits")
-    attenuator = i03.attenuator()
+    attenuator = i03.attenuator(connect_immediately=True, mock=True)
     flux = i03.flux(fake_with_ophyd_sim=True)
     dcm = i03.dcm(fake_with_ophyd_sim=True)
     aperture_scatterguard = ApertureScatterguard(
@@ -45,7 +45,6 @@ async def test_getting_data_for_ispyb():
     await undulator.connect()
     await synchrotron.connect()
     await slit_gaps.connect()
-    await attenuator.connect(mock=True)
     await flux.connect()
     await aperture_scatterguard.connect()
     await smargon.connect()

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -46,7 +46,7 @@ async def test_getting_data_for_ispyb():
     await slit_gaps.connect()
     await flux.connect()
     await aperture_scatterguard.connect()
-    robot = i03.robot(fake_with_ophyd_sim=True)
+    robot = i03.robot(connect_immediately=True, mock=True)
 
     RE = RunEngine()
 

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -29,7 +29,7 @@ async def test_getting_data_for_ispyb():
         name="undulator",
         id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
-    synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
+    synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
     slit_gaps = S4SlitGaps(f"{CONST.SIM.BEAMLINE}-AL-SLITS-04:", name="slits")
     attenuator = i03.attenuator(connect_immediately=True, mock=True)
     flux = i03.flux(fake_with_ophyd_sim=True)
@@ -40,14 +40,12 @@ async def test_getting_data_for_ispyb():
         loaded_positions=load_positions_from_beamline_parameters(params),
         tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
-    smargon = i03.smargon(fake_with_ophyd_sim=True)
+    smargon = i03.smargon(connect_immediately=True, mock=True)
     eiger = i03.eiger(fake_with_ophyd_sim=True)
     await undulator.connect()
-    await synchrotron.connect()
     await slit_gaps.connect()
     await flux.connect()
     await aperture_scatterguard.connect()
-    await smargon.connect()
     robot = i03.robot(fake_with_ophyd_sim=True)
 
     RE = RunEngine()

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -31,7 +31,7 @@ async def test_getting_data_for_ispyb():
     )
     synchrotron = i03.synchrotron(fake_with_ophyd_sim=True)
     slit_gaps = S4SlitGaps(f"{CONST.SIM.BEAMLINE}-AL-SLITS-04:", name="slits")
-    attenuator = i03.attenuator(fake_with_ophyd_sim=True)
+    attenuator = i03.attenuator()
     flux = i03.flux(fake_with_ophyd_sim=True)
     dcm = i03.dcm(fake_with_ophyd_sim=True)
     aperture_scatterguard = ApertureScatterguard(
@@ -45,7 +45,7 @@ async def test_getting_data_for_ispyb():
     await undulator.connect()
     await synchrotron.connect()
     await slit_gaps.connect()
-    await attenuator.connect()
+    await attenuator.connect(mock=True)
     await flux.connect()
     await aperture_scatterguard.connect()
     await smargon.connect()

--- a/tests/unit_tests/hyperion/conftest.py
+++ b/tests/unit_tests/hyperion/conftest.py
@@ -11,7 +11,11 @@ BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
 
 @pytest.fixture(scope="session")
 def i03_device_factories():
-    return [f for f in collect_factories(i03).values() if hasattr(f, "cache_clear")]
+    return [
+        f
+        for f in collect_factories(i03, include_skipped=True).values()
+        if hasattr(f, "cache_clear")
+    ]
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/unit_tests/hyperion/conftest.py
+++ b/tests/unit_tests/hyperion/conftest.py
@@ -3,8 +3,22 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from dodal.beamlines import i03
+from dodal.utils import collect_factories
 
 BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
+
+
+@pytest.fixture(scope="session")
+def i03_device_factories():
+    return [f for f in collect_factories(i03).values() if hasattr(f, "cache_clear")]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_device_factory_caches_after_every_test(i03_device_factories):
+    yield None
+    for f in i03_device_factories:
+        f.cache_clear()  # type: ignore
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -10,7 +10,6 @@ from bluesky.run_engine import RunEngine, RunEngineResult
 from bluesky.simulators import assert_message_and_return_remaining
 from bluesky.utils import FailedStatus, Msg
 from dodal.beamlines import i03
-from dodal.common.beamlines.beamline_utils import clear_device
 from dodal.devices.aperturescatterguard import AperturePosition, ApertureValue
 from dodal.devices.detector.det_dim_constants import (
     EIGER_TYPE_EIGER2_X_16M,
@@ -605,8 +604,7 @@ class TestFlyscanXrayCentrePlan:
         done_status: Status,
     ):
         fake_fgs_composite.eiger.unstage = MagicMock(return_value=done_status)
-        clear_device("zebra_fast_grid_scan")
-        fgs = i03.zebra_fast_grid_scan(fake_with_ophyd_sim=True)
+        fgs = i03.zebra_fast_grid_scan(connect_immediately=True, mock=True)
         fgs.KICKOFF_TIMEOUT = 0.1
         fgs.complete = MagicMock(return_value=done_status)
         set_mock_value(fgs.motion_program.running, 1)
@@ -632,7 +630,6 @@ class TestFlyscanXrayCentrePlan:
 
         assert isinstance(res, RunEngineResult)
         assert res.exit_status == "success"
-        clear_device("zebra_fast_grid_scan")
 
     @patch(
         "mx_bluesky.hyperion.experiment_plans.flyscan_xray_centre_plan.run_gridscan",
@@ -718,7 +715,9 @@ class TestFlyscanXrayCentrePlan:
     def test_GIVEN_scan_already_valid_THEN_wait_for_GRIDSCAN_returns_immediately(
         self, patch_sleep: MagicMock, RE: RunEngine
     ):
-        test_fgs: ZebraFastGridScan = i03.zebra_fast_grid_scan(fake_with_ophyd_sim=True)
+        test_fgs: ZebraFastGridScan = i03.zebra_fast_grid_scan(
+            connect_immediately=True, mock=True
+        )
 
         set_mock_value(test_fgs.position_counter, 0)
         set_mock_value(test_fgs.scan_invalid, False)
@@ -734,7 +733,9 @@ class TestFlyscanXrayCentrePlan:
     def test_GIVEN_scan_not_valid_THEN_wait_for_GRIDSCAN_raises_and_sleeps_called(
         self, patch_sleep: MagicMock, RE: RunEngine
     ):
-        test_fgs: ZebraFastGridScan = i03.zebra_fast_grid_scan(fake_with_ophyd_sim=True)
+        test_fgs: ZebraFastGridScan = i03.zebra_fast_grid_scan(
+            connect_immediately=True, mock=True
+        )
 
         set_mock_value(test_fgs.scan_invalid, True)
         set_mock_value(test_fgs.position_counter, 0)

--- a/tests/unit_tests/hyperion/experiment_plans/test_grid_detection_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_grid_detection_plan.py
@@ -49,7 +49,7 @@ def fake_devices(
     params = OAVConfig(
         test_config_files["zoom_params_file"], test_config_files["display_config"]
     )
-    oav = i03.oav(fake_with_ophyd_sim=True, params=params)
+    oav = i03.oav(connect_immediately=True, mock=True, params=params)
     zoom_levels_list = ["1.0x", "3.0x", "5.0x", "7.5x", "10.0x", "15.0x"]
     oav.zoom_controller._get_allowed_zoom_levels = AsyncMock(
         return_value=zoom_levels_list
@@ -58,7 +58,7 @@ def fake_devices(
     set_mock_value(oav.grid_snapshot.x_size, 1024)
     set_mock_value(oav.grid_snapshot.y_size, 768)
 
-    pin_tip_detection = i03.pin_tip_detection(fake_with_ophyd_sim=True)
+    pin_tip_detection = i03.pin_tip_detection(connect_immediately=True, mock=True)
     pin_tip_detection._get_tip_and_edge_data = AsyncMock(
         return_value=SampleLocation(
             8,

--- a/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
@@ -41,9 +41,7 @@ def mock_emit():
 
 @pytest.fixture
 async def fake_composite(attenuator) -> OptimizeAttenuationComposite:
-    sample_shutter = i03.sample_shutter(
-        fake_with_ophyd_sim=True, wait_for_connection=True
-    )
+    sample_shutter = i03.sample_shutter(connect_immediately=True, mock=True)
     xspress3mini = i03.xspress3mini(connect_immediately=True, mock=True)
 
     return OptimizeAttenuationComposite(

--- a/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
@@ -40,12 +40,11 @@ def mock_emit():
 
 
 @pytest.fixture
-def fake_composite() -> OptimizeAttenuationComposite:
+async def fake_composite(attenuator) -> OptimizeAttenuationComposite:
     sample_shutter = i03.sample_shutter(
         fake_with_ophyd_sim=True, wait_for_connection=True
     )
     xspress3mini = i03.xspress3mini(fake_with_ophyd_sim=True, wait_for_connection=True)
-    attenuator = i03.attenuator(fake_with_ophyd_sim=True, wait_for_connection=True)
 
     return OptimizeAttenuationComposite(
         sample_shutter=sample_shutter, xspress3mini=xspress3mini, attenuator=attenuator

--- a/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
@@ -44,7 +44,7 @@ async def fake_composite(attenuator) -> OptimizeAttenuationComposite:
     sample_shutter = i03.sample_shutter(
         fake_with_ophyd_sim=True, wait_for_connection=True
     )
-    xspress3mini = i03.xspress3mini(fake_with_ophyd_sim=True, wait_for_connection=True)
+    xspress3mini = i03.xspress3mini(connect_immediately=True, mock=True)
 
     return OptimizeAttenuationComposite(
         sample_shutter=sample_shutter, xspress3mini=xspress3mini, attenuator=attenuator


### PR DESCRIPTION
This addresses
* DiamondLightSource/dodal#846

See also dodal PR
* DiamondLightSource/dodal#975

Additionally, this PR also adds unit test duration summary to the end of pytest, this was done because it seems that tests are taking longer, see related issue that is not addressed here
* DiamondLightSource/dodal#973

