### PR TITLE
(#256) Remove walrus operator from asserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.9.0a2",
     "bluesky == 1.13",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b119d38c70c67925a998f9bcfc09689db9043eaf",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@6fb409a5eade3be5357c700f9204989d9a5b8b41",
 ]
 
 

--- a/src/mx_bluesky/common/external_interaction/callbacks/common/ispyb_callback_base.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/common/ispyb_callback_base.py
@@ -121,10 +121,8 @@ class BaseISPyBCallback(PlanReactiveCallback):
         ISPYB_ZOCALO_CALLBACK_LOGGER.info(
             "ISPyB handler received event from read hardware"
         )
-        assert isinstance(
-            synchrotron_mode := doc["data"]["synchrotron-synchrotron_mode"],
-            SynchrotronMode,
-        )
+        synchrotron_mode = doc["data"]["synchrotron-synchrotron_mode"]
+        assert isinstance(synchrotron_mode, SynchrotronMode)
 
         hwscan_data_collection_info = DataCollectionInfo(
             undulator_gap1=doc["data"]["undulator-current_gap"],

--- a/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
@@ -42,7 +42,8 @@ class ZocaloCallback(CallbackBase):
         ISPYB_ZOCALO_CALLBACK_LOGGER.info("Zocalo handler received start document.")
         if self.triggering_plan and doc.get("subplan_name") == self.triggering_plan:
             self.run_uid = doc.get("uid")
-            assert isinstance(scan_points := doc.get("scan_points"), list)
+            scan_points = doc.get("scan_points")
+            assert isinstance(scan_points, list)
             if (
                 isinstance(ispyb_ids := doc.get("ispyb_dcids"), tuple)
                 and len(ispyb_ids) > 0

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/nexus_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/nexus_callback.py
@@ -79,7 +79,8 @@ class GridscanNexusFileCallback(PlanReactiveCallback):
         self.descriptors[doc["uid"]] = doc
 
     def activity_gated_event(self, doc: Event) -> Event | None:
-        assert (event_descriptor := self.descriptors.get(doc["descriptor"])) is not None
+        event_descriptor = self.descriptors.get(doc["descriptor"])
+        assert event_descriptor is not None
         if event_descriptor.get("name") == DocDescriptorNames.HARDWARE_READ_DURING:
             data = doc["data"]
             for nexus_writer in [self.nexus_writer_1, self.nexus_writer_2]:


### PR DESCRIPTION
Fixes #256

Link to dodal PR: #[1100](https://github.com/DiamondLightSource/dodal/pull/1100)

### Instructions to reviewer on how to test:

1. Search for the walrus operator inside the codebase.
2. Confirm it never occurs inside an assert, other than in tests.
3. If possible, run tests with the -O flag, possible using [dissert](https://github.com/boothby/dissert).

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
