### PR TITLE
Remove callable parameter in i04 thaw plan.

### DIFF
--- a/src/mx_bluesky/beamlines/i04/thawing_plan.py
+++ b/src/mx_bluesky/beamlines/i04/thawing_plan.py
@@ -64,7 +64,7 @@ def thaw_and_stream_to_redis(
         yield from bps.kickoff(oav_to_redis_forwarder, wait=True)
         yield from bps.monitor(smargon.omega.user_readback, name="smargon")
         yield from bps.monitor(oav_to_redis_forwarder.uuid, name="oav")
-        yield from thaw(
+        yield from _thaw(
             time_to_thaw, rotation, thawer, smargon, switch_forwarder_to_ROI
         )
         yield from bps.complete(oav_to_redis_forwarder)
@@ -79,6 +79,15 @@ def thaw_and_stream_to_redis(
 
 
 def thaw(
+    time_to_thaw: float,
+    rotation: float = 360,
+    thawer: Thawer = inject("thawer"),
+    smargon: Smargon = inject("smargon"),
+) -> MsgGenerator:
+    yield from _thaw(time_to_thaw, rotation, thawer, smargon)
+
+
+def _thaw(
     time_to_thaw: float,
     rotation: float = 360,
     thawer: Thawer = inject("thawer"),

--- a/tests/unit_tests/beamlines/i04/test_thawing.py
+++ b/tests/unit_tests/beamlines/i04/test_thawing.py
@@ -24,7 +24,10 @@ from ophyd_async.testing import (
     set_mock_value,
 )
 
-from mx_bluesky.beamlines.i04.thawing_plan import thaw, thaw_and_stream_to_redis
+from mx_bluesky.beamlines.i04.thawing_plan import (
+    thaw,
+    thaw_and_stream_to_redis,
+)
 
 DISPLAY_CONFIGURATION = "tests/test_data/test_display.configuration"
 ZOOM_LEVELS_XML = "tests/test_data/test_jCameraManZoomLevels.xml"
@@ -351,9 +354,9 @@ def test_given_thaw_succeeds_then_thaw_and_stream_sets_zoom_to_1_and_back(
 
 
 @patch("mx_bluesky.beamlines.i04.thawing_plan.MurkoCallback")
-@patch("mx_bluesky.beamlines.i04.thawing_plan.thaw")
+@patch("mx_bluesky.beamlines.i04.thawing_plan._thaw")
 def test_given_thaw_fails_then_thaw_and_stream_sets_zoom_to_1_and_back(
-    mock_thaw,
+    mock__thaw,
     patch_murko_callback,
     smargon: Smargon,
     thawer: Thawer,
@@ -362,7 +365,7 @@ def test_given_thaw_fails_then_thaw_and_stream_sets_zoom_to_1_and_back(
     robot: BartRobot,
     RE: RunEngine,
 ):
-    mock_thaw.side_effect = Exception()
+    mock__thaw.side_effect = Exception()
     _run_thaw_and_stream_and_assert_zoom_changes(
         smargon, thawer, oav_forwarder, oav, robot, RE, Exception
     )


### PR DESCRIPTION
Fixes #884 

Previously the `thaw` plan accepted a parameter `plan_between_rotations` that was a callable. This causes issues with blueapi, so I've re-factored the `thaw` and `thaw_and_stream_to_redis` to avoid this.

### Instructions to reviewer on how to test:

1. Run an i04 blueapi instance.
2. Confirm the `thaw` and `thaw_and_stream_to_redis` plans are listed when you click on 'get plans'.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
