### PR TITLE
Make it clear to a user that we're skipping collections after blank XRC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.9.0a2",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@ffdd9e8434d5e7975f618307cd10fe9e5f97a999",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.9.0a2",
     "bluesky >= 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@ffdd9e8434d5e7975f618307cd10fe9e5f97a999",
 ]
 
 

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -43,7 +43,11 @@ from mx_bluesky.common.parameters.constants import DocDescriptorNames, PlanNameC
 from mx_bluesky.common.parameters.gridscan import (
     GridCommon,
 )
-from mx_bluesky.common.utils.exceptions import ISPyBDepositionNotMade
+from mx_bluesky.common.utils.exceptions import (
+    CrystalNotFoundException,
+    ISPyBDepositionNotMade,
+    SampleException,
+)
 from mx_bluesky.common.utils.log import ISPYB_ZOCALO_CALLBACK_LOGGER, set_dcgid_tag
 
 if TYPE_CHECKING:
@@ -281,8 +285,10 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             )
             if self.ispyb_ids == IspybIds():
                 raise ISPyBDepositionNotMade("ispyb was not initialised at run start")
-            reason = doc.get("reason") or ""
-            if "CrystalNotFoundException" in reason:
-                doc["reason"] = "Diffraction not found, skipping sample."
+            exception_type, message = SampleException.type_and_message_from_reason(
+                doc.get("reason", "")
+            )
+            if exception_type == CrystalNotFoundException.__name__:
+                doc["reason"] = message
             return super().activity_gated_stop(doc)
         return self._tag_doc(doc)

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -281,5 +281,8 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             )
             if self.ispyb_ids == IspybIds():
                 raise ISPyBDepositionNotMade("ispyb was not initialised at run start")
+            reason = doc.get("reason") or ""
+            if "CrystalNotFoundException" in reason:
+                doc["reason"] = "Diffraction not found, skipping sample."
             return super().activity_gated_stop(doc)
         return self._tag_doc(doc)

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -288,7 +288,7 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             exception_type, message = SampleException.type_and_message_from_reason(
                 doc.get("reason", "")
             )
-            if exception_type == CrystalNotFoundException.__name__:
+            if exception_type:
                 doc["reason"] = message
             return super().activity_gated_stop(doc)
         return self._tag_doc(doc)

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -44,7 +44,6 @@ from mx_bluesky.common.parameters.gridscan import (
     GridCommon,
 )
 from mx_bluesky.common.utils.exceptions import (
-    CrystalNotFoundException,
     ISPyBDepositionNotMade,
     SampleException,
 )

--- a/src/mx_bluesky/common/utils/exceptions.py
+++ b/src/mx_bluesky/common/utils/exceptions.py
@@ -39,7 +39,8 @@ T = TypeVar("T")
 class CrystalNotFoundException(SampleException):
     """Raised if grid detection completed normally but no crystal was found."""
 
-    pass
+    def __init__(self):
+        super().__init__("Diffraction not found, skipping sample.")
 
 
 def catch_exception_and_warn(

--- a/src/mx_bluesky/common/utils/exceptions.py
+++ b/src/mx_bluesky/common/utils/exceptions.py
@@ -39,7 +39,7 @@ T = TypeVar("T")
 class CrystalNotFoundException(SampleException):
     """Raised if grid detection completed normally but no crystal was found."""
 
-    def __init__(self):
+    def __init__(self, *args):
         super().__init__("Diffraction not found, skipping sample.")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1215,6 +1215,13 @@ class TestData(OavGridSnapshotTestEvents):
         "subplan_name": PlanNameConstants.GRID_DETECT_AND_DO_GRIDSCAN,
         "mx_bluesky_parameters": dummy_params().model_dump_json(),
     }
+    test_gridscan3d_stop_document_with_crystal_exception: RunStop = {
+        "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+        "time": 1666604299.6149616,
+        "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
+        "exit_status": "fail",
+        "reason": "CrystalNotFoundException",
+    }
     test_gridscan2d_start_document = {
         "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
         "time": 1666604299.6149616,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1223,7 +1223,7 @@ class TestData(OavGridSnapshotTestEvents):
         "time": 1666604299.6149616,
         "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
         "exit_status": "fail",
-        "reason": f"{str(CrystalNotFoundException())}",
+        "reason": f"{CrystalNotFoundException()}",
     }
     test_gridscan2d_start_document = {
         "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ from mx_bluesky.common.parameters.constants import (
     PlanNameConstants,
     TriggerConstants,
 )
+from mx_bluesky.common.utils.exceptions import (
+    CrystalNotFoundException,
+)
 from mx_bluesky.common.utils.log import (
     ALL_LOGGERS,
     ISPYB_ZOCALO_CALLBACK_LOGGER,
@@ -1220,7 +1223,7 @@ class TestData(OavGridSnapshotTestEvents):
         "time": 1666604299.6149616,
         "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
         "exit_status": "fail",
-        "reason": "CrystalNotFoundException",
+        "reason": f"{str(CrystalNotFoundException())}",
     }
     test_gridscan2d_start_document = {
         "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
@@ -84,6 +84,23 @@ class TestXrayCentreISPyBCallback:
         mx_acq.upsert_data_collection.update_dc_position.assert_not_called()
         mx_acq.upsert_data_collection.upsert_dc_grid.assert_not_called()
 
+    def test_reason_provided_if_crystal_not_found_error(self, mock_ispyb_conn):
+        callback = GridscanISPyBCallback(
+            param_type=GridCommonWithHyperionDetectorParams
+        )
+        callback.activity_gated_start(TestData.test_gridscan3d_start_document)  # pyright: ignore
+        mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
+        callback.activity_gated_stop(
+            TestData.test_gridscan3d_stop_document_with_crystal_exception
+        )
+        assert mx_acq.update_data_collection_append_comments.call_args_list[0] == (
+            (
+                TEST_DATA_COLLECTION_IDS[0],
+                "DataCollection Unsuccessful reason: Diffraction not found, skipping sample.",
+                " ",
+            ),
+        )
+
     def test_hardware_read_event_3d(self, mock_ispyb_conn):
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams


### PR DESCRIPTION
Fixes issue #784 
Added the hotfix @DominicOram wrote in the beamline deployment, and a unit test to test the ispyb callback stop event.