### PR TITLE
Remove unused dummy_rotation_params from callback tests

### DIFF
--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback import (
     RotationISPyBCallback,
 )
@@ -47,21 +45,14 @@ EXPECTED_DATA_COLLECTION = {
 }
 
 
-@pytest.fixture
-def rotation_start_outer_doc_without_snapshots(test_rotation_start_outer_document):
-    return test_rotation_start_outer_document
-
-
 @patch(
     "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
-def test_activity_gated_start(
-    mock_ispyb_conn, rotation_start_outer_doc_without_snapshots
-):
+def test_activity_gated_start(mock_ispyb_conn, test_rotation_start_outer_document):
     callback = RotationISPyBCallback()
 
-    callback.activity_gated_start(rotation_start_outer_doc_without_snapshots)
+    callback.activity_gated_start(test_rotation_start_outer_document)
     mx = mx_acquisition_from_conn(mock_ispyb_conn)
     assert_upsert_call_with(
         mx.upsert_data_collection_group.mock_calls[0],
@@ -202,10 +193,10 @@ def test_flux_read_events(mock_ispyb_conn, test_rotation_start_outer_document):
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
 def test_oav_rotation_snapshot_triggered_event(
-    mock_ispyb_conn, rotation_start_outer_doc_without_snapshots
+    mock_ispyb_conn, test_rotation_start_outer_document
 ):
     callback = RotationISPyBCallback()
-    callback.activity_gated_start(rotation_start_outer_doc_without_snapshots)  # pyright: ignore
+    callback.activity_gated_start(test_rotation_start_outer_document)  # pyright: ignore
     callback.activity_gated_start(
         TestData.test_rotation_start_main_document  # pyright: ignore
     )

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -49,9 +49,7 @@ EXPECTED_DATA_COLLECTION = {
     "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
-def test_activity_gated_start_with_snapshot_parameters(
-    mock_ispyb_conn, test_rotation_start_outer_document
-):
+def test_activity_gated_start(mock_ispyb_conn, test_rotation_start_outer_document):
     callback = RotationISPyBCallback()
 
     callback.activity_gated_start(test_rotation_start_outer_document)

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -49,31 +49,6 @@ EXPECTED_DATA_COLLECTION = {
     "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
-def test_activity_gated_start(mock_ispyb_conn, test_rotation_start_outer_document):
-    callback = RotationISPyBCallback()
-
-    callback.activity_gated_start(test_rotation_start_outer_document)
-    mx = mx_acquisition_from_conn(mock_ispyb_conn)
-    assert_upsert_call_with(
-        mx.upsert_data_collection_group.mock_calls[0],
-        mx.get_data_collection_group_params(),
-        {
-            "parentid": TEST_SESSION_ID,
-            "experimenttype": "SAD",
-            "sampleid": TEST_SAMPLE_ID,
-        },
-    )
-    assert_upsert_call_with(
-        mx.upsert_data_collection.mock_calls[0],
-        mx.get_data_collection_params(),
-        EXPECTED_DATA_COLLECTION,
-    )
-
-
-@patch(
-    "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
-    new=MagicMock(return_value=EXPECTED_START_TIME),
-)
 def test_activity_gated_start_with_snapshot_parameters(
     mock_ispyb_conn, test_rotation_start_outer_document
 ):

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -48,9 +48,7 @@ EXPECTED_DATA_COLLECTION = {
 
 
 @pytest.fixture
-def rotation_start_outer_doc_without_snapshots(
-    test_rotation_start_outer_document, dummy_rotation_params
-):
+def rotation_start_outer_doc_without_snapshots(test_rotation_start_outer_document):
     return test_rotation_start_outer_document
 
 
@@ -112,9 +110,7 @@ def test_activity_gated_start_with_snapshot_parameters(
     "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
-def test_hardware_read_events(
-    mock_ispyb_conn, dummy_rotation_params, test_rotation_start_outer_document
-):
+def test_hardware_read_events(mock_ispyb_conn, test_rotation_start_outer_document):
     callback = RotationISPyBCallback()
     callback.activity_gated_start(test_rotation_start_outer_document)  # pyright: ignore
     callback.activity_gated_start(
@@ -162,9 +158,7 @@ def test_hardware_read_events(
     "mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping.get_current_time_string",
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
-def test_flux_read_events(
-    mock_ispyb_conn, dummy_rotation_params, test_rotation_start_outer_document
-):
+def test_flux_read_events(mock_ispyb_conn, test_rotation_start_outer_document):
     callback = RotationISPyBCallback()
     callback.activity_gated_start(test_rotation_start_outer_document)  # pyright: ignore
     callback.activity_gated_start(
@@ -208,7 +202,7 @@ def test_flux_read_events(
     new=MagicMock(return_value=EXPECTED_START_TIME),
 )
 def test_oav_rotation_snapshot_triggered_event(
-    mock_ispyb_conn, dummy_rotation_params, rotation_start_outer_doc_without_snapshots
+    mock_ispyb_conn, rotation_start_outer_doc_without_snapshots
 ):
     callback = RotationISPyBCallback()
     callback.activity_gated_start(rotation_start_outer_doc_without_snapshots)  # pyright: ignore
@@ -288,7 +282,7 @@ def test_activity_gated_stop(mock_ispyb_conn, test_rotation_start_outer_document
 
 
 def test_comment_correct_after_hardware_read(
-    mock_ispyb_conn, dummy_rotation_params, test_rotation_start_outer_document
+    mock_ispyb_conn, test_rotation_start_outer_document
 ):
     callback = RotationISPyBCallback()
     test_rotation_start_outer_document["mx_bluesky_parameters"] = (


### PR DESCRIPTION
We pass `dummy_rotation_params` to our tests, but this is never explicitly used, so this is now removed.

At some point, the fixture `rotation_start_outer_doc_without_snapshots` was used to set `dummy_rotation_params.ispyb_extras.xtal_snapshots_omega_start = None` (changes [here](https://github.com/DiamondLightSource/hyperion/pull/1437/files#diff-93a54e1eb3d5894e18d8dd8cdf2d028e670d39823917e71890f51e1c726d1695)), but currently this fixture simply returns `test_rotation_start_outer_document`, which populates `"mx_bluesky_parameters": dummy_rotation_params.model_dump_json()`.  Looks like `xtal_snapshots_omega_start` was removed in #493, so this PR removes the now redundant test `test_activity_gated_start_with_snapshot_parameters`.

### Instructions to reviewer on how to test:

1. Confirm tests pass with expected behavior

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
