### PR TITLE
632 Add external interaction system tests to the containerised system tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ filterwarnings = [
     "ignore:.*custom tp_new.*:DeprecationWarning",
     # Ignore warning about deprecated throw() call https://github.com/bluesky/bluesky/issues/1817
     "ignore:.*signature of throw\\(\\) is deprecated.*:DeprecationWarning",
+    # Ignore warning about deprecations in python-workflows encountered during system tests 
+    "ignore:.*`Field` should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning"
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests/unit_tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.9.0a2",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@61d2eb609245cb96184c9dbfb8d9af8adef50447",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@7e0e008ce1f8ea84b641ff450af0bfbf2bafa4ec",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,8 @@ filterwarnings = [
     "ignore:.*custom tp_new.*:DeprecationWarning",
     # Ignore warning about deprecated throw() call https://github.com/bluesky/bluesky/issues/1817
     "ignore:.*signature of throw\\(\\) is deprecated.*:DeprecationWarning",
-    # Ignore warning about deprecations in python-workflows encountered during system tests 
+    # Ignore warning about deprecations in python-workflows encountered during system tests
+    # https://github.com/DiamondLightSource/python-workflows/issues/188
     "ignore:.*`Field` should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning"
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,8 @@ skipsdist=True
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
+setenv =
+    systemtests: DODAL_TEST_MODE=true
 allowlist_externals =
     pytest
     pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.9.0a2",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@7e0e008ce1f8ea84b641ff450af0bfbf2bafa4ec",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@ff68ad54b5ab96b50701f23796694884b8e72987",
 ]
 
 

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -133,7 +133,7 @@ def test_RE_with_external_callbacks_starts_and_stops(
 @pytest.mark.system_test
 async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
     RE_with_external_callbacks: RunEngine,
-    test_fgs_params: HyperionSpecifiedThreeDGridScan,
+    dummy_params: HyperionSpecifiedThreeDGridScan,
     fgs_composite_for_fake_zocalo: HyperionFlyScanXRayCentreComposite,
     done_status,
     fetch_comment,  # noqa
@@ -148,7 +148,7 @@ async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
     RE.subscribe(doc_catcher)
 
     # Run the xray centring plan
-    RE(flyscan_xray_centre(fgs_composite_for_fake_zocalo, test_fgs_params))
+    RE(flyscan_xray_centre(fgs_composite_for_fake_zocalo, dummy_params))
 
     # Check that we we emitted a valid reading from the zocalo device
     zocalo_event = doc_catcher.event.call_args.args[0]  # type: ignore

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -206,9 +206,9 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
         )
 
     sleep(1)
-    assert isfile("tmp/dev/hyperion_ispyb_callback.log")
+    assert isfile("/tmp/logs/bluesky/hyperion_ispyb_callback.log")
     ispyb_log_tail = subprocess.run(
-        ["tail", "tmp/dev/hyperion_ispyb_callback.log"],
+        ["tail", "/tmp/logs/bluesky/hyperion_ispyb_callback.log"],
         timeout=1,
         stdout=subprocess.PIPE,
     ).stdout.decode("utf-8")

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -77,7 +77,9 @@ def event_monitor(monitor: zmq.Socket, connection_active_lock: threading.Lock) -
 
 
 @pytest.fixture
-def RE_with_external_callbacks():
+def RE_with_external_callbacks(
+    zocalo_env,  # ZOCALO_CONFIG must be exported to external callback environment
+):
     RE = RunEngine()
 
     process_env = os.environ.copy()

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -16,7 +16,6 @@ from bluesky.callbacks import CallbackBase
 from bluesky.callbacks.zmq import Publisher
 from bluesky.run_engine import RunEngine
 from dodal.devices.zocalo.zocalo_results import (
-    ZocaloResults,
     get_processing_results_from_event,
 )
 from zmq.utils.monitor import recv_monitor_message
