### PR TITLE
785 Write XRC results to alphabetically first comment so that they appear in Synchweb

### DIFF
--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -116,7 +116,7 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             scan_data_infos = [
                 ScanDataInfo(
                     data_collection_info=populate_remaining_data_collection_info(
-                        None,
+                        "MX-Bluesky: Xray centring 1 -",
                         None,
                         populate_xy_data_collection_info(
                             self.params.detector_params,
@@ -126,7 +126,7 @@ class GridscanISPyBCallback(BaseISPyBCallback):
                 ),
                 ScanDataInfo(
                     data_collection_info=populate_remaining_data_collection_info(
-                        None,
+                        "MX-Bluesky: Xray centring 2 -",
                         None,
                         populate_xz_data_collection_info(self.params.detector_params),
                         self.params,

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_mapping.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_mapping.py
@@ -43,7 +43,7 @@ def construct_comment_for_gridscan(grid_info: DataCollectionGridInfo) -> str:
         grid_info.microns_per_pixel_y,
     )
     return (
-        "MX-Bluesky: Xray centring - Diffraction grid scan of "
+        "Diffraction grid scan of "
         f"{grid_info.steps_x} by "
         f"{grid_info.steps_y} images in "
         f"{(grid_info.dx_in_mm * 1e3):.1f} um by "

--- a/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
+++ b/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
@@ -206,9 +206,16 @@ class StoreInIspyb:
     def _store_data_collection_table(
         self, conn, data_collection_id, data_collection_info
     ):
+        if data_collection_id and data_collection_info.comments:
+            self.append_to_comment(
+                data_collection_id, data_collection_info.comments, " "
+            )
+            data_collection_info.comments = None
+
         params = self._fill_common_data_collection_params(
             conn, data_collection_id, data_collection_info
         )
+
         return self._upsert_data_collection(conn, params)
 
     def _store_single_scan_data(

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -136,7 +136,7 @@ class RotationISPyBCallback(BaseISPyBCallback):
             "handle_ispyb_hardware_read triggered before activity_gated_start"
         )
         motor_positions_um = [position * 1000 for position in motor_positions_mm]
-        comment = f"Sample position (µm): ({motor_positions_um[0]:.0f}, {motor_positions_um[1]:.0f}, {motor_positions_um[2]:.0f}) {self.params.comment} "
+        comment = f"Sample position (µm): ({motor_positions_um[0]:.0f}, {motor_positions_um[1]:.0f}, {motor_positions_um[2]:.0f})"
         scan_data_infos[0].data_collection_info.comments = comment
         return scan_data_infos
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,47 @@ i03.DAQ_CONFIGURATION_PATH = "tests/test_data/test_daq_configuration"
 
 TEST_GRAYLOG_PORT = 5555
 
+TEST_RESULT_LARGE = [
+    {
+        "centre_of_mass": [1, 2, 3],
+        "max_voxel": [1, 2, 3],
+        "max_count": 105062,
+        "n_voxels": 35,
+        "total_count": 2387574,
+        "bounding_box": [[2, 2, 2], [8, 8, 7]],
+    }
+]
+TEST_RESULT_MEDIUM = [
+    {
+        "centre_of_mass": [1, 2, 3],
+        "max_voxel": [2, 4, 5],
+        "max_count": 50000,
+        "n_voxels": 35,
+        "total_count": 100000,
+        "bounding_box": [[1, 2, 3], [3, 4, 4]],
+    }
+]
+TEST_RESULT_SMALL = [
+    {
+        "centre_of_mass": [1, 2, 3],
+        "max_voxel": [1, 2, 3],
+        "max_count": 1000,
+        "n_voxels": 35,
+        "total_count": 1000,
+        "bounding_box": [[2, 2, 2], [3, 3, 3]],
+    }
+]
+TEST_RESULT_BELOW_THRESHOLD = [
+    {
+        "centre_of_mass": [2, 3, 4],
+        "max_voxel": [2, 3, 4],
+        "max_count": 2,
+        "n_voxels": 1,
+        "total_count": 2,
+        "bounding_box": [[1, 2, 3], [2, 3, 4]],
+    }
+]
+
 
 @pytest.fixture(scope="session")
 def active_device_factories() -> set[AnyDeviceFactory]:

--- a/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -35,10 +35,8 @@ from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.gridscan import HyperionSpecifiedThreeDGridScan
 from mx_bluesky.hyperion.parameters.rotation import RotationScan
 
-from .....conftest import fake_read
+from .....conftest import TEST_RESULT_LARGE, fake_read
 from ..conftest import (  # noqa
-    TEST_RESULT_LARGE,
-    TEST_RESULT_MEDIUM,
     fetch_comment,
     zocalo_env,
 )

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -54,48 +54,12 @@ from mx_bluesky.hyperion.experiment_plans.rotation_scan_plan import (
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.gridscan import HyperionSpecifiedThreeDGridScan
 
-from ....conftest import fake_read, pin_tip_edge_data, raw_params_from_file
-
-TEST_RESULT_LARGE = [
-    {
-        "centre_of_mass": [1, 2, 3],
-        "max_voxel": [1, 2, 3],
-        "max_count": 105062,
-        "n_voxels": 35,
-        "total_count": 2387574,
-        "bounding_box": [[2, 2, 2], [8, 8, 7]],
-    }
-]
-TEST_RESULT_MEDIUM = [
-    {
-        "centre_of_mass": [1, 2, 3],
-        "max_voxel": [2, 4, 5],
-        "max_count": 50000,
-        "n_voxels": 35,
-        "total_count": 100000,
-        "bounding_box": [[1, 2, 3], [3, 4, 4]],
-    }
-]
-TEST_RESULT_SMALL = [
-    {
-        "centre_of_mass": [1, 2, 3],
-        "max_voxel": [1, 2, 3],
-        "max_count": 1000,
-        "n_voxels": 35,
-        "total_count": 1000,
-        "bounding_box": [[2, 2, 2], [3, 3, 3]],
-    }
-]
-TEST_RESULT_BELOW_THRESHOLD = [
-    {
-        "centre_of_mass": [2, 3, 4],
-        "max_voxel": [2, 3, 4],
-        "max_count": 2,
-        "n_voxels": 1,
-        "total_count": 2,
-        "bounding_box": [[1, 2, 3], [2, 3, 4]],
-    }
-]
+from ....conftest import (
+    TEST_RESULT_MEDIUM,
+    fake_read,
+    pin_tip_edge_data,
+    raw_params_from_file,
+)
 
 
 def get_current_datacollection_comment(Session: Callable, dcid: int) -> str:

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -277,14 +277,14 @@ def test_execute_load_centre_collect_full(
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_gridscan_cb.ispyb_ids.data_collection_ids[0],
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 30 by 6 "
+        "MX-Bluesky: Xray centring 1 - Diffraction grid scan of 30 by 6 "
         "images in 20.0 um by 20.0 um steps. Top left (px): [130,130], "
         "bottom right (px): [874,278]. Aperture: Small. ",
     )
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_gridscan_cb.ispyb_ids.data_collection_ids[1],
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 30 by 6 "
+        "MX-Bluesky: Xray centring 2 - Diffraction grid scan of 30 by 6 "
         "images in 20.0 um by 20.0 um steps. Top left (px): [130,130], "
         "bottom right (px): [874,278]. Aperture: Small. ",
     )
@@ -310,7 +310,8 @@ def test_execute_load_centre_collect_full(
     compare_comment(
         fetch_datacollection_attribute,
         ispyb_rotation_cb.ispyb_ids.data_collection_ids[0],
-        "Sample position (µm): (-2309, -591, 341) Hyperion Rotation Scan -   Aperture: Small. ",
+        "Hyperion Rotation Scan -  Sample position (µm): (-2309, -591, 341) Aperture: "
+        "Small. ",
     )
     assert fetch_blsample(SAMPLE_ID).blSampleStatus == "LOADED"  # type: ignore
 

--- a/tests/unit_tests/common/external_interaction/callbacks/ispyb/test_gridscan_ispyb_store_3d.py
+++ b/tests/unit_tests/common/external_interaction/callbacks/ispyb/test_gridscan_ispyb_store_3d.py
@@ -1,3 +1,6 @@
+from dataclasses import replace
+from functools import partial
+from itertools import dropwhile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,11 +26,11 @@ from ......conftest import (
     TEST_DATA_COLLECTION_GROUP_ID,
     TEST_DATA_COLLECTION_IDS,
     TEST_GRID_INFO_IDS,
-    TEST_POSITION_ID,
     TEST_SAMPLE_ID,
     TEST_SESSION_ID,
     assert_upsert_call_with,
     mx_acquisition_from_conn,
+    remap_upsert_columns,
 )
 
 
@@ -40,97 +43,169 @@ def dummy_collection_group_info():
     )
 
 
+DC_INFO_FOR_BEGIN_XY = DataCollectionInfo(
+    omega_start=0.0,
+    data_collection_number=1,
+    xtal_snapshot1="test_1_y",
+    xtal_snapshot2="test_2_y",
+    xtal_snapshot3="test_3_y",
+    n_images=800,
+    axis_range=0,
+    axis_end=0.0,
+    kappa_start=None,
+    parent_id=None,
+    visit_string="cm31105-4",
+    sample_id=364758,
+    detector_id=78,
+    axis_start=0.0,
+    focal_spot_size_at_samplex=0.0,
+    focal_spot_size_at_sampley=0.0,
+    slitgap_vertical=0.1,
+    slitgap_horizontal=0.1,
+    beamsize_at_samplex=0.1,
+    beamsize_at_sampley=0.1,
+    transmission=100.0,
+    comments="MX-Bluesky: Xray centring 1 -",
+    detector_distance=100.0,
+    exp_time=0.1,
+    imgdir="/tmp/",
+    file_template="file_name_0_master.h5",
+    imgprefix="file_name",
+    imgsuffix="h5",
+    n_passes=1,
+    overlap=0,
+    start_image_number=1,
+    wavelength=123.98419840550369,
+    xbeam=150.0,
+    ybeam=160.0,
+    synchrotron_mode=None,
+    undulator_gap1=1.0,
+    start_time=EXPECTED_START_TIME,
+)
+
+DC_INFO_FOR_BEGIN_XZ = replace(
+    DC_INFO_FOR_BEGIN_XY,
+    xtal_snapshot1="test_1_z",
+    xtal_snapshot2="test_2_z",
+    xtal_snapshot3="test_3_z",
+    omega_start=90.0,
+    n_images=400,
+    axis_end=90.0,
+    axis_start=90.0,
+    file_template="file_name_1_master.h5",
+    comments="MX-Bluesky: Xray centring 2 -",
+)
+
+DC_INFO_FOR_UPDATE_XY = replace(
+    DC_INFO_FOR_BEGIN_XY,
+    parent_id=34,
+    comments="Diffraction grid scan of 40 by 20 images in 100.0 um by 100.0 um steps. Top left (px): [50,100], bottom right (px): [3250,1700].",
+    flux=10.0,
+    synchrotron_mode="test",
+)
+
+DC_INFO_FOR_UPDATE_XZ = replace(
+    DC_INFO_FOR_BEGIN_XZ,
+    parent_id=34,
+    comments="Diffraction grid scan of 40 by 10 images in 100.0 um by 200.0 um steps. Top left (px): [50,120], bottom right (px): [3250,1720].",
+    flux=10.0,
+    synchrotron_mode="test",
+)
+
+EXPECTED_BASE_UPSERT = {
+    "visitid": TEST_SESSION_ID,
+    "parentid": TEST_DATA_COLLECTION_GROUP_ID,
+    "sampleid": TEST_SAMPLE_ID,
+    "detectorid": 78,
+    "axisrange": 0,
+    "focal_spot_size_at_samplex": 0.0,
+    "focal_spot_size_at_sampley": 0.0,
+    "slitgap_vertical": 0.1,
+    "slitgap_horizontal": 0.1,
+    "beamsize_at_samplex": 0.1,
+    "beamsize_at_sampley": 0.1,
+    "transmission": 100.0,
+    "data_collection_number": 1,
+    "detector_distance": 100.0,
+    "exp_time": 0.1,
+    "imgdir": "/tmp/",
+    "imgprefix": "file_name",
+    "imgsuffix": "h5",
+    "n_passes": 1,
+    "overlap": 0,
+    "start_image_number": 1,
+    "wavelength": 123.98419840550369,
+    "xbeam": 150.0,
+    "ybeam": 160.0,
+    "undulator_gap1": 1.0,
+    "starttime": EXPECTED_START_TIME,
+}
+
+EXPECTED_BASE_XY_UPSERT = EXPECTED_BASE_UPSERT | {
+    "xtal_snapshot1": "test_1_y",
+    "xtal_snapshot2": "test_2_y",
+    "xtal_snapshot3": "test_3_y",
+    "omegastart": 0,
+    "axisstart": 0.0,
+    "axisend": 0,
+    "filetemplate": "file_name_0_master.h5",
+    "nimages": 40 * 20,
+}
+
+EXPECTED_BASE_XZ_UPSERT = EXPECTED_BASE_UPSERT | {
+    "xtal_snapshot1": "test_1_z",
+    "xtal_snapshot2": "test_2_z",
+    "xtal_snapshot3": "test_3_z",
+    "omegastart": 90.0,
+    "axisstart": 90.0,
+    "axisend": 90.0,
+    "filetemplate": "file_name_1_master.h5",
+    "nimages": 40 * 10,
+}
+
+EXPECTED_DC_XY_BEGIN_UPSERT = EXPECTED_BASE_XY_UPSERT | {
+    "comments": "MX-Bluesky: Xray centring 1 -",
+}
+
+EXPECTED_DC_XZ_BEGIN_UPSERT = EXPECTED_BASE_XZ_UPSERT | {
+    "comments": "MX-Bluesky: Xray centring 2 -",
+}
+
+EXPECTED_DC_XY_UPDATE_UPSERT = EXPECTED_BASE_XY_UPSERT | {
+    "id": 12,
+    "flux": 10.0,
+    "synchrotron_mode": "test",
+}
+
+EXPECTED_DC_XZ_UPDATE_UPSERT = EXPECTED_BASE_XZ_UPSERT | {
+    "id": 13,
+    "flux": 10,
+    "synchrotron_mode": "test",
+}
+
+
 @pytest.fixture
-def scan_data_info_for_begin():
-    return ScanDataInfo(
-        data_collection_info=DataCollectionInfo(
-            omega_start=0.0,
-            data_collection_number=1,
-            xtal_snapshot1="test_1_y",
-            xtal_snapshot2="test_2_y",
-            xtal_snapshot3="test_3_y",
-            n_images=800,
-            axis_range=0,
-            axis_end=0.0,
-            kappa_start=None,
-            parent_id=None,
-            visit_string="cm31105-4",
-            sample_id=364758,
-            detector_id=78,
-            axis_start=0.0,
-            focal_spot_size_at_samplex=0.0,
-            focal_spot_size_at_sampley=0.0,
-            slitgap_vertical=0.1,
-            slitgap_horizontal=0.1,
-            beamsize_at_samplex=0.1,
-            beamsize_at_sampley=0.1,
-            transmission=100.0,
-            comments="MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 images in 100.0 um by 100.0 um steps. Top left (px): [50,100], bottom right (px): [3250,1700].",
-            detector_distance=100.0,
-            exp_time=0.1,
-            imgdir="/tmp/",
-            file_template="file_name_0_master.h5",
-            imgprefix="file_name",
-            imgsuffix="h5",
-            n_passes=1,
-            overlap=0,
-            start_image_number=1,
-            wavelength=123.98419840550369,
-            xbeam=150.0,
-            ybeam=160.0,
-            synchrotron_mode=None,
-            undulator_gap1=1.0,
-            start_time=EXPECTED_START_TIME,
+def scan_data_infos_for_begin():
+    return [
+        ScanDataInfo(
+            data_collection_info=replace(DC_INFO_FOR_BEGIN_XY),
+            data_collection_id=None,
+            data_collection_position_info=None,
+            data_collection_grid_info=None,
         ),
-        data_collection_id=None,
-        data_collection_position_info=None,
-        data_collection_grid_info=None,
-    )
+        ScanDataInfo(
+            data_collection_info=replace(DC_INFO_FOR_BEGIN_XZ),
+            data_collection_id=None,
+            data_collection_position_info=None,
+            data_collection_grid_info=None,
+        ),
+    ]
 
 
 @pytest.fixture
 def scan_data_infos_for_update():
     scan_xy_data_info_for_update = ScanDataInfo(
-        data_collection_info=DataCollectionInfo(
-            omega_start=0.0,
-            data_collection_number=1,
-            xtal_snapshot1="test_1_y",
-            xtal_snapshot2="test_2_y",
-            xtal_snapshot3="test_3_y",
-            n_images=800,
-            axis_range=0,
-            axis_end=0.0,
-            kappa_start=None,
-            parent_id=34,
-            visit_string="cm31105-4",
-            sample_id=364758,
-            detector_id=78,
-            axis_start=0.0,
-            focal_spot_size_at_samplex=0.0,
-            focal_spot_size_at_sampley=0.0,
-            slitgap_vertical=0.1,
-            slitgap_horizontal=0.1,
-            beamsize_at_samplex=0.1,
-            beamsize_at_sampley=0.1,
-            transmission=100.0,
-            comments="MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 images in 100.0 um by 100.0 um steps. Top left (px): [50,100], bottom right (px): [3250,1700].",
-            detector_distance=100.0,
-            exp_time=0.1,
-            imgdir="/tmp/",
-            file_template="file_name_0_master.h5",
-            imgprefix="file_name",
-            imgsuffix="h5",
-            n_passes=1,
-            overlap=0,
-            flux=10.0,
-            start_image_number=1,
-            wavelength=123.98419840550369,
-            xbeam=150.0,
-            ybeam=160.0,
-            synchrotron_mode="test",
-            undulator_gap1=1.0,
-            start_time=EXPECTED_START_TIME,
-        ),
+        data_collection_info=replace(DC_INFO_FOR_UPDATE_XY),
         data_collection_id=TEST_DATA_COLLECTION_IDS[0],
         data_collection_position_info=DataCollectionPositionInfo(
             pos_x=0, pos_y=0, pos_z=0
@@ -149,47 +224,8 @@ def scan_data_infos_for_update():
         ),
     )
     scan_xz_data_info_for_update = ScanDataInfo(
-        data_collection_info=DataCollectionInfo(
-            omega_start=90.0,
-            data_collection_number=1,
-            xtal_snapshot1="test_1_z",
-            xtal_snapshot2="test_2_z",
-            xtal_snapshot3="test_3_z",
-            n_images=400,
-            axis_range=0,
-            axis_end=90.0,
-            kappa_start=None,
-            parent_id=34,
-            visit_string="cm31105-4",
-            sample_id=364758,
-            detector_id=78,
-            axis_start=90.0,
-            focal_spot_size_at_samplex=0.0,
-            focal_spot_size_at_sampley=0.0,
-            slitgap_vertical=0.1,
-            slitgap_horizontal=0.1,
-            beamsize_at_samplex=0.1,
-            beamsize_at_sampley=0.1,
-            transmission=100.0,
-            comments="MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 10 images in 100.0 um by 200.0 um steps. Top left (px): [50,120], bottom right (px): [3250,1720].",
-            detector_distance=100.0,
-            exp_time=0.1,
-            imgdir="/tmp/",
-            file_template="file_name_1_master.h5",
-            imgprefix="file_name",
-            imgsuffix="h5",
-            n_passes=1,
-            overlap=0,
-            flux=10.0,
-            start_image_number=1,
-            wavelength=123.98419840550369,
-            xbeam=150.0,
-            ybeam=160.0,
-            synchrotron_mode="test",
-            undulator_gap1=1.0,
-            start_time=EXPECTED_START_TIME,
-        ),
-        data_collection_id=None,
+        data_collection_info=replace(DC_INFO_FOR_UPDATE_XZ),
+        data_collection_id=TEST_DATA_COLLECTION_IDS[1],
         data_collection_position_info=DataCollectionPositionInfo(
             pos_x=0.0, pos_y=0.0, pos_z=0.0
         ),
@@ -209,49 +245,45 @@ def scan_data_infos_for_update():
     return [scan_xy_data_info_for_update, scan_xz_data_info_for_update]
 
 
-def setup_mock_return_values(ispyb_conn):
-    mx_acquisition = ispyb_conn.return_value.__enter__.return_value.mx_acquisition
-
-    mx_acquisition.get_data_collection_group_params = (
-        MXAcquisition.get_data_collection_group_params
-    )
-    mx_acquisition.get_data_collection_params = MXAcquisition.get_data_collection_params
-    mx_acquisition.get_dc_grid_params = MXAcquisition.get_dc_grid_params
-    mx_acquisition.get_dc_position_params = MXAcquisition.get_dc_position_params
-
-    ispyb_conn.return_value.core.retrieve_visit_id.return_value = TEST_SESSION_ID
-    mx_acquisition.upsert_data_collection.side_effect = TEST_DATA_COLLECTION_IDS * 2
-    mx_acquisition.update_dc_position.return_value = TEST_POSITION_ID
-    mx_acquisition.upsert_data_collection_group.return_value = (
-        TEST_DATA_COLLECTION_GROUP_ID
-    )
-    mx_acquisition.upsert_dc_grid.return_value = TEST_GRID_INFO_IDS[0]
-
-
 def test_ispyb_deposition_comment_for_3D_correct(
     mock_ispyb_conn: MagicMock,
     dummy_3d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
+    scan_data_infos_for_begin,
     scan_data_infos_for_update,
 ):
     mock_ispyb_conn = mock_ispyb_conn
     mock_mx_aquisition = mx_acquisition_from_conn(mock_ispyb_conn)
     mock_upsert_dc = mock_mx_aquisition.upsert_data_collection
     ispyb_ids = dummy_3d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
     dummy_3d_gridscan_ispyb.update_deposition(ispyb_ids, scan_data_infos_for_update)
 
-    first_upserted_param_value_list = mock_upsert_dc.call_args_list[1][0][0]
-    second_upserted_param_value_list = mock_upsert_dc.call_args_list[2][0][0]
-    assert first_upserted_param_value_list[29] == (
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 images "
-        "in 100.0 um by 100.0 um steps. Top left (px): [50,100], bottom right (px): [3250,1700]."
+    upsert_keys = mock_mx_aquisition.get_data_collection_params()
+    first_upserted_param_value_dict = remap_upsert_columns(
+        upsert_keys, mock_upsert_dc.call_args_list[0][0][0]
     )
-    assert second_upserted_param_value_list[29] == (
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 10 images "
-        "in 100.0 um by 200.0 um steps. Top left (px): [50,120], bottom right (px): [3250,1720]."
+    second_upserted_param_value_dict = remap_upsert_columns(
+        upsert_keys, mock_upsert_dc.call_args_list[1][0][0]
+    )
+    assert first_upserted_param_value_dict["comments"] == (
+        "MX-Bluesky: Xray centring 1 -"
+    )
+    assert second_upserted_param_value_dict["comments"] == (
+        "MX-Bluesky: Xray centring 2 -"
+    )
+    mock_mx_aquisition.update_data_collection_append_comments.assert_any_call(
+        TEST_DATA_COLLECTION_IDS[0],
+        "Diffraction grid scan of 40 by 20 images "
+        "in 100.0 um by 100.0 um steps. Top left (px): [50,100], bottom right (px): [3250,1700].",
+        " ",
+    )
+    mock_mx_aquisition.update_data_collection_append_comments.assert_any_call(
+        TEST_DATA_COLLECTION_IDS[1],
+        "Diffraction grid scan of 40 by 10 images "
+        "in 100.0 um by 200.0 um steps. Top left (px): [50,120], bottom right (px): [3250,1720].",
+        " ",
     )
 
 
@@ -259,14 +291,14 @@ def test_store_3d_grid_scan(
     mock_ispyb_conn,
     dummy_3d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
+    scan_data_infos_for_begin,
     scan_data_infos_for_update,
 ):
     ispyb_ids = dummy_3d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
     assert ispyb_ids == IspybIds(
-        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0],),
+        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0], TEST_DATA_COLLECTION_IDS[1]),
         data_collection_group_id=TEST_DATA_COLLECTION_GROUP_ID,
     )
 
@@ -287,12 +319,12 @@ def test_begin_deposition(
     mock_ispyb_conn,
     dummy_3d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
+    scan_data_infos_for_begin,
 ):
     assert dummy_3d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     ) == IspybIds(
-        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0],),
+        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0], TEST_DATA_COLLECTION_IDS[1]),
         data_collection_group_id=TEST_DATA_COLLECTION_GROUP_ID,
     )
 
