### PR TITLE
Remove unnecessary pydantic model_config arbitrary_types_allowed=True

### DIFF
--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -93,7 +93,6 @@ class IspybExperimentType(StrEnum):
 
 class MxBlueskyParameters(BaseModel):
     model_config = ConfigDict(
-        arbitrary_types_allowed=True,
         extra="allow",
     )
 


### PR DESCRIPTION
This removes the `arbitrary_types_allowed=True` fro `MxBlueskyParameters.model_config`