### PR TITLE
Enforce pytest.raises() is simple

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ lint.select = [
     "I",   # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "SLF", # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
+    "PT012" # flake8-pytest-style rules - https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/#pytest-raises-with-multiple-statements-pt012
 ]
 lint.extend-ignore = [
     "E501", # Line too long

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_nexus_handler.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_nexus_handler.py
@@ -132,10 +132,10 @@ def test_sensible_error_if_writing_triggered_before_params_received(
     nexus_handler = GridscanNexusFileCallback(
         param_type=HyperionSpecifiedThreeDGridScan
     )
+    nexus_handler.activity_gated_descriptor(
+        TestData.test_descriptor_document_during_data_collection
+    )
     with pytest.raises(AssertionError) as excinfo:
-        nexus_handler.activity_gated_descriptor(
-            TestData.test_descriptor_document_during_data_collection
-        )
         nexus_handler.activity_gated_event(
             TestData.test_event_document_during_data_collection
         )

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -213,9 +213,8 @@ class TestFlyscanXrayCentrePlan:
         )
         RE.subscribe(ispyb_callback)
 
-        error = None
+        error = AssertionError("Test Exception")
         with patch.object(fake_fgs_composite.smargon.omega, "set") as mock_set:
-            error = AssertionError("Test Exception")
             mock_set.return_value = FailedStatus(error)
             with pytest.raises(FailedStatus) as exc:
                 RE(flyscan_xray_centre(fake_fgs_composite, test_fgs_params))

--- a/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -214,11 +214,10 @@ class TestFlyscanXrayCentrePlan:
         RE.subscribe(ispyb_callback)
 
         error = None
-        with pytest.raises(FailedStatus) as exc:
-            with patch.object(fake_fgs_composite.smargon.omega, "set") as mock_set:
-                error = AssertionError("Test Exception")
-                mock_set.return_value = FailedStatus(error)
-
+        with patch.object(fake_fgs_composite.smargon.omega, "set") as mock_set:
+            error = AssertionError("Test Exception")
+            mock_set.return_value = FailedStatus(error)
+            with pytest.raises(FailedStatus) as exc:
                 RE(flyscan_xray_centre(fake_fgs_composite, test_fgs_params))
 
         assert exc.value.args[0] is error

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -290,7 +290,7 @@ def test_cleanup_happens(
                     fake_create_rotation_devices, test_rotation_params, motion_values
                 )
             )
-            cleanup_plan.assert_not_called()
+        cleanup_plan.assert_not_called()
         # check that failure is handled in composite plan
         with pytest.raises(MyTestException) as exc:
             RE(
@@ -300,8 +300,8 @@ def test_cleanup_happens(
                     oav_parameters_for_rotation,
                 )
             )
-            assert "Experiment fails because this is a test" in exc.value.args[0]
-            cleanup_plan.assert_called_once()
+        assert "Experiment fails because this is a test" in exc.value.args[0]
+        cleanup_plan.assert_called_once()
 
 
 def test_rotation_plan_reads_hardware(

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
@@ -121,9 +121,9 @@ def test_zocalo_start_and_end_not_triggered_if_ispyb_ids_not_present(
 
     ispyb_callback.ispyb = MagicMock(spec=StoreInIspyb)
     ispyb_callback.params = params
+    RE.subscribe(nexus_callback)
+    RE.subscribe(ispyb_callback)
     with pytest.raises(ISPyBDepositionNotMade):
-        RE.subscribe(nexus_callback)
-        RE.subscribe(ispyb_callback)
         RE(do_rotation_scan)
     zocalo_trigger.run_start.assert_not_called()  # type: ignore
 

--- a/tests/unit_tests/hyperion/parameters/test_parameter_model.py
+++ b/tests/unit_tests/hyperion/parameters/test_parameter_model.py
@@ -95,19 +95,23 @@ def test_serialise_deserialise(minimal_3d_gridscan_params):
     assert deserialised.x_start_um == 0.123
 
 
-def test_param_version(minimal_3d_gridscan_params):
-    with pytest.raises(ValidationError):
-        minimal_3d_gridscan_params["parameter_model_version"] = "4.3.0"
+@pytest.mark.parametrize(
+    "version, valid",
+    [
+        ("4.3.0", False),
+        ("6.3.7", False),
+        ("5.0.0", True),
+        ("5.3.0", True),
+        ("5.3.7", True),
+    ],
+)
+def test_param_version(minimal_3d_gridscan_params, version: str, valid: bool):
+    minimal_3d_gridscan_params["parameter_model_version"] = version
+    if valid:
         _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
-    minimal_3d_gridscan_params["parameter_model_version"] = "5.0.0"
-    _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
-    minimal_3d_gridscan_params["parameter_model_version"] = "5.3.0"
-    _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
-    minimal_3d_gridscan_params["parameter_model_version"] = "5.3.7"
-    _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
-    with pytest.raises(ValidationError):
-        minimal_3d_gridscan_params["parameter_model_version"] = "6.3.7"
-        _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
+    else:
+        with pytest.raises(ValidationError):
+            _ = HyperionSpecifiedThreeDGridScan(**minimal_3d_gridscan_params)
 
 
 def test_robot_load_then_centre_params():


### PR DESCRIPTION
Fixes #851 

This PR should amend all tests that use `with pytest.raises()..`, such that the context manager only contains a single line of code (i.e., the line that raises the expected exception). This follows the newly added ruff linting rule [PT012](https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/). The main reason we are doing this is to avoid accidentally asserting within a `pytest.raises()` block, as this never runs, but looks like it does.

### Instructions to reviewer on how to test:

1. Check all instances of `with pytest.raises()..` accounted for.
2. Confirm tests still pass.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