@@ -306,50 +338,15 @@ def test_begin_deposition(
             "sampleid": TEST_SAMPLE_ID,
         },
     )
-    mx_acq.upsert_data_collection.assert_called_once()
     assert_upsert_call_with(
         mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        {
-            "visitid": TEST_SESSION_ID,
-            "parentid": TEST_DATA_COLLECTION_GROUP_ID,
-            "sampleid": TEST_SAMPLE_ID,
-            "detectorid": 78,
-            "axisstart": 0.0,
-            "axisrange": 0,
-            "axisend": 0,
-            "focal_spot_size_at_samplex": 0.0,
-            "focal_spot_size_at_sampley": 0.0,
-            "slitgap_vertical": 0.1,
-            "slitgap_horizontal": 0.1,
-            "beamsize_at_samplex": 0.1,
-            "beamsize_at_sampley": 0.1,
-            "transmission": 100.0,
-            "comments": "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 "
-            "images in 100.0 um by 100.0 um steps. Top left (px): [50,100], "
-            "bottom right (px): [3250,1700].",
-            "data_collection_number": 1,
-            "detector_distance": 100.0,
-            "exp_time": 0.1,
-            "imgdir": "/tmp/",
-            "imgprefix": "file_name",
-            "imgsuffix": "h5",
-            "n_passes": 1,
-            "overlap": 0,
-            "omegastart": 0,
-            "start_image_number": 1,
-            "wavelength": 123.98419840550369,
-            "xbeam": 150.0,
-            "ybeam": 160.0,
-            "xtal_snapshot1": "test_1_y",
-            "xtal_snapshot2": "test_2_y",
-            "xtal_snapshot3": "test_3_y",
-            "synchrotron_mode": None,
-            "undulator_gap1": 1.0,
-            "starttime": EXPECTED_START_TIME,
-            "filetemplate": "file_name_0_master.h5",
-            "nimages": 40 * 20,
-        },
+        EXPECTED_DC_XY_BEGIN_UPSERT,
+    )
+    assert_upsert_call_with(
+        mx_acq.upsert_data_collection.mock_calls[1],
+        mx_acq.get_data_collection_params(),
+        EXPECTED_DC_XZ_BEGIN_UPSERT,
     )
     mx_acq.update_dc_position.assert_not_called()
     mx_acq.upsert_dc_grid.assert_not_called()
