### PR TITLE
(#898) Add docs on developing dodal alongside MXB

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,23 @@ Contributions and issues are most welcome! All issues and pull requests are hand
 
 **Work should not be done without an associated ticket describing what the work is**
 
+## Developing mx-bluesky and dodal
+
+Some issues will span the mx-bluesky repo and the dodal repo. When working on both at the same time, follow these instructions:
+1. An issue is created for the work, inside mx-bluesky. This issue should describe in as much detail as possible the work that needs to be done. Anyone is free to make a ticket and/or comment on one.
+2. If a developer is going to do the work they assign themselves to the issue.
+3. The developer makes a new branch in mx-bluesky with the format `issue_short_description` e.g. `122_create_a_contributing_file`. The developer also creates a new branch in dodal, with the format `mx_bluesky_issue_short_description` - the same as the mx-bluesky branch name but with `mx_bluesky_` in front. (External developers are also welcome to make forks)
+4. The developer does the work on these branches, adding their work in small commits. Commit messages should be informative and prefixed with the issue number e.g. `(#122) Added contributing file`.
+5. Once the developer has done the final commit in both repos, they find the latest commit SHA in the dodal repo using `git log`. In `mx-bluesky/pyproject.toml`, the developer changes `dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@{dodal_commmit_SHA}` using the SHA they just found.
+6. The developer commits and pushes this final change on mx-bluesky.
+7. The developer submits a dodal PR for the work they have done in the dodal repo. The pull request should start with `Fixes #issue_num` e.g. `Fixes #122`, and should link to the issue created in mx-bluesky. The developer should also add some background on how the reviewer might test the change.
+8. The developer submits a mx-bluesky PR for the work they have done in the mx-bluesky repo. The pull request should start with `Fixes #issue_num` e.g. `Fixes #122`. This PR should link to the dodal PR just created with something like "Also needs #456". Again, the developer should add some background on how the reviewer might test the change.
+9. If the developer has a particular person in mind to review the work they should assign that person to the PRs as a reviewer.
+10. The reviewer and developer go back and forth on the code until the reviewer approves it. (See "Reviewing Work" below)
+11. Once the work is approved the original developer merges it.
+
+**Work should not be done without an associated ticket describing what the work is**
+
 ## Reviewing Work
 
 **Work must be reviewed by another developer before it can be merged**. Remember that work is reviewed for a number of reasons:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Some issues will span the mx-bluesky repo and the dodal repo. When working on bo
 8. The developer submits a mx-bluesky PR for the work they have done in the mx-bluesky repo. The pull request should start with `Fixes #issue_num` e.g. `Fixes #122`. This PR should link to the dodal PR just created with something like "Also needs #456". Again, the developer should add some background on how the reviewer might test the change.
 9. If the developer has a particular person in mind to review the work they should assign that person to the PRs as a reviewer.
 10. The reviewer and developer go back and forth on the code until the reviewer approves it. (See "Reviewing Work" below)
-11. Once the work is approved the original developer merges it.
+11. Once the work is approved on both PRs, the original developer merges them. The PRs should be merged at the same time.
 
 **Work should not be done without an associated ticket describing what the work is**
 


### PR DESCRIPTION
Fixes #898

### Instructions to reviewer on how to test:

1. Check `.github/CONTRIBUTING.md`
2. Check the instructions under 'Developing mx-bluesky and dodal' are clear and correct.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