@@ -41,7 +40,6 @@ from ..conftest import (  # noqa
     TEST_RESULT_LARGE,
     TEST_RESULT_MEDIUM,
     fetch_comment,
-    zocalo_env,
 )
 
 """
@@ -135,16 +133,14 @@ def test_RE_with_external_callbacks_starts_and_stops(
 @pytest.mark.system_test
 async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
     RE_with_external_callbacks: RunEngine,
-    zocalo_env,  # noqa
     test_fgs_params: HyperionSpecifiedThreeDGridScan,
     fgs_composite_for_fake_zocalo: HyperionFlyScanXRayCentreComposite,
     done_status,
-    zocalo_device: ZocaloResults,
     fetch_comment,  # noqa
 ):
-    """This test doesn't actually require S03 to be running, but it does require fake
-    zocalo, and a connection to the dev ISPyB database; like S03 tests, it can only run
-    locally at DLS."""
+    """
+    This test requires fake zocalo, and a connection to the dev ISPyB database.
+    """
 
     RE = RE_with_external_callbacks
 

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -221,7 +221,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     dcid = matches[0][0]
 
     comment = fetch_comment(dcid)
-    assert comment == "Hyperion rotation scan"
+    assert comment == "Sample position (µm): (1, 2, 3) test  Aperture: Small."
     wavelength = fetch_datacollection_attribute(dcid, "wavelength")
     beamsize_x = fetch_datacollection_attribute(dcid, "beamSizeAtSampleX")
     beamsize_y = fetch_datacollection_attribute(dcid, "beamSizeAtSampleY")

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -180,7 +180,7 @@ async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
 @pytest.mark.system_test
 def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     RE_with_external_callbacks: RunEngine,
-    test_rotation_params: RotationScan,
+    params_for_rotation_scan: RotationScan,
     fetch_comment,  # noqa
     fetch_datacollection_attribute,
     composite_for_rotation_scan,
@@ -192,15 +192,15 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     test_exp_time = 0.023
     test_img_wid = 0.27
 
-    test_rotation_params.rotation_increment_deg = test_img_wid
-    test_rotation_params.exposure_time_s = test_exp_time
-    test_rotation_params.demand_energy_ev = convert_angstrom_to_eV(test_wl)
+    params_for_rotation_scan.rotation_increment_deg = test_img_wid
+    params_for_rotation_scan.exposure_time_s = test_exp_time
+    params_for_rotation_scan.demand_energy_ev = convert_angstrom_to_eV(test_wl)
 
     with patch("bluesky.preprocessors.__read_and_stash_a_motor", fake_read):
         RE_with_external_callbacks(
             rotation_scan(
                 composite_for_rotation_scan,
-                test_rotation_params,
+                params_for_rotation_scan,
                 oav_parameters_for_rotation,
             )
         )

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -184,6 +184,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     fetch_comment,  # noqa
     fetch_datacollection_attribute,
     composite_for_rotation_scan,
+    oav_parameters_for_rotation,
 ):
     test_wl = 0.71
     test_bs_x = 0.023
@@ -200,6 +201,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
             rotation_scan(
                 composite_for_rotation_scan,
                 test_rotation_params,
+                oav_parameters_for_rotation,
             )
         )
 

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -221,7 +221,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     dcid = matches[0][0]
 
     comment = fetch_comment(dcid)
-    assert comment == "Sample position (µm): (1, 2, 3) test  Aperture: Small."
+    assert comment == "Sample position (µm): (1, 2, 3) test  Aperture: Small. "
     wavelength = fetch_datacollection_attribute(dcid, "wavelength")
     beamsize_x = fetch_datacollection_attribute(dcid, "beamSizeAtSampleX")
     beamsize_y = fetch_datacollection_attribute(dcid, "beamSizeAtSampleY")

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -133,7 +133,6 @@ def test_RE_with_external_callbacks_starts_and_stops(
 
 
 @pytest.mark.system_test
-@pytest.mark.skip(reason="need zocalo")
 async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
     RE_with_external_callbacks: RunEngine,
     zocalo_env,  # noqa
@@ -181,7 +180,6 @@ async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
 
 
 @pytest.mark.system_test
-@pytest.mark.skip(reason="need zocalo")
 def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     RE_with_external_callbacks: RunEngine,
     test_rotation_params: RotationScan,

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -173,7 +173,7 @@ async def test_external_callbacks_handle_gridscan_ispyb_and_zocalo(
     ispyb_comment = fetch_comment(dcid)
     assert ispyb_comment != ""
     assert "Zocalo processing took" in ispyb_comment
-    assert "Position (grid boxes) ['1', '2', '3']" in ispyb_comment
+    assert "Position (grid boxes) ['1.0', '2.0', '3.0']" in ispyb_comment
     assert "Size (grid boxes) [6 6 5];" in ispyb_comment
 
 

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -213,7 +213,9 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
         stdout=subprocess.PIPE,
     ).stdout.decode("utf-8")
 
-    ids_re = re.compile(r"data_collection_ids=(\d+) data_collection_group_id=(\d+) ")
+    ids_re = re.compile(
+        r"data_collection_ids=\((\d+),\) data_collection_group_id=(\d+) "
+    )
     matches = ids_re.findall(ispyb_log_tail)
 
     dcid = matches[0][0]

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -187,8 +187,8 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     oav_parameters_for_rotation,
 ):
     test_wl = 0.71
-    test_bs_x = 0.023
-    test_bs_y = 0.047
+    test_bs_x = 0.020
+    test_bs_y = 0.020
     test_exp_time = 0.023
     test_img_wid = 0.27
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -228,7 +228,7 @@ def dummy_params():
         )
     )
     dummy_params.visit = os.environ.get("ST_VISIT", "cm31105-5")
-    dummy_params.sample_id = os.environ.get("ST_SAMPLE_ID", dummy_params.sample_id)
+    dummy_params.sample_id = int(os.environ.get("ST_SAMPLE_ID", dummy_params.sample_id))
     return dummy_params
 
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -248,9 +248,12 @@ def zocalo_env():
 
 
 @pytest_asyncio.fixture
-async def zocalo_for_fake_zocalo():
+async def zocalo_for_fake_zocalo(zocalo_env) -> ZocaloResults:
+    """
+    This attempts to connect to a fake zocalo via rabbitmq
+    """
     zd = ZocaloResults()
-    zd.timeout_s = 5
+    zd.timeout_s = 10
     await zd.connect()
     return zd
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -53,6 +53,7 @@ from mx_bluesky.hyperion.parameters.device_composites import (
     HyperionFlyScanXRayCentreComposite,
 )
 from mx_bluesky.hyperion.parameters.gridscan import HyperionSpecifiedThreeDGridScan
+from mx_bluesky.hyperion.parameters.rotation import RotationScan
 
 from ....conftest import fake_read, pin_tip_edge_data, raw_params_from_file
 
@@ -393,6 +394,16 @@ def pin_tip_no_pin_found(ophyd_pin_tip_detection):
 
     with patch.object(ophyd_pin_tip_detection, "trigger", side_effect=no_pin_tip_found):
         yield ophyd_pin_tip_detection
+
+
+@pytest.fixture
+def params_for_rotation_scan(test_rotation_params: RotationScan) -> RotationScan:
+    test_rotation_params.rotation_increment_deg = 0.27
+    test_rotation_params.exposure_time_s = 0.023
+    test_rotation_params.detector_params.expected_energy_ev = 0.71
+    test_rotation_params.visit = os.environ.get("ST_VISIT", "cm31105-4")
+    test_rotation_params.sample_id = int(os.environ.get("ST_SAMPLE_ID", 123456))
+    return test_rotation_params
 
 
 @pytest.fixture

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -227,7 +227,8 @@ def dummy_params():
             "tests/test_data/parameter_json_files/test_gridscan_param_defaults.json"
         )
     )
-    dummy_params.visit = "cm31105-5"
+    dummy_params.visit = os.environ.get("ST_VISIT", "cm31105-5")
+    dummy_params.sample_id = os.environ.get("ST_SAMPLE_ID", dummy_params.sample_id)
     return dummy_params
 
 

--- a/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
+++ b/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
@@ -1,18 +1,23 @@
+import os
 from time import sleep
 
 import pytest
 from requests import get
 
+from mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping import (
+    get_proposal_and_session_from_visit_string,
+)
 from mx_bluesky.common.external_interaction.ispyb.exp_eye_store import (
     BLSampleStatus,
     ExpeyeInteraction,
 )
 
 CONTAINER_ID = 288588
-SAMPLE_ID = 5289780
+
+SAMPLE_ID = int(os.environ.get("ST_SAMPLE_ID", 5289780))
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 @pytest.mark.parametrize(
     "message, expected_message",
     [
@@ -28,11 +33,14 @@ def test_start_and_end_robot_load(message: str, expected_message: str):
     https://ispyb-test.diamond.ac.uk/dc/visit/cm37235-2 and see that data is added
     when it's run.
     """
