### PR TITLE
Dodal 846 device factory support for ophyd v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.8a5",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@ae57c22eb170ef92ea9364541b63da30f6fbd52e",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@709df016424e3a6776f839cc58993651c5c678ab",
 ]
 
 

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -80,7 +80,7 @@ def fake_rotation_scan(
 
 def fake_create_rotation_devices():
     beamstop = i03.beamstop(connect_immediately=True, mock=True)
-    eiger = i03.eiger(fake_with_ophyd_sim=True)
+    eiger = i03.eiger(connect_immediately=True, mock=True)
     smargon = i03.smargon(connect_immediately=True, mock=True)
     zebra = i03.zebra(connect_immediately=True, mock=True)
     detector_motion = i03.detector_motion(connect_immediately=True, mock=True)

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -8,7 +8,9 @@ from unittest.mock import patch
 import bluesky.preprocessors as bpp
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
+from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.devices.oav.oav_parameters import OAVConfig
+from dodal.devices.s4_slit_gaps import S4SlitGaps
 from ophyd_async.testing import set_mock_value
 
 from mx_bluesky.hyperion.device_setup_plans.read_hardware_for_setup import (

--- a/src/mx_bluesky/hyperion/utils/validation.py
+++ b/src/mx_bluesky/hyperion/utils/validation.py
@@ -8,9 +8,7 @@ from unittest.mock import patch
 import bluesky.preprocessors as bpp
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
-from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.devices.oav.oav_parameters import OAVConfig
-from dodal.devices.s4_slit_gaps import S4SlitGaps
 from ophyd_async.testing import set_mock_value
 
 from mx_bluesky.hyperion.device_setup_plans.read_hardware_for_setup import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from dodal.common.beamlines import beamline_utils
 from dodal.common.beamlines.beamline_parameters import (
     GDABeamlineParameters,
 )
-from dodal.common.beamlines.beamline_utils import clear_devices, device_instantiation
+from dodal.common.beamlines.beamline_utils import clear_devices
 from dodal.devices.aperturescatterguard import (
     AperturePosition,
     ApertureScatterguard,
@@ -382,7 +382,7 @@ def undulator():
 
 
 @pytest.fixture
-def s4_slit_gaps():
+def s4_slit_gaps() -> S4SlitGaps:
     return i03.s4_slit_gaps(connect_immediately=True, mock=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from dodal.common.beamlines import beamline_utils
 from dodal.common.beamlines.beamline_parameters import (
     GDABeamlineParameters,
 )
-from dodal.common.beamlines.beamline_utils import clear_devices
+from dodal.common.beamlines.beamline_utils import clear_devices, device_instantiation
 from dodal.devices.aperturescatterguard import (
     AperturePosition,
     ApertureScatterguard,
@@ -817,6 +817,7 @@ async def fake_fgs_composite(
     dcm,
     panda,
     backlight,
+    s4_slit_gaps,
 ):
     fake_composite = FlyScanXRayCentreComposite(
         aperture_scatterguard=aperture_scatterguard,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,7 +306,7 @@ def done_status():
 
 @pytest.fixture
 def eiger(done_status):
-    eiger = i03.eiger(fake_with_ophyd_sim=True)
+    eiger = i03.eiger(connect_immediately=True, mock=True)
     eiger.stage = MagicMock(return_value=done_status)
     eiger.do_arm.set = MagicMock(return_value=done_status)
     eiger.unstage = MagicMock(return_value=done_status)
@@ -825,7 +825,7 @@ async def fake_fgs_composite(
         backlight=backlight,
         dcm=dcm,
         # We don't use the eiger fixture here because .unstage() is used in some tests
-        eiger=i03.eiger(fake_with_ophyd_sim=True),
+        eiger=i03.eiger(connect_immediately=True, mock=True),
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(
             connect_immediately=True, mock=True
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -830,7 +830,7 @@ async def fake_fgs_composite(
             connect_immediately=True, mock=True
         ),
         flux=i03.flux(connect_immediately=True, mock=True),
-        s4_slit_gaps=i03.s4_slit_gaps(connect_immediately=True, mock=True),
+        s4_slit_gaps=s4_slit_gaps,
         smargon=smargon,
         undulator=i03.undulator(connect_immediately=True, mock=True),
         synchrotron=synchrotron,

--- a/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_fgs_plan.py
@@ -83,7 +83,7 @@ async def fxc_composite():
         dcm=i03.dcm(fake_with_ophyd_sim=True),
         eiger=i03.eiger(),
         zebra_fast_grid_scan=i03.zebra_fast_grid_scan(),
-        flux=i03.flux(fake_with_ophyd_sim=True),
+        flux=i03.flux(connect_immediately=True, mock=True),
         robot=i03.robot(connect_immediately=True, mock=True),
         panda=i03.panda(connect_immediately=True, mock=True),
         panda_fast_grid_scan=i03.panda_fast_grid_scan(

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -41,7 +41,7 @@ async def test_getting_data_for_ispyb():
         tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
     smargon = i03.smargon(connect_immediately=True, mock=True)
-    eiger = i03.eiger(fake_with_ophyd_sim=True)
+    eiger = i03.eiger(mock=True)
     await undulator.connect()
     await slit_gaps.connect()
     await flux.connect()

--- a/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/hyperion/experiment_plans/test_plan_system.py
@@ -32,7 +32,7 @@ async def test_getting_data_for_ispyb():
     synchrotron = i03.synchrotron(connect_immediately=True, mock=True)
     slit_gaps = S4SlitGaps(f"{CONST.SIM.BEAMLINE}-AL-SLITS-04:", name="slits")
     attenuator = i03.attenuator(connect_immediately=True, mock=True)
-    flux = i03.flux(fake_with_ophyd_sim=True)
+    flux = i03.flux(connect_immediately=True, mock=True)
     dcm = i03.dcm(fake_with_ophyd_sim=True)
     aperture_scatterguard = ApertureScatterguard(
         prefix="BL03S",

--- a/tests/unit_tests/common/device_setup_plans/test_read_hardware_for_setup.py
+++ b/tests/unit_tests/common/device_setup_plans/test_read_hardware_for_setup.py
@@ -12,7 +12,7 @@ from mx_bluesky.common.device_setup_plans.read_hardware_for_setup import (
 
 @pytest.fixture
 def fake_eiger() -> EigerDetector:
-    return eiger(fake_with_ophyd_sim=True)
+    return eiger(mock=True)
 
 
 def test_read_hardware_for_zocalo_in_RE(fake_eiger, RE: RunEngine):

--- a/tests/unit_tests/common/plan_stubs/test_do_fgs.py
+++ b/tests/unit_tests/common/plan_stubs/test_do_fgs.py
@@ -29,7 +29,7 @@ def fgs_devices(RE):
         grid_scan_device = ZebraFastGridScan("zebra_fgs")
 
     # Eiger done separately as not ophyd-async yet
-    detector = eiger(fake_with_ophyd_sim=True)
+    detector = eiger(mock=True)
 
     return {
         "synchrotron": synchrotron,

--- a/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
@@ -14,7 +14,7 @@ from mx_bluesky.hyperion.device_setup_plans.utils import (
 
 @pytest.fixture()
 def mock_eiger():
-    eiger = i03.eiger(fake_with_ophyd_sim=True)
+    eiger = i03.eiger(mock=True)
     eiger.detector_params = MagicMock()
     eiger.async_stage = MagicMock()
     eiger.disarm_detector = MagicMock()


### PR DESCRIPTION
This is part of
* DiamondLightSource/dodal#846

This PR updates mx-bluesky to work with changes introduced in dodal PR
* DiamondLightSource/dodal#984

which adds support for ophyd v1 devices to `device_factory`

This PR builds on mx-bluesky PR:
* #735 

