### PR TITLE
Assert setpoint in motor tests

### DIFF
--- a/tests/unit_tests/beamlines/i24/serial/extruder/test_extruder_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/extruder/test_extruder_collect.py
@@ -125,7 +125,7 @@ def test_initialise_extruder(
 
 async def test_enterhutch(detector_stage, RE):
     RE(enter_hutch(detector_stage))
-    assert await detector_stage.z.user_readback.get_value() == 1480
+    assert await detector_stage.z.user_setpoint.get_value() == 1480
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_chip_manager.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_chip_manager.py
@@ -146,8 +146,8 @@ async def test_moveto_oxford_origin(fake_caget: MagicMock, pmac: PMAC, RE):
     fake_caget.return_value = 0
     RE(moveto(Fiducials.origin, pmac))
     assert fake_caget.call_count == 1
-    assert await pmac.x.user_readback.get_value() == 0.0
-    assert await pmac.y.user_readback.get_value() == 0.0
+    assert await pmac.x.user_setpoint.get_value() == 0.0
+    assert await pmac.y.user_setpoint.get_value() == 0.0
 
 
 @patch("mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_Chip_Manager_py3v1.caget")
@@ -155,8 +155,8 @@ async def test_moveto_oxford_inner_f1(fake_caget: MagicMock, pmac: PMAC, RE):
     fake_caget.return_value = 1
     RE(moveto(Fiducials.fid1, pmac))
     assert fake_caget.call_count == 1
-    assert await pmac.x.user_readback.get_value() == 24.60
-    assert await pmac.y.user_readback.get_value() == 0.0
+    assert await pmac.x.user_setpoint.get_value() == 24.60
+    assert await pmac.y.user_setpoint.get_value() == 0.0
 
 
 async def test_moveto_chip_aspecific(pmac: PMAC, RE):
@@ -179,7 +179,7 @@ async def test_moveto_preset(
     RE(moveto_preset("load_position", pmac, beamstop, backlight, detector_stage))
     assert await beamstop.pos_select.get_value() == "Robot"
     assert await backlight.backlight_position.pos_level.get_value() == "Out"
-    assert await detector_stage.z.user_readback.get_value() == 1300
+    assert await detector_stage.z.user_setpoint.get_value() == 1300
 
 
 @pytest.mark.parametrize(
@@ -205,9 +205,9 @@ async def test_moveto_preset_with_pmac_move(
     RE(moveto_preset(pos_request, pmac, beamstop, backlight, detector_stage))
     assert fake_caput.call_count == expected_num_caput
 
-    assert await pmac.x.user_readback.get_value() == expected_pmac_move[0]
-    assert await pmac.y.user_readback.get_value() == expected_pmac_move[1]
-    assert await pmac.z.user_readback.get_value() == expected_pmac_move[2]
+    assert await pmac.x.user_setpoint.get_value() == expected_pmac_move[0]
+    assert await pmac.y.user_setpoint.get_value() == expected_pmac_move[1]
+    assert await pmac.z.user_setpoint.get_value() == expected_pmac_move[2]
 
     if other_devices:
         assert await beamstop.pos_select.get_value() == "Data Collection"

--- a/tests/unit_tests/beamlines/i24/serial/setup_beamline/test_setup_beamline.py
+++ b/tests/unit_tests/beamlines/i24/serial/setup_beamline/test_setup_beamline.py
@@ -18,7 +18,7 @@ async def test_setup_beamline_for_collection_plan(
 
     assert await aperture.position.get_value() == "In"
     assert await beamstop.pos_select.get_value() == "Data Collection"
-    assert await beamstop.y_rotation.user_readback.get_value() == 0
+    assert await beamstop.y_rotation.user_setpoint.get_value() == 0
 
     assert await backlight.backlight_position.pos_level.get_value() == "Out"
 
@@ -27,7 +27,7 @@ async def test_move_detector_stage_to_position_plan(detector_stage: DetectorMoti
     det_dist = 100
     RE(setup_beamline.move_detector_stage_to_position_plan(detector_stage, det_dist))
 
-    assert await detector_stage.z.user_readback.get_value() == det_dist
+    assert await detector_stage.z.user_setpoint.get_value() == det_dist
 
 
 async def test_set_detector_beam_center_plan(eiger_beam_center: DetectorBeamCenter, RE):

--- a/tests/unit_tests/beamlines/i24/serial/setup_beamline/test_setup_detector.py
+++ b/tests/unit_tests/beamlines/i24/serial/setup_beamline/test_setup_detector.py
@@ -49,8 +49,8 @@ async def test_setup_detector_stage(
 ):
     fake_caget.return_value = DetRequest.eiger.value
     RE(setup_detector_stage(SSXType.FIXED, detector_stage))
-    assert await detector_stage.y.user_readback.get_value() == Eiger.det_y_target
+    assert await detector_stage.y.user_setpoint.get_value() == Eiger.det_y_target
 
     fake_caget.return_value = DetRequest.pilatus.value
     RE(setup_detector_stage(SSXType.EXTRUDER, detector_stage))
-    assert await detector_stage.y.user_readback.get_value() == Pilatus.det_y_target
+    assert await detector_stage.y.user_setpoint.get_value() == Pilatus.det_y_target

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -152,16 +152,16 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
     smargon.stub_offsets.set = MagicMock(return_value=done_status)
     aperture_scatterguard.set = MagicMock(return_value=done_status)
 
-    set_mock_value(smargon.x.user_readback, 10)
-    set_mock_value(smargon.z.user_readback, 5)
-    set_mock_value(smargon.omega.user_readback, 90)
+    set_mock_value(smargon.x.user_setpoint, 10)
+    set_mock_value(smargon.z.user_setpoint, 5)
+    set_mock_value(smargon.omega.user_setpoint, 90)
 
     RE = RunEngine()
     RE(prepare_for_robot_load(aperture_scatterguard, smargon))
 
-    assert await smargon.x.user_readback.get_value() == 0
-    assert await smargon.z.user_readback.get_value() == 0
-    assert await smargon.omega.user_readback.get_value() == 0
+    assert await smargon.x.user_setpoint.get_value() == 0
+    assert await smargon.z.user_setpoint.get_value() == 0
+    assert await smargon.omega.user_setpoint.get_value() == 0
 
     smargon.stub_offsets.set.assert_called_once_with(StubPosition.RESET_TO_ROBOT_LOAD)  # type: ignore
     aperture_scatterguard.set.assert_called_once_with(ApertureValue.ROBOT_LOAD)  # type: ignore

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -216,11 +216,11 @@ async def test_full_rotation_plan_smargon_settings(
     omega_velocity_set: MagicMock = get_mock_put(smargon.omega.velocity)
     rotation_speed = params.rotation_increment_deg / params.exposure_time_s
 
-    assert await smargon.phi.user_readback.get_value() == params.phi_start_deg
-    assert await smargon.chi.user_readback.get_value() == params.chi_start_deg
-    assert await smargon.x.user_readback.get_value() == params.x_start_um / 1000  # type: ignore
-    assert await smargon.y.user_readback.get_value() == params.y_start_um / 1000  # type: ignore
-    assert await smargon.z.user_readback.get_value() == params.z_start_um / 1000  # type: ignore
+    assert await smargon.phi.user_setpoint.get_value() == params.phi_start_deg
+    assert await smargon.chi.user_setpoint.get_value() == params.chi_start_deg
+    assert await smargon.x.user_setpoint.get_value() == params.x_start_um / 1000  # type: ignore
+    assert await smargon.y.user_setpoint.get_value() == params.y_start_um / 1000  # type: ignore
+    assert await smargon.z.user_setpoint.get_value() == params.z_start_um / 1000  # type: ignore
     assert (
         # 4 * snapshots, restore omega, 1 * rotation sweep
         omega_set.call_count == 4 + 1 + 1
@@ -259,7 +259,6 @@ async def test_rotation_plan_smargon_doesnt_move_xyz_if_not_given_in_params(
     assert params.y_start_um is None
     assert params.z_start_um is None
     for motor in [smargon.phi, smargon.chi, smargon.x, smargon.y, smargon.z]:
-        assert await motor.user_readback.get_value() == 0
         get_mock_put(motor.user_setpoint).assert_not_called()  # type: ignore
 
 


### PR DESCRIPTION
This addresses issue #318.

All motor tests that assert `user_readback == ` should be changed to assert `user_setpoint == `. I have some clarifications of changes as comments below, that I would appreciate thoughts on.