+    proposal, session = get_proposal_and_session_from_visit_string(
+        os.environ.get("ST_VISIT", "cm37235-2")
+    )
     BARCODE = "test_barcode"
 
     expeye = ExpeyeInteraction()
 
-    robot_action_id = expeye.start_load("cm37235", 2, SAMPLE_ID, 40, 3)
+    robot_action_id = expeye.start_load(proposal, session, SAMPLE_ID, 40, 3)
 
     sleep(0.5)
 
@@ -61,7 +69,7 @@ def test_start_and_end_robot_load(message: str, expected_message: str):
     assert response["message"] == expected_message
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_update_sample_updates_the_sample_status():
     sample_handling = ExpeyeInteraction()
     output_sample = sample_handling.update_sample_status(

--- a/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
+++ b/tests/system_tests/hyperion/external_interaction/test_exp_eye_dev.py
@@ -12,7 +12,7 @@ from mx_bluesky.common.external_interaction.ispyb.exp_eye_store import (
     ExpeyeInteraction,
 )
 
-CONTAINER_ID = 288588
+CONTAINER_ID = int(os.environ.get("ST_CONTAINER_ID", 288588))
 
 SAMPLE_ID = int(os.environ.get("ST_SAMPLE_ID", 5289780))
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -195,16 +195,6 @@ def scan_data_infos_for_update_3d(
     return [scan_xy_data_info_for_update, scan_xz_data_info_for_update]
 
 
-@pytest.fixture
-def params_for_rotation_scan(test_rotation_params: RotationScan):
-    test_rotation_params.rotation_increment_deg = 0.27
-    test_rotation_params.exposure_time_s = 0.023
-    test_rotation_params.detector_params.expected_energy_ev = 0.71
-    test_rotation_params.visit = os.environ.get("ST_VISIT", "cm31105-4")
-    test_rotation_params.sample_id = int(os.environ.get("ST_SAMPLE_ID", 123456))
-    return test_rotation_params
-
-
 @pytest.mark.system_test
 def test_ispyb_deposition_comment_correct_on_failure(
     dummy_ispyb: StoreInIspyb,

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -480,13 +480,13 @@ def test_ispyb_deposition_in_rotation_plan(
     )
 
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {
-        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
+        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
         ".png",
-        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
+        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
         ".png",
-        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
+        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
         ".png",
-        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456-4/snapshots/\\d{6}_oav_snapshot_270"
+        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
         ".png",
     }
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -197,7 +197,7 @@ def params_for_rotation_scan(test_rotation_params: RotationScan):
     test_rotation_params.exposure_time_s = 0.023
     test_rotation_params.detector_params.expected_energy_ev = 0.71
     test_rotation_params.visit = os.environ.get("ST_VISIT", "cm31105-4")
-    test_rotation_params.sample_id = os.environ.get("ST_SAMPLE_ID", 123456)
+    test_rotation_params.sample_id = int(os.environ.get("ST_SAMPLE_ID", 123456))
     return test_rotation_params
 
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -198,7 +198,7 @@ def params_for_rotation_scan(test_rotation_params: RotationScan):
     return test_rotation_params
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_ispyb_get_comment_from_collection_correctly(fetch_comment: Callable[..., Any]):
     expected_comment_contents = (
         "Xray centring - "
@@ -211,7 +211,7 @@ def test_ispyb_get_comment_from_collection_correctly(fetch_comment: Callable[...
     assert fetch_comment(2) == ""
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_ispyb_deposition_comment_correct_on_failure(
     dummy_ispyb: StoreInIspyb,
     fetch_comment: Callable[..., Any],
@@ -228,7 +228,7 @@ def test_ispyb_deposition_comment_correct_on_failure(
     )
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_ispyb_deposition_comment_correct_for_3D_on_failure(
     dummy_ispyb_3d: StoreInIspyb,
     fetch_comment: Callable[..., Any],
@@ -259,7 +259,7 @@ def test_ispyb_deposition_comment_correct_for_3D_on_failure(
     )
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 @pytest.mark.parametrize(
     "experiment_type, exp_num_of_grids, success",
     [
@@ -319,7 +319,7 @@ def test_can_store_2D_ispyb_data_correctly_when_in_error(
         assert fetch_comment(dc_id) == expected_comments[grid_no]
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 @pytest.mark.skip(
     "Broken, fix in https://github.com/DiamondLightSource/mx-bluesky/issues/183"
 )
@@ -461,7 +461,7 @@ def test_ispyb_deposition_in_gridscan(
     )
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_ispyb_deposition_in_rotation_plan(
     composite_for_rotation_scan: RotationScanComposite,
     params_for_rotation_scan: RotationScan,

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -46,6 +46,7 @@ from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback 
 )
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.gridscan import (
+    GridCommonWithHyperionDetectorParams,
     GridScanWithEdgeDetect,
     HyperionSpecifiedThreeDGridScan,
 )
@@ -324,7 +325,7 @@ def test_ispyb_deposition_in_gridscan(
     set_mock_value(
         grid_detect_then_xray_centre_composite.s4_slit_gaps.ygap.user_readback, 0.1
     )
-    ispyb_callback = GridscanISPyBCallback(HyperionSpecifiedThreeDGridScan)
+    ispyb_callback = GridscanISPyBCallback(GridCommonWithHyperionDetectorParams)
     RE.subscribe(ispyb_callback)
     RE(
         grid_detect_then_xray_centre(

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -51,6 +51,9 @@ from mx_bluesky.hyperion.parameters.gridscan import (
     HyperionSpecifiedThreeDGridScan,
 )
 from mx_bluesky.hyperion.parameters.rotation import RotationScan
+from unit_tests.hyperion.external_interaction.callbacks.robot_load.test_robot_load_ispyb_callback import (
+    VISIT,
+)
 
 from ...conftest import (
     DATA_COLLECTION_COLUMN_MAP,
@@ -58,6 +61,7 @@ from ...conftest import (
     compare_comment,
 )
 from .conftest import raw_params_from_file
+from .test_exp_eye_dev import SAMPLE_ID
 
 EXPECTED_DATACOLLECTION_FOR_ROTATION = {
     "wavelength": 0.71,
@@ -122,6 +126,8 @@ def grid_detect_then_xray_centre_parameters():
     json_dict = raw_params_from_file(
         "tests/test_data/parameter_json_files/ispyb_gridscan_system_test_parameters.json"
     )
+    json_dict["sample_id"] = SAMPLE_ID
+    json_dict["visit"] = VISIT
     return GridScanWithEdgeDetect(**json_dict)
 
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -350,7 +350,7 @@ def test_ispyb_deposition_in_gridscan(
         "datacollectionnumber": 1,
         "detectordistance": 100.0,
         "exposuretime": 0.12,
-        "imagedirectory": "/tmp/",
+        "imagedirectory": f"{storage_directory}/",
         "imageprefix": "file_name",
         "imagesuffix": "h5",
         "numberofpasses": 1,

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -197,6 +197,7 @@ def params_for_rotation_scan(test_rotation_params: RotationScan):
     test_rotation_params.exposure_time_s = 0.023
     test_rotation_params.detector_params.expected_energy_ev = 0.71
     test_rotation_params.visit = os.environ.get("ST_VISIT", "cm31105-4")
+    test_rotation_params.sample_id = os.environ.get("ST_SAMPLE_ID", 123456)
     return test_rotation_params
 
 
@@ -491,15 +492,14 @@ def test_ispyb_deposition_in_rotation_plan(
         fetch_comment(dcid) == "Sample position (µm): (1, 2, 3) test  Aperture: Small. "
     )
 
-    visit = params_for_rotation_scan.visit
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {
-        "xtalSnapshotFullPath1": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
+        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
         ".png",
-        "xtalSnapshotFullPath2": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
+        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
         ".png",
-        "xtalSnapshotFullPath3": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
+        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
         ".png",
-        "xtalSnapshotFullPath4": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
+        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
         ".png",
     }
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from typing import Any, Literal
@@ -195,6 +196,7 @@ def params_for_rotation_scan(test_rotation_params: RotationScan):
     test_rotation_params.rotation_increment_deg = 0.27
     test_rotation_params.exposure_time_s = 0.023
     test_rotation_params.detector_params.expected_energy_ev = 0.71
+    test_rotation_params.visit = os.environ.get("ST_VISIT", "cm31105-4")
     return test_rotation_params
 
 
@@ -489,14 +491,15 @@ def test_ispyb_deposition_in_rotation_plan(
         fetch_comment(dcid) == "Sample position (µm): (1, 2, 3) test  Aperture: Small. "
     )
 
+    visit = params_for_rotation_scan.visit
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {
-        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
+        "xtalSnapshotFullPath1": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
         ".png",
-        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
+        "xtalSnapshotFullPath2": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
         ".png",
-        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
+        "xtalSnapshotFullPath3": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
         ".png",
-        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
+        "xtalSnapshotFullPath4": f"regex:/tmp/dls/i03/data/2024/{visit}/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
         ".png",
     }
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -51,9 +51,6 @@ from mx_bluesky.hyperion.parameters.gridscan import (
     HyperionSpecifiedThreeDGridScan,
 )
 from mx_bluesky.hyperion.parameters.rotation import RotationScan
-from unit_tests.hyperion.external_interaction.callbacks.robot_load.test_robot_load_ispyb_callback import (
-    VISIT,
-)
 
 from ...conftest import (
     DATA_COLLECTION_COLUMN_MAP,
@@ -127,7 +124,7 @@ def grid_detect_then_xray_centre_parameters():
         "tests/test_data/parameter_json_files/ispyb_gridscan_system_test_parameters.json"
     )
     json_dict["sample_id"] = SAMPLE_ID
-    json_dict["visit"] = VISIT
+    json_dict["visit"] = os.environ.get("ST_VISIT", "cm31105-4")
     return GridScanWithEdgeDetect(**json_dict)
 
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -202,19 +202,6 @@ def params_for_rotation_scan(test_rotation_params: RotationScan):
 
 
 @pytest.mark.system_test
-def test_ispyb_get_comment_from_collection_correctly(fetch_comment: Callable[..., Any]):
-    expected_comment_contents = (
-        "Xray centring - "
-        "Diffraction grid scan of 1 by 41 images, "
-        "Top left [454,-4], Bottom right [455,772]"
-    )
-
-    assert fetch_comment(8292317) == expected_comment_contents
-
-    assert fetch_comment(2) == ""
-
-
-@pytest.mark.system_test
 def test_ispyb_deposition_comment_correct_on_failure(
     dummy_ispyb: StoreInIspyb,
     fetch_comment: Callable[..., Any],
@@ -493,13 +480,13 @@ def test_ispyb_deposition_in_rotation_plan(
     )
 
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {
-        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
+        "xtalSnapshotFullPath1": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_0"
         ".png",
-        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
+        "xtalSnapshotFullPath2": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_90"
         ".png",
-        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
+        "xtalSnapshotFullPath3": "regex:/tmp/dls/i03/data/2024/cm-31105-4/auto/123456/snapshots/\\d{6}_oav_snapshot_180"
         ".png",
-        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456/snapshots/\\d{6}_oav_snapshot_270"
+        "xtalSnapshotFullPath4": "regex:/tmp/dls/i03/data/2024/cm-31105/auto/123456-4/snapshots/\\d{6}_oav_snapshot_270"
         ".png",
     }
 

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -363,20 +363,20 @@ def test_ispyb_deposition_in_gridscan(
         "wavelength": 0.976254,
         "xbeam": 150.0,
         "ybeam": 160.0,
-        "xtalsnapshotfullpath1": "test_1_y",
-        "xtalsnapshotfullpath2": "test_2_y",
-        "xtalsnapshotfullpath3": "test_3_y",
+        "xtalsnapshotfullpath1": "/tmp/snapshots/file_name_1_0_grid_overlay.png",
+        "xtalsnapshotfullpath2": "/tmp/snapshots/file_name_1_0_outer_overlay.png",
+        "xtalsnapshotfullpath3": "/tmp/snapshots/file_name_1_0.png",
         "synchrotronmode": "User",
         "undulatorgap1": 1.11,
         "filetemplate": "file_name_1_master.h5",
-        "numberofimages": 20 * 12,
+        "numberofimages": 20 * 6,
     }
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_ids.data_collection_ids[0],
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 20 by 12 "
-        "images in 20.0 um by 20.0 um steps. Top left (px): [100,161], "
-        "bottom right (px): [239,244]. Small. ",
+        "MX-Bluesky: Xray centring - Diffraction grid scan of 20 by 6 "
+        "images in 20.0 um by 20.0 um steps. Top left (px): [130,130], "
+        "bottom right (px): [626,278]. Aperture: Small. ",
     )
     compare_actual_and_expected(
         ispyb_ids.data_collection_ids[0],
@@ -389,14 +389,14 @@ def test_ispyb_deposition_in_gridscan(
         "dx_mm": 0.02,
         "dy_mm": 0.02,
         "steps_x": 20,
-        "steps_y": 12,
-        "snapshot_offsetXPixel": 100,
-        "snapshot_offsetYPixel": 161,
+        "steps_y": 6,
+        "snapshot_offsetXPixel": 130,
+        "snapshot_offsetYPixel": 130,
         "orientation": "horizontal",
         "snaked": True,
         "dataCollectionId": ispyb_ids.data_collection_ids[0],
-        "micronsPerPixelX": 2.87,
-        "micronsPerPixelY": 2.87,
+        "micronsPerPixelX": 0.806,
+        "micronsPerPixelY": 0.806,
     }
 
     compare_actual_and_expected(
@@ -416,7 +416,10 @@ def test_ispyb_deposition_in_gridscan(
             "datacollectionnumber": 2,
             "omegastart": 90.0,
             "filetemplate": "file_name_2_master.h5",
-            "numberofimages": 220,
+            "xtalsnapshotfullpath1": "/tmp/snapshots/file_name_1_90_grid_overlay.png",
+            "xtalsnapshotfullpath2": "/tmp/snapshots/file_name_1_90_outer_overlay.png",
+            "xtalsnapshotfullpath3": "/tmp/snapshots/file_name_1_90.png",
+            "numberofimages": 20 * 6,
         }
     )
     compare_actual_and_expected(
@@ -428,9 +431,9 @@ def test_ispyb_deposition_in_gridscan(
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_ids.data_collection_ids[1],
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 20 by 11 "
-        "images in 20.0 um by 20.0 um steps. Top left (px): [100,165], "
-        "bottom right (px): [239,241]. Small. ",
+        "MX-Bluesky: Xray centring - Diffraction grid scan of 20 by 6 "
+        "images in 20.0 um by 20.0 um steps. Top left (px): [130,130], "
+        "bottom right (px): [626,278]. Aperture: Small. ",
     )
     position_id = fetch_datacollection_attribute(
         ispyb_ids.data_collection_ids[1], DATA_COLLECTION_COLUMN_MAP["positionid"]
@@ -439,8 +442,8 @@ def test_ispyb_deposition_in_gridscan(
     GRIDINFO_EXPECTED_VALUES.update(
         {
             "gridInfoId": ispyb_ids.grid_ids[1],
-            "steps_y": 11.0,
-            "snapshot_offsetYPixel": 165.0,
+            "steps_y": 6.0,
+            "snapshot_offsetYPixel": 130.0,
             "dataCollectionId": ispyb_ids.data_collection_ids[1],
         }
     )

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -310,9 +310,6 @@ def test_can_store_2D_ispyb_data_correctly_when_in_error(
 
 
 @pytest.mark.system_test
-@pytest.mark.skip(
-    "Broken, fix in https://github.com/DiamondLightSource/mx-bluesky/issues/183"
-)
 def test_ispyb_deposition_in_gridscan(
     RE: RunEngine,
     grid_detect_then_xray_centre_composite: GridDetectThenXRayCentreComposite,

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -119,12 +119,18 @@ def dummy_scan_data_info_for_begin(dummy_params):
 
 
 @pytest.fixture
-def grid_detect_then_xray_centre_parameters():
+def storage_directory(tmp_path) -> str:
+    return str(tmp_path)
+
+
+@pytest.fixture
+def grid_detect_then_xray_centre_parameters(storage_directory):
     json_dict = raw_params_from_file(
         "tests/test_data/parameter_json_files/ispyb_gridscan_system_test_parameters.json"
     )
     json_dict["sample_id"] = SAMPLE_ID
     json_dict["visit"] = os.environ.get("ST_VISIT", "cm31105-4")
+    json_dict["storage_directory"] = storage_directory
     return GridScanWithEdgeDetect(**json_dict)
 
 
@@ -311,6 +317,7 @@ def test_ispyb_deposition_in_gridscan(
     fetch_datacollection_attribute: Callable[..., Any],
     fetch_datacollection_grid_attribute: Callable[..., Any],
     fetch_datacollection_position_attribute: Callable[..., Any],
+    storage_directory: str,
 ):
     set_mock_value(
         grid_detect_then_xray_centre_composite.s4_slit_gaps.xgap.user_readback, 0.1
@@ -353,9 +360,9 @@ def test_ispyb_deposition_in_gridscan(
         "wavelength": 0.976254,
         "xbeam": 150.0,
         "ybeam": 160.0,
-        "xtalsnapshotfullpath1": "/tmp/snapshots/file_name_1_0_grid_overlay.png",
-        "xtalsnapshotfullpath2": "/tmp/snapshots/file_name_1_0_outer_overlay.png",
-        "xtalsnapshotfullpath3": "/tmp/snapshots/file_name_1_0.png",
+        "xtalsnapshotfullpath1": f"{storage_directory}/snapshots/file_name_1_0_grid_overlay.png",
+        "xtalsnapshotfullpath2": f"{storage_directory}/snapshots/file_name_1_0_outer_overlay.png",
+        "xtalsnapshotfullpath3": f"{storage_directory}/snapshots/file_name_1_0.png",
         "synchrotronmode": "User",
         "undulatorgap1": 1.11,
         "filetemplate": "file_name_1_master.h5",
@@ -406,9 +413,9 @@ def test_ispyb_deposition_in_gridscan(
             "datacollectionnumber": 2,
             "omegastart": 90.0,
             "filetemplate": "file_name_2_master.h5",
-            "xtalsnapshotfullpath1": "/tmp/snapshots/file_name_1_90_grid_overlay.png",
-            "xtalsnapshotfullpath2": "/tmp/snapshots/file_name_1_90_outer_overlay.png",
-            "xtalsnapshotfullpath3": "/tmp/snapshots/file_name_1_90.png",
+            "xtalsnapshotfullpath1": f"{storage_directory}/snapshots/file_name_1_90_grid_overlay.png",
+            "xtalsnapshotfullpath2": f"{storage_directory}/snapshots/file_name_1_90_outer_overlay.png",
+            "xtalsnapshotfullpath3": f"{storage_directory}/snapshots/file_name_1_90.png",
             "numberofimages": 20 * 6,
         }
     )

--- a/tests/system_tests/hyperion/external_interaction/test_nexgen.py
+++ b/tests/system_tests/hyperion/external_interaction/test_nexgen.py
@@ -137,7 +137,10 @@ def _check_nexgen_output_passes_imginfo(test_file, reference_file):
 
 def _run_imginfo(filename):
     process = subprocess.run(
-        ["utility_scripts/run_imginfo.sh", filename], text=True, capture_output=True
+        # This file is provided in the system test docker image
+        ["/usr/local/bin/imginfo", filename],
+        text=True,
+        capture_output=True,
     )
     assert process.returncode != 2, "imginfo is not available"
     assert process.returncode == 0, (

--- a/tests/system_tests/hyperion/external_interaction/test_nexgen.py
+++ b/tests/system_tests/hyperion/external_interaction/test_nexgen.py
@@ -55,7 +55,7 @@ def test_params(tmpdir):
         ),
     ],
 )
-@pytest.mark.s03
+@pytest.mark.system_test
 def test_rotation_nexgen(
     test_params: RotationScan,
     tmpdir,

--- a/tests/system_tests/hyperion/external_interaction/test_zocalo_system.py
+++ b/tests/system_tests/hyperion/external_interaction/test_zocalo_system.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 from bluesky.run_engine import RunEngine
 from dodal.devices.zocalo import ZOCALO_READING_PLAN_NAME, ZocaloResults
+from dodal.utils import is_test_mode
 
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
     ispyb_activation_wrapper,
@@ -106,7 +107,12 @@ def run_zocalo_with_dev_ispyb(
     return inner
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
+def test_is_test_mode():
+    assert is_test_mode(), "DODAL_TEST_MODE must be set in environment before launch"
+
+
+@pytest.mark.system_test
 async def test_given_a_result_with_no_diffraction_when_zocalo_called_then_move_to_fallback(
     run_zocalo_with_dev_ispyb, zocalo_env
 ):
@@ -115,7 +121,7 @@ async def test_given_a_result_with_no_diffraction_when_zocalo_called_then_move_t
     assert np.allclose(centre, fallback)
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 async def test_given_a_result_with_no_diffraction_ispyb_comment_updated(
     run_zocalo_with_dev_ispyb, zocalo_env, fetch_comment
 ):
@@ -125,7 +131,7 @@ async def test_given_a_result_with_no_diffraction_ispyb_comment_updated(
     assert "Zocalo found no crystals in this gridscan." in comment
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 async def test_zocalo_adds_nonzero_comment_time(
     run_zocalo_with_dev_ispyb, zocalo_env, fetch_comment
 ):
@@ -139,7 +145,7 @@ async def test_zocalo_adds_nonzero_comment_time(
     assert time_s < 180
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 async def test_given_a_single_crystal_result_ispyb_comment_updated(
     run_zocalo_with_dev_ispyb, zocalo_env, fetch_comment
 ):
@@ -150,7 +156,7 @@ async def test_given_a_single_crystal_result_ispyb_comment_updated(
     assert "Size (grid boxes)" in comment
 
 
-@pytest.mark.s03
+@pytest.mark.system_test
 async def test_given_a_result_with_multiple_crystals_ispyb_comment_updated(
     run_zocalo_with_dev_ispyb, zocalo_env, fetch_comment
 ):

--- a/tests/test_data/nexus_files/rotation/ins_8_5_expected_output.txt
+++ b/tests/test_data/nexus_files/rotation/ins_8_5_expected_output.txt
@@ -53,7 +53,7 @@
  wavelength                      [A] = 0.976254
  sensor thickness               [mm] = 0.450
  sensor material                     = Si
- Phi-angle                  [degree] = 0.00000
+ Phi-angle                  [degree] = 0.47000
  Omega-angle (start, end)   [degree] = 0.00000 0.10000
  Oscillation-angle in Omega [degree] = 0.10000
  Chi-angle                  [degree] = 23.85000

--- a/tests/test_data/nexus_files/rotation_unicode_metafile/ins_8_5_expected_output.txt
+++ b/tests/test_data/nexus_files/rotation_unicode_metafile/ins_8_5_expected_output.txt
@@ -53,7 +53,7 @@
  wavelength                      [A] = 0.976254
  sensor thickness               [mm] = 0.450
  sensor material                     = Si
- Phi-angle                  [degree] = 0.00000
+ Phi-angle                  [degree] = 0.47000
  Omega-angle (start, end)   [degree] = 0.00000 0.10000
  Oscillation-angle in Omega [degree] = 0.10000
  Chi-angle                  [degree] = 23.85000


### PR DESCRIPTION
This addresses 

* #632 

and builds on

* #793

it also requires

* DiamondLightSource/dodal#1049
* https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/merge_requests/2

These changes fix up and enable the following system tests when the containerised system tests are run:

* `test_external_callbacks`   -- external callback launching
* `test_exp_eye_dev` -- ExpEye integration
* `test_ispyb_dev_connection` -- ISPyB integration
* `test_nexgen` -- imginfo integration
* `test_zocalo_system` -- zocalo integration (using the "fake" zocalo

`test_config_service` is not currently included, to include this ideally we should make changes to the `daq-config-server` images so that instead of creating dev/production images with hard-coded configurations, it pushes a single set of images which are fully configurable for either production or development/test environments. See

* #817 

