### PR TITLE
Fixes for dodal 1085 breakage, pydantic deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ filterwarnings = [
     # Ignore warning about deprecations in python-workflows encountered during system tests
     # https://github.com/DiamondLightSource/python-workflows/issues/188
     "ignore:.*`Field` should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning",
+    # https://github.com/bluesky/ophyd-async/issues/838
+    "ignore:Accessing this attribute on the instance is deprecated"
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests/unit_tests"

--- a/src/mx_bluesky/hyperion/device_setup_plans/setup_panda.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/setup_panda.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import cast
 
 import bluesky.plan_stubs as bps
 from bluesky.utils import MsgGenerator
 from dodal.common.beamlines.beamline_utils import get_path_provider
+from dodal.common.types import UpdatingPathProvider
 from dodal.devices.fast_grid_scan import PandAGridScanParams
 from dodal.devices.smargon import Smargon
 from ophyd_async.fastcs.panda import (
@@ -222,6 +224,8 @@ def set_panda_directory(panda_directory: Path) -> MsgGenerator:
     suffix = datetime.now().strftime("_%Y%m%d%H%M%S")
 
     async def set_panda_dir():
-        await get_path_provider().update(directory=panda_directory, suffix=suffix)
+        await cast(UpdatingPathProvider, get_path_provider()).update(
+            directory=panda_directory, suffix=suffix
+        )
 
     yield from bps.wait_for([set_panda_dir])

--- a/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
@@ -1,3 +1,5 @@
+import warnings
+
 from deepdiff.diff import DeepDiff
 
 from mx_bluesky.hyperion.external_interaction.agamemnon import (
@@ -27,8 +29,14 @@ def test_given_test_agamemnon_instruction_then_returns_none_loop_type():
 def test_given_test_agamemnon_instruction_then_load_centre_collect_parameters_populated():
     params = _get_parameters_from_url(AGAMEMNON_URL + "/example/collect")
     load_centre_collect = populate_parameters_from_agamemnon(params)
-    difference = DeepDiff(
-        load_centre_collect,
-        EXPECTED_PARAMETERS,
-    )
+    difference = True
+    with warnings.catch_warnings():
+        # Suppress warning exceptions due to Pydantic 2.11 deprecation warnings
+        warnings.filterwarnings(
+            "ignore", "Accessing this attribute on the instance is deprecated"
+        )
+        difference = DeepDiff(
+            load_centre_collect,
+            EXPECTED_PARAMETERS,
+        )
     assert not difference


### PR DESCRIPTION
Fixes breakages caused by upstream changes:

* DiamondLightSource/dodal#1085
* bluesky/ophyd-async#838

plus a test failure in our own code caused by our use of `DeepDiff` on pydantic models which also triggers the problematic deprecation warnings

N.b. pydantic 2.11 is currently in pre-release but I have it accidentally installed due to having to revert some other package in my venv.

### Instructions to reviewer on how to test:

1. Tests pass
