### PR TITLE
Do not forward invalid images to murko

### DIFF
--- a/src/mx_bluesky/beamlines/i04/redis_to_murko_forwarder.py
+++ b/src/mx_bluesky/beamlines/i04/redis_to_murko_forwarder.py
@@ -156,8 +156,15 @@ class RedisListener:
             sample_id = data["sample_id"]
 
             # Images are put in redis as raw jpeg bytes, murko needs numpy arrays
-            raw_image = self.redis_client.hget(f"murko:{sample_id}:raw", uuid)
-            assert isinstance(raw_image, bytes)
+            image_key = f"murko:{sample_id}:raw"
+            raw_image = self.redis_client.hget(image_key, uuid)
+
+            if not isinstance(raw_image, bytes):
+                LOGGER.warning(
+                    f"Image at {image_key}:{uuid} is {raw_image}, expected bytes. Ignoring the data"
+                )
+                return
+
             image = Image.open(io.BytesIO(raw_image))
             image = np.asarray(image)
 


### PR DESCRIPTION
Fixes #804

Formalized the idea of just warning and moving on. I think this is fine because I haven't seen the issue re-occur over the last week and we're streaming so many images to murko if we're a bit lossy it doesn't matter.

### Instructions to reviewer on how to test:

1. Confirm test passes

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
