### PR TITLE
(#899) Replace 'setup.cfg' with 'pyproject.tml' in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 Fixes #ISSUE
 
 Link to dodal PR (if required): #XXX
-(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)
+(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)
 
 ### Instructions to reviewer on how to test:
 


### PR DESCRIPTION
Fixes #899

### Instructions to reviewer on how to test:

1. Check that the template now includes 'pyproject.toml' rather than 'setup.cfg'.
2. Once merged, could check that this change is reflected when making a new PR.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