@@ -363,16 +360,17 @@ def test_update_deposition(
     mock_ispyb_conn,
     dummy_3d_gridscan_ispyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
+    scan_data_infos_for_begin,
     scan_data_infos_for_update,
 ):
     ispyb_ids = dummy_3d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
     mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
     mx_acq.upsert_data_collection_group.assert_called_once()
-    mx_acq.upsert_data_collection.assert_called_once()
+    mx_acq.upsert_data_collection.assert_called()
     mx_acq.upsert_data_collection_group.reset_mock()
+    mx_acq.upsert_data_collection.reset_mock()
 
     dummy_collection_group_info.sample_barcode = TEST_BARCODE
 
@@ -389,50 +387,19 @@ def test_update_deposition(
     mx_acq.upsert_data_collection_group.assert_not_called()
 
     assert_upsert_call_with(
-        mx_acq.upsert_data_collection.mock_calls[1],
+        mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        {
-            "id": 12,
-            "visitid": TEST_SESSION_ID,
-            "parentid": TEST_DATA_COLLECTION_GROUP_ID,
-            "sampleid": TEST_SAMPLE_ID,
-            "detectorid": 78,
-            "axisstart": 0.0,
-            "axisrange": 0,
-            "axisend": 0,
-            "focal_spot_size_at_samplex": 0.0,
-            "focal_spot_size_at_sampley": 0.0,
-            "slitgap_vertical": 0.1,
-            "slitgap_horizontal": 0.1,
-            "beamsize_at_samplex": 0.1,
-            "beamsize_at_sampley": 0.1,
-            "transmission": 100.0,
-            "comments": "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 "
+        EXPECTED_DC_XY_UPDATE_UPSERT,
+    )
+
+    assert mx_acq.update_data_collection_append_comments.call_args_list[0] == (
+        (
+            TEST_DATA_COLLECTION_IDS[0],
+            "Diffraction grid scan of 40 by 20 "
             "images in 100.0 um by 100.0 um steps. Top left (px): [50,100], "
             "bottom right (px): [3250,1700].",
-            "data_collection_number": 1,
-            "detector_distance": 100.0,
-            "exp_time": 0.1,
-            "imgdir": "/tmp/",
-            "imgprefix": "file_name",
-            "imgsuffix": "h5",
-            "n_passes": 1,
-            "overlap": 0,
-            "flux": 10.0,
-            "omegastart": 0.0,
-            "start_image_number": 1,
-            "wavelength": 123.98419840550369,
-            "xbeam": 150.0,
-            "ybeam": 160.0,
-            "xtal_snapshot1": "test_1_y",
-            "xtal_snapshot2": "test_2_y",
-            "xtal_snapshot3": "test_3_y",
-            "synchrotron_mode": "test",
-            "undulator_gap1": 1.0,
-            "starttime": EXPECTED_START_TIME,
-            "filetemplate": "file_name_0_master.h5",
-            "nimages": 40 * 20,
-        },
+            " ",
+        ),
     )
 
     assert_upsert_call_with(
@@ -465,50 +432,19 @@ def test_update_deposition(
     )
 
     assert_upsert_call_with(
-        mx_acq.upsert_data_collection.mock_calls[2],
+        mx_acq.upsert_data_collection.mock_calls[1],
         mx_acq.get_data_collection_params(),
-        {
-            "id": None,
-            "visitid": TEST_SESSION_ID,
-            "parentid": TEST_DATA_COLLECTION_GROUP_ID,
-            "sampleid": TEST_SAMPLE_ID,
-            "detectorid": 78,
-            "axisstart": 90.0,
-            "axisrange": 0,
-            "axisend": 90.0,
-            "focal_spot_size_at_samplex": 0.0,
-            "focal_spot_size_at_sampley": 0.0,
-            "slitgap_vertical": 0.1,
-            "slitgap_horizontal": 0.1,
-            "beamsize_at_samplex": 0.1,
-            "beamsize_at_sampley": 0.1,
-            "transmission": 100.0,
-            "comments": "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 10 "
+        EXPECTED_DC_XZ_UPDATE_UPSERT,
+    )
+
+    assert mx_acq.update_data_collection_append_comments.call_args_list[1] == (
+        (
+            TEST_DATA_COLLECTION_IDS[1],
+            "Diffraction grid scan of 40 by 10 "
             "images in 100.0 um by 200.0 um steps. Top left (px): [50,120], "
             "bottom right (px): [3250,1720].",
-            "data_collection_number": 1,
-            "detector_distance": 100.0,
-            "exp_time": 0.1,
-            "imgdir": "/tmp/",
-            "imgprefix": "file_name",
-            "imgsuffix": "h5",
-            "n_passes": 1,
-            "overlap": 0,
-            "flux": 10.0,
-            "omegastart": 90.0,
-            "start_image_number": 1,
-            "wavelength": 123.98419840550369,
-            "xbeam": 150.0,
-            "ybeam": 160.0,
-            "xtal_snapshot1": "test_1_z",
-            "xtal_snapshot2": "test_2_z",
-            "xtal_snapshot3": "test_3_z",
-            "synchrotron_mode": "test",
-            "undulator_gap1": 1.0,
-            "starttime": EXPECTED_START_TIME,
-            "filetemplate": "file_name_1_master.h5",
-            "nimages": 40 * 10,
-        },
+            " ",
+        ),
     )
 
     assert_upsert_call_with(
@@ -553,11 +489,11 @@ def test_end_deposition_happy_path(
     mock_ispyb_conn,
     dummy_3d_gridscan_ispyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
+    scan_data_infos_for_begin,
     scan_data_infos_for_update,
 ):
     ispyb_ids = dummy_3d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
     mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
     assert len(mx_acq.upsert_data_collection_group.mock_calls) == 1
@@ -565,20 +501,18 @@ def test_end_deposition_happy_path(
         ispyb_ids, scan_data_infos_for_update
     )
     assert len(mx_acq.upsert_data_collection_group.mock_calls) == 1
-    assert len(mx_acq.upsert_data_collection.mock_calls) == 3
+    assert len(mx_acq.upsert_data_collection.mock_calls) == 4
     assert len(mx_acq.upsert_dc_grid.mock_calls) == 2
 
     get_current_time.return_value = EXPECTED_END_TIME
     dummy_3d_gridscan_ispyb.end_deposition(ispyb_ids, "success", "Test succeeded")
-    assert mx_acq.update_data_collection_append_comments.call_args_list[0] == (
-        (
-            TEST_DATA_COLLECTION_IDS[0],
-            "DataCollection Successful reason: Test succeeded",
-            " ",
-        ),
+    mx_acq.update_data_collection_append_comments.assert_any_call(
+        TEST_DATA_COLLECTION_IDS[0],
+        "DataCollection Successful reason: Test succeeded",
+        " ",
     )
     assert_upsert_call_with(
-        mx_acq.upsert_data_collection.mock_calls[3],
+        mx_acq.upsert_data_collection.mock_calls[4],
         mx_acq.get_data_collection_params(),
         {
             "id": TEST_DATA_COLLECTION_IDS[0],
@@ -587,15 +521,13 @@ def test_end_deposition_happy_path(
             "runstatus": "DataCollection Successful",
         },
     )
-    assert mx_acq.update_data_collection_append_comments.call_args_list[1] == (
-        (
-            TEST_DATA_COLLECTION_IDS[1],
-            "DataCollection Successful reason: Test succeeded",
-            " ",
-        ),
+    mx_acq.update_data_collection_append_comments.assert_any_call(
+        TEST_DATA_COLLECTION_IDS[1],
+        "DataCollection Successful reason: Test succeeded",
+        " ",
     )
     assert_upsert_call_with(
-        mx_acq.upsert_data_collection.mock_calls[4],
+        mx_acq.upsert_data_collection.mock_calls[5],
         mx_acq.get_data_collection_params(),
         {
             "id": TEST_DATA_COLLECTION_IDS[1],
@@ -610,18 +542,18 @@ def test_param_keys(
     mock_ispyb_conn,
     dummy_2d_gridscan_ispyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_xy_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
 ):
     ispyb_ids = dummy_2d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
     assert dummy_2d_gridscan_ispyb.update_deposition(
-        ispyb_ids, [scan_xy_data_info_for_update]
+        ispyb_ids, scan_data_infos_for_update
     ) == IspybIds(
-        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0],),
+        data_collection_ids=(TEST_DATA_COLLECTION_IDS[0], TEST_DATA_COLLECTION_IDS[1]),
         data_collection_group_id=TEST_DATA_COLLECTION_GROUP_ID,
-        grid_ids=(TEST_GRID_INFO_IDS[0],),
+        grid_ids=(TEST_GRID_INFO_IDS[0], TEST_GRID_INFO_IDS[1]),
     )
 
 
@@ -630,23 +562,29 @@ def _test_when_grid_scan_stored_then_data_present_in_upserts(
     dummy_ispyb,
     test_function,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
     test_group=False,
 ):
-    setup_mock_return_values(ispyb_conn)
     ispyb_ids = dummy_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
-    dummy_ispyb.update_deposition(ispyb_ids, [scan_data_info_for_update])
+    dummy_ispyb.update_deposition(ispyb_ids, scan_data_infos_for_update)
 
-    mx_acquisition = ispyb_conn.return_value.__enter__.return_value.mx_acquisition
+    mx_acquisition = mx_acquisition_from_conn(ispyb_conn)
 
-    upsert_data_collection_arg_list = (
-        mx_acquisition.upsert_data_collection.call_args_list[1][0]
-    )
-    actual = upsert_data_collection_arg_list[0]
-    assert test_function(MXAcquisition.get_data_collection_params(), actual)
+    def call_does_not_have_dcid(id, func_call):
+        return func_call.args[0][0] != id
+
+    for dc_id in ispyb_ids.data_collection_ids:
+        upsert_call = next(
+            dropwhile(
+                partial(call_does_not_have_dcid, dc_id),
+                mx_acquisition.upsert_data_collection.call_args_list,
+            )
+        )
+        actual = upsert_call[0][0]
+        assert test_function(MXAcquisition.get_data_collection_params(), actual)
 
     if test_group:
         upsert_data_collection_group_arg_list = (
@@ -656,40 +594,41 @@ def _test_when_grid_scan_stored_then_data_present_in_upserts(
         assert test_function(MXAcquisition.get_data_collection_group_params(), actual)
 
 
-@patch("ispyb.open", autospec=True)
 def test_given_sampleid_of_none_when_grid_scan_stored_then_sample_id_not_set(
-    ispyb_conn,
+    mock_ispyb_conn,
     dummy_2d_gridscan_ispyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_xy_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
 ):
     dummy_collection_group_info.sample_id = None
-    scan_data_info_for_begin.data_collection_info.sample_id = None
-    scan_xy_data_info_for_update.data_collection_info.sample_id = None
+    for dc_info in [
+        scan_info.data_collection_info
+        for scan_info in scan_data_infos_for_begin + scan_data_infos_for_update
+    ]:
+        dc_info.sample_id = None
 
     def test_sample_id(default_params, actual):
         sampleid_idx = list(default_params).index("sampleid")
         return actual[sampleid_idx] == default_params["sampleid"]
 
     _test_when_grid_scan_stored_then_data_present_in_upserts(
-        ispyb_conn,
+        mock_ispyb_conn,
         dummy_2d_gridscan_ispyb,
         test_sample_id,
         dummy_collection_group_info,
-        scan_data_info_for_begin,
-        scan_xy_data_info_for_update,
+        scan_data_infos_for_begin,
+        scan_data_infos_for_update,
         True,
     )
 
 
-@patch("ispyb.open", autospec=True)
 def test_given_real_sampleid_when_grid_scan_stored_then_sample_id_set(
-    ispyb_conn,
+    mock_ispyb_conn,
     dummy_2d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_xy_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
 ):
     expected_sample_id = 364758
 
@@ -698,12 +637,12 @@ def test_given_real_sampleid_when_grid_scan_stored_then_sample_id_set(
         return actual[sampleid_idx] == expected_sample_id
 
     _test_when_grid_scan_stored_then_data_present_in_upserts(
-        ispyb_conn,
+        mock_ispyb_conn,
         dummy_2d_gridscan_ispyb,
         test_sample_id,
         dummy_collection_group_info,
-        scan_data_info_for_begin,
-        scan_xy_data_info_for_update,
+        scan_data_infos_for_begin,
+        scan_data_infos_for_update,
         True,
     )
 
@@ -712,8 +651,8 @@ def test_fail_result_run_results_in_bad_run_status(
     mock_ispyb_conn: MagicMock,
     dummy_2d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_xy_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
 ):
     mock_ispyb_conn = mock_ispyb_conn
     mock_mx_aquisition = (
@@ -722,44 +661,59 @@ def test_fail_result_run_results_in_bad_run_status(
     mock_upsert_data_collection = mock_mx_aquisition.upsert_data_collection
 
     ispyb_ids = dummy_2d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
-    ispyb_ids = dummy_2d_gridscan_ispyb.update_deposition(
-        ispyb_ids, [scan_xy_data_info_for_update]
-    )
+    ispyb_ids = dummy_2d_gridscan_ispyb.update_deposition(ispyb_ids, scan_data_infos_for_update)
     dummy_2d_gridscan_ispyb.end_deposition(ispyb_ids, "fail", "test specifies failure")
 
     mock_upsert_data_collection_calls = mock_upsert_data_collection.call_args_list
-    end_deposition_upsert_args = mock_upsert_data_collection_calls[2][0]
-    upserted_param_value_list = end_deposition_upsert_args[0]
-    assert "DataCollection Unsuccessful" in upserted_param_value_list
-    assert "DataCollection Successful" not in upserted_param_value_list
+    for upsert_call in mock_upsert_data_collection_calls[4:5]:
+        end_deposition_upsert_args = upsert_call[0]
+        upserted_param_value_list = end_deposition_upsert_args[0]
+        assert "DataCollection Unsuccessful" in upserted_param_value_list
+        assert "DataCollection Successful" not in upserted_param_value_list
 
 
 def test_no_exception_during_run_results_in_good_run_status(
     mock_ispyb_conn: MagicMock,
     dummy_2d_gridscan_ispyb: StoreInIspyb,
     dummy_collection_group_info,
-    scan_data_info_for_begin,
-    scan_xy_data_info_for_update,
+    scan_data_infos_for_begin,
+    scan_data_infos_for_update,
 ):
-    mock_ispyb_conn = mock_ispyb_conn
-    setup_mock_return_values(mock_ispyb_conn)
-    mock_mx_aquisition = (
+    mock_mx_acquisition = (
         mock_ispyb_conn.return_value.__enter__.return_value.mx_acquisition
     )
-    mock_upsert_data_collection = mock_mx_aquisition.upsert_data_collection
+    mock_upsert_data_collection = mock_mx_acquisition.upsert_data_collection
 
     ispyb_ids = dummy_2d_gridscan_ispyb.begin_deposition(
-        dummy_collection_group_info, [scan_data_info_for_begin]
+        dummy_collection_group_info, scan_data_infos_for_begin
     )
-    ispyb_ids = dummy_2d_gridscan_ispyb.update_deposition(
-        ispyb_ids, [scan_xy_data_info_for_update]
-    )
+    ispyb_ids = dummy_2d_gridscan_ispyb.update_deposition(ispyb_ids, scan_data_infos_for_update)
     dummy_2d_gridscan_ispyb.end_deposition(ispyb_ids, "success", "")
 
     mock_upsert_data_collection_calls = mock_upsert_data_collection.call_args_list
-    end_deposition_upsert_args = mock_upsert_data_collection_calls[2][0]
-    upserted_param_value_list = end_deposition_upsert_args[0]
-    assert "DataCollection Unsuccessful" not in upserted_param_value_list
-    assert "DataCollection Successful" in upserted_param_value_list
+    for upsert_call in mock_upsert_data_collection_calls[4:5]:
+        end_deposition_upsert_args = upsert_call[0]
+        upserted_param_value_list = end_deposition_upsert_args[0]
+        assert "DataCollection Unsuccessful" not in upserted_param_value_list
+        assert "DataCollection Successful" in upserted_param_value_list
+
+
+def test_update_data_collection_no_comment(
+    mock_ispyb_conn: MagicMock,
+    dummy_3d_gridscan_ispyb: StoreInIspyb,
+    dummy_collection_group_info: DataCollectionGroupInfo,
+    scan_data_infos_for_begin: list[ScanDataInfo],
+    scan_data_infos_for_update: list[ScanDataInfo],
+):
+    for scan_data_info in scan_data_infos_for_update:
+        scan_data_info.data_collection_info.comments = None
+
+    ispyb_ids = dummy_3d_gridscan_ispyb.begin_deposition(
+        dummy_collection_group_info, scan_data_infos_for_begin
+    )
+    dummy_3d_gridscan_ispyb.update_deposition(ispyb_ids, scan_data_infos_for_update)
+
+    mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
+    mx_acq.update_data_collection_append_comments.assert_not_called()

--- a/tests/unit_tests/common/external_interaction/callbacks/ispyb/test_rotation_ispyb_store.py
+++ b/tests/unit_tests/common/external_interaction/callbacks/ispyb/test_rotation_ispyb_store.py
@@ -26,7 +26,7 @@ from ......conftest import (
     mx_acquisition_from_conn,
 )
 
-EXPECTED_DATA_COLLECTION = {
+EXPECTED_UPDATE_DATA_COLLECTION = {
     "visitid": TEST_SESSION_ID,
     "parentid": TEST_DATA_COLLECTION_GROUP_ID,
     "sampleid": None,
@@ -39,7 +39,6 @@ EXPECTED_DATA_COLLECTION = {
     "beamsize_at_samplex": 1,
     "beamsize_at_sampley": 1,
     "transmission": 100.0,
-    "comments": "Hyperion rotation scan",
     "data_collection_number": 0,
     "detector_distance": 100.0,
     "exp_time": 0.1,
@@ -61,6 +60,10 @@ EXPECTED_DATA_COLLECTION = {
     "filetemplate": "file_name_1_master.h5",
     "nimages": 1800,
     "kappastart": 0,
+}
+
+EXPECTED_BEGIN_DATA_COLLECTION = EXPECTED_UPDATE_DATA_COLLECTION | {
+    "comments": "Hyperion rotation scan",
 }
 
 
@@ -147,7 +150,6 @@ def scan_data_info_for_update(scan_data_info_for_begin):
             beamsize_at_samplex=1.0,
             beamsize_at_sampley=1.0,
             transmission=100.0,
-            comments="Hyperion rotation scan",
             detector_distance=100.0,
             exp_time=0.1,
             imgdir="/tmp/",
@@ -216,7 +218,7 @@ def test_begin_deposition(
     assert_upsert_call_with(
         mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        EXPECTED_DATA_COLLECTION | {"sampleid": TEST_SAMPLE_ID},
+        EXPECTED_BEGIN_DATA_COLLECTION | {"sampleid": TEST_SAMPLE_ID},
     )
 
 
@@ -259,7 +261,7 @@ def test_begin_deposition_with_group_id_updates_but_doesnt_insert(
     assert_upsert_call_with(
         mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        EXPECTED_DATA_COLLECTION | {"sampleid": TEST_SAMPLE_ID},
+        EXPECTED_BEGIN_DATA_COLLECTION | {"sampleid": TEST_SAMPLE_ID},
     )
 
 
@@ -328,7 +330,7 @@ def test_update_deposition(
     assert_upsert_call_with(
         mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        EXPECTED_DATA_COLLECTION
+        EXPECTED_UPDATE_DATA_COLLECTION
         | {
             "id": TEST_DATA_COLLECTION_IDS[0],
             "synchrotron_mode": "test",
@@ -387,7 +389,7 @@ def test_update_deposition_with_group_id_updates(
     assert_upsert_call_with(
         mx_acq.upsert_data_collection.mock_calls[0],
         mx_acq.get_data_collection_params(),
-        EXPECTED_DATA_COLLECTION
+        EXPECTED_UPDATE_DATA_COLLECTION
         | {
             "id": TEST_DATA_COLLECTION_IDS[0],
             "synchrotron_mode": "test",

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
@@ -14,12 +14,14 @@ from .....conftest import (
     TestData,
     assert_upsert_call_with,
     mx_acquisition_from_conn,
+    remap_upsert_columns,
 )
 
 EXPECTED_DATA_COLLECTION_3D_XY = {
     "visitid": TEST_SESSION_ID,
     "parentid": TEST_DATA_COLLECTION_GROUP_ID,
     "sampleid": TEST_SAMPLE_ID,
+    "comments": "MX-Bluesky: Xray centring 1 -",
     "detectorid": 78,
     "data_collection_number": 1,
     "detector_distance": 100.0,
@@ -40,6 +42,7 @@ EXPECTED_DATA_COLLECTION_3D_XY = {
 }
 
 EXPECTED_DATA_COLLECTION_3D_XZ = EXPECTED_DATA_COLLECTION_3D_XY | {
+    "comments": "MX-Bluesky: Xray centring 2 -",
     "data_collection_number": 2,
     "filetemplate": "file_name_2_master.h5",
 }
@@ -215,14 +218,18 @@ class TestXrayCentreISPyBCallback:
                 "xtal_snapshot1": "test_1_y",
                 "xtal_snapshot2": "test_2_y",
                 "xtal_snapshot3": "test_3_y",
-                "comments": "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 "
-                "images in 126.4 um by 126.4 um steps. Top left (px): [50,100], "
-                "bottom right (px): [3250,1700].",
                 "axisstart": 0,
                 "omegastart": 0,
                 "axisend": 0,
                 "axisrange": 0,
             },
+        )
+        mx_acq.update_data_collection_append_comments.assert_any_call(
+            TEST_DATA_COLLECTION_IDS[0],
+            "Diffraction grid scan of 40 by 20 "
+            "images in 126.4 um by 126.4 um steps. Top left (px): [50,100], "
+            "bottom right (px): [3250,1700].",
+            " ",
         )
         assert_upsert_call_with(
             mx_acq.upsert_data_collection.mock_calls[1],
@@ -234,14 +241,18 @@ class TestXrayCentreISPyBCallback:
                 "xtal_snapshot1": "test_1_z",
                 "xtal_snapshot2": "test_2_z",
                 "xtal_snapshot3": "test_3_z",
-                "comments": "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 10 "
-                "images in 126.4 um by 126.4 um steps. Top left (px): [50,0], "
-                "bottom right (px): [3250,800].",
                 "axisstart": 90,
                 "omegastart": 90,
                 "axisend": 90,
                 "axisrange": 0,
             },
+        )
+        mx_acq.update_data_collection_append_comments.assert_any_call(
+            TEST_DATA_COLLECTION_IDS[1],
+            "Diffraction grid scan of 40 by 10 "
+            "images in 126.4 um by 126.4 um steps. Top left (px): [50,0], "
+            "bottom right (px): [3250,800].",
+            " ",
         )
         assert_upsert_call_with(
             mx_acq.upsert_dc_grid.mock_calls[0],
@@ -277,3 +288,22 @@ class TestXrayCentreISPyBCallback:
                 "snaked": True,
             },
         )
+
+    def test_activity_gated_start_first_gridscan_comment_is_first_lexicographically(
+        self, mock_ispyb_conn
+    ):
+        callback = GridscanISPyBCallback(
+            param_type=GridCommonWithHyperionDetectorParams
+        )
+        callback.activity_gated_start(TestData.test_gridscan3d_start_document)  # pyright: ignore
+        mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
+        upsert_dc_1 = mx_acq.upsert_data_collection.mock_calls[0]
+        upsert_dc_2 = mx_acq.upsert_data_collection.mock_calls[1]
+
+        dc_1_cols = remap_upsert_columns(
+            mx_acq.get_data_collection_params(), upsert_dc_1.args[0]
+        )
+        dc_2_cols = remap_upsert_columns(
+            mx_acq.get_data_collection_params(), upsert_dc_2.args[0]
+        )
+        assert dc_1_cols["comments"] < dc_2_cols["comments"]

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_mapping.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_mapping.py
@@ -44,7 +44,7 @@ def test_ispyb_deposition_rounds_position_to_int(
             True,  # type: ignore
         ),
     ) == (
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 40 by 20 images "
+        "Diffraction grid scan of 40 by 20 images "
         "in 100.0 um by 100.0 um steps. Top left (px): [0,100], bottom right (px): [3200,1700]."
     )
 
@@ -77,6 +77,6 @@ def test_ispyb_deposition_rounds_box_size_int(
     bottom_right_from_top_left.return_value = [0, 0]
 
     assert construct_comment_for_gridscan(data_collection_grid_info) == (
-        "MX-Bluesky: Xray centring - Diffraction grid scan of 0 by 0 images in "
+        "Diffraction grid scan of 0 by 0 images in "
         f"{rounded} um by {rounded} um steps. Top left (px): [0,0], bottom right (px): [0,0]."
     )

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -78,12 +78,13 @@ from tests.conftest import (
     create_dummy_scan_spec,
 )
 
-from ....conftest import TestData, simulate_xrc_result
-from ....system_tests.hyperion.external_interaction.conftest import (
+from ....conftest import (
     TEST_RESULT_BELOW_THRESHOLD,
     TEST_RESULT_LARGE,
     TEST_RESULT_MEDIUM,
     TEST_RESULT_SMALL,
+    TestData,
+    simulate_xrc_result,
 )
 from .conftest import (
     assert_event,

--- a/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -28,10 +28,7 @@ from mx_bluesky.hyperion.parameters.gridscan import (
     PinTipCentreThenXrayCentre,
 )
 
-from ....conftest import raw_params_from_file, simulate_xrc_result
-from ....system_tests.hyperion.external_interaction.conftest import (
-    TEST_RESULT_LARGE,
-)
+from ....conftest import TEST_RESULT_LARGE, raw_params_from_file, simulate_xrc_result
 from .conftest import FLYSCAN_RESULT_LOW, FLYSCAN_RESULT_MED, sim_fire_event_on_open_run
 
 

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -16,6 +16,7 @@ from ......conftest import (
     TestData,
     assert_upsert_call_with,
     mx_acquisition_from_conn,
+    remap_upsert_columns,
 )
 
 EXPECTED_DATA_COLLECTION = {
@@ -140,10 +141,12 @@ def test_hardware_read_events(
             "slitgapvertical": 0.2345,
             "synchrotronmode": "User",
             "undulatorgap1": 1.234,
-            "comments": "Sample position (µm): (158, 24, 3) test ",
             "resolution": 1.1830593331191241,
             "wavelength": 1.11647184541378,
         },
+    )
+    mx.update_data_collection_append_comments.assert_called_with(
+        TEST_DATA_COLLECTION_IDS[0], "Sample position (µm): (158, 24, 3)", " "
     )
     expected_data = TestData.test_event_document_pre_data_collection["data"]
     assert_upsert_call_with(
@@ -301,6 +304,11 @@ def test_comment_correct_after_hardware_read(
         TestData.test_rotation_start_main_document  # pyright: ignore
     )
     mx = mx_acquisition_from_conn(mock_ispyb_conn)
+    dc_upsert_dict = remap_upsert_columns(
+        mx.get_data_collection_params(),
+        mx.upsert_data_collection.mock_calls[0].args[0],
+    )
+    assert dc_upsert_dict["comments"] == "a lovely unit test"
 
     mx.upsert_data_collection_group.reset_mock()
     mx.upsert_data_collection.reset_mock()
@@ -319,8 +327,10 @@ def test_comment_correct_after_hardware_read(
             "slitgapvertical": 0.2345,
             "synchrotronmode": "User",
             "undulatorgap1": 1.234,
-            "comments": "Sample position (µm): (158, 24, 3) a lovely unit test ",
             "resolution": 1.1830593331191241,
             "wavelength": 1.11647184541378,
         },
+    )
+    mx.update_data_collection_append_comments.assert_called_with(
+        TEST_DATA_COLLECTION_IDS[0], "Sample position (µm): (158, 24, 3)", " "
     )


### PR DESCRIPTION
Fixes 

* #785

* Calls to `StoreInIspyb.update_deposition()` should now result in a call to the append comment sproc instead of blindly overwriting any existing comments.
* The initial upsert to the DataCollection table now has the comment prefix string including the gridscan number to ensure lexicographic sorting.

Unfortunately there has been significant churn to some of the unit tests because of the above changes, and also because some of the tests were written to emulate older behaviour whereby the second DataCollection in the gridscan was not created on the start event - this has not been true for some time and the tests no longer emulate this.

### Instructions to reviewer on how to test:

1. The XRC results (i.e. crystals found) comment should now always appear in the SynchWeb summary for the XRC.
2. Gridscan data collection comments should now be prefixed with `MX-Bluesky: Xray centring n - ` where n is 1 or 2
3. Tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
