### PR TITLE
Fix unit test banned path check to allow access to project folder

### DIFF
--- a/tests/unit_tests/hyperion/conftest.py
+++ b/tests/unit_tests/hyperion/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
+PERMITTED_PATHS = [Path("/tmp")]
 
 
 @pytest.fixture(autouse=True)
@@ -17,8 +17,8 @@ def patch_open_to_prevent_dls_reads_in_tests():
     def patched_open(*args, **kwargs):
         requested_path = Path(args[0])
         if requested_path.is_absolute():
-            for p in BANNED_PATHS:
-                assert not requested_path.is_relative_to(
+            for p in PERMITTED_PATHS:
+                assert requested_path.is_relative_to(
                     p
                 ) or requested_path.is_relative_to(project_folder), (
                     f"Attempt to open {requested_path} from inside a unit test"

--- a/tests/unit_tests/hyperion/conftest.py
+++ b/tests/unit_tests/hyperion/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-PERMITTED_PATHS = [Path("/tmp")]
+BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
 
 
 @pytest.fixture(autouse=True)
@@ -17,8 +17,8 @@ def patch_open_to_prevent_dls_reads_in_tests():
     def patched_open(*args, **kwargs):
         requested_path = Path(args[0])
         if requested_path.is_absolute():
-            for p in PERMITTED_PATHS:
-                assert requested_path.is_relative_to(
+            for p in BANNED_PATHS:
+                assert not requested_path.is_relative_to(
                     p
                 ) or requested_path.is_relative_to(project_folder), (
                     f"Attempt to open {requested_path} from inside a unit test"

--- a/tests/unit_tests/hyperion/conftest.py
+++ b/tests/unit_tests/hyperion/conftest.py
@@ -1,3 +1,4 @@
+from importlib import resources
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,12 +10,17 @@ BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
 @pytest.fixture(autouse=True)
 def patch_open_to_prevent_dls_reads_in_tests():
     unpatched_open = open
+    project_folder = resources.files(__package__)
+    assert isinstance(project_folder, Path)
+    project_folder = project_folder.parent.parent.parent
 
     def patched_open(*args, **kwargs):
         requested_path = Path(args[0])
         if requested_path.is_absolute():
             for p in BANNED_PATHS:
-                assert not requested_path.is_relative_to(p), (
+                assert not requested_path.is_relative_to(
+                    p
+                ) or requested_path.is_relative_to(project_folder), (
                     f"Attempt to open {requested_path} from inside a unit test"
                 )
         return unpatched_open(*args, **kwargs)


### PR DESCRIPTION
Fixes
* #533 

This change adjusts the check for unit tests trying to open files so that files in the project folder are allowed