### PR TITLE
Fix unit tests broken by DiamondLightSource/dodal#1193

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,6 +365,16 @@ def beamline_parameters():
     )
 
 
+@pytest.fixture(autouse=True)
+def i03_beamline_parameters():
+    """Fix default i03 beamline parameters to refer to a test file not the /dls_sw folder"""
+    with patch.dict(
+        "dodal.common.beamlines.beamline_parameters.BEAMLINE_PARAMETER_PATHS",
+        {"i03": "tests/test_data/test_beamline_parameters.txt"},
+    ) as params:
+        yield params
+
+
 @pytest.fixture
 def test_fgs_params():
     return HyperionSpecifiedThreeDGridScan(


### PR DESCRIPTION
Fixes unit tests broken by
* DiamondLightSource/dodal#1193

by patching the i03 default beamline_parameters file

