### PR TITLE
731 Add source IP access control to k8s hyperion

### DIFF
--- a/docs/developer/hyperion/deploying-hyperion.rst
+++ b/docs/developer/hyperion/deploying-hyperion.rst
@@ -100,9 +100,10 @@ The dev deployment bind-mounts the current ``hyperion`` workspace and ``../dodal
 run against your own development code. **Clusters do not allow bind mounts from arbitrary directories so
 your workspace will have to be in a permitted directory such as your home directory.**
 
-By default the script will log into the ``argus`` cluster, if you want to deploy to an alternate cluster,
-log in with ``kubectl set-context --current --namespace=<NAMESPACE>`` and then specify ``--no-login`` when running the
-script
+By default the script will log into the ``argus`` cluster if ``--dev`` is specified, otherwise the beamline cluster.
+If you want to deploy to an alternate namespace/cluster, change cluster with ``module load <cluster module>``
+and then set your namespace with ``kubectl config set-context --current --namespace=<NAMESPACE>`` and then
+specify ``--no-login`` when running the script.
 
 Please note, the deployment script is intended to be run from a checked-out matching version of the git repository.
 

--- a/helmchart/templates/ingress.yaml
+++ b/helmchart/templates/ingress.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hyperion-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.subnet }}
 spec:
   ingressClassName: nginx
   tls:

--- a/helmchart/templates/ingress.yaml
+++ b/helmchart/templates/ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: hyperion-ingress
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.subnet }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.hyperion.subnet }}
 spec:
   ingressClassName: nginx
   tls:

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -14,6 +14,7 @@ hyperion:
   projectDir: SET_ON_INSTALL
   appVersion: SET_ON_INSTALL
   externalHostname: i03-hyperion.diamond.ac.uk
+  subnet: "172.23.103.64/24"
 dodal:
   projectDir: SET_ON_INSTALL
 service:

--- a/utility_scripts/build_docker_image.sh
+++ b/utility_scripts/build_docker_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# builds the docker image
+# Convenience script for building development versions of the docker image
 BUILD=1
 PUSH=1
 PODMAN_FLAGS=""
@@ -21,7 +21,8 @@ for option in "$@"; do
         --help|--info|--h)
             CMD=`basename $0`
             echo "$CMD [options]"
-            echo "Builds and/or pushes the docker container image to the repository"
+            echo "Convenience script for building and/or pushing development versions of the docker container image"
+            echo "to a repository"
             echo "  --help                  This help"
             echo "  --no-build              Do not build the image"
             echo "  --no-push               Do not push the image"
@@ -73,5 +74,5 @@ if [[ $PUSH == 1 ]]; then
   fi
   echo "Pushing to ghcr.io/$NAMESPACE/$IMAGE:latest ..."
   podman push $IMAGE:latest docker://ghcr.io/$NAMESPACE/$IMAGE:latest
-  podman push $IMAGE:latest docker://ghcr.io/$NAMESPACE/$IMAGE:$IMAGE_VERSION
+  podman push $IMAGE:latest docker://ghcr.io/$NAMESPACE/$IMAGE:v$IMAGE_VERSION
 fi

--- a/utility_scripts/deploy/deploy_hyperion_to_k8s.sh
+++ b/utility_scripts/deploy/deploy_hyperion_to_k8s.sh
@@ -143,8 +143,8 @@ if [[ -n $REPOSITORY ]]; then
   HELM_OPTIONS+="--set hyperion.imageRepository=$REPOSITORY "
 fi
 
-ensure_version_py
 if [[ -z $APP_VERSION ]]; then
+  ensure_version_py
   APP_VERSION=$(app_version)
 fi
 

--- a/utility_scripts/deploy/deploy_hyperion_to_k8s.sh
+++ b/utility_scripts/deploy/deploy_hyperion_to_k8s.sh
@@ -171,7 +171,7 @@ hyperion.externalHostname=test-hyperion.diamond.ac.uk "
   mkdir -p $PROJECTDIR/tmp/data
   DEPLOYMENT_DIR=$PROJECTDIR
 else
-  DEPLOYMENT_DIR=/dls_sw/i03/software/bluesky/mx-bluesky_v${APP_VERSION}/mx-bluesky
+  DEPLOYMENT_DIR=/dls_sw/i03/software/bluesky/mx-bluesky_v${CHECKED_OUT_VERSION}/mx-bluesky
 fi
 
 HELM_OPTIONS+="--set hyperion.appVersion=v$APP_VERSION,\


### PR DESCRIPTION
This addresses
* #731 

It adds an annotation to the `ingress.yml` that whitelists the beamline subnet, this in conjuction with a change to the DNS entry in SCHD-7502 servicedesk ticket that ensures source IPs are preserved in requests, enables requests to `i03-hyperion.diamond.ac.uk` to be only allowed for hosts on the beamline.

In addition this PR contains various other minor fixes to deployment / image build scripts / documentation to make it easier to deploy test images.

Acceptance criteria:

* Requests to `i03-hyperion.diamond.ac.uk` can't be made from outside the i03 beamline.
