### PR TITLE
Change error_code references for bart robot

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
@@ -120,7 +120,7 @@ def do_robot_load(
     demand_energy_ev: float | None,
     thawing_time: float,
 ):
-    error_code = yield from bps.rd(composite.robot.error_code)
+    error_code = yield from bps.rd(composite.robot.controller_error.code)
     # Reset robot if light curtains were tripped
     if error_code == 40:
         yield from bps.trigger(composite.robot.reset, wait=True)

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -189,7 +189,9 @@ async def test_when_error_40_reset_robot_before_load(
 
     demand_energy_ev = robot_load_and_energy_change_params.demand_energy_ev
 
-    set_mock_value(robot_load_and_energy_change_composite.robot.error_code, 40)
+    set_mock_value(
+        robot_load_and_energy_change_composite.robot.controller_error.code, 40
+    )
 
     RE = RunEngine()
     RE(


### PR DESCRIPTION
Now that dodal issue [1036](https://github.com/DiamondLightSource/dodal/pull/1036) is merged, testing is failing due to an incorrect PV name, so this PR amends the references to the PV.