### PR TITLE
Yield to event loop in bluesky_retry to catch previous exceptions

### DIFF
--- a/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/setup_zebra.py
@@ -42,6 +42,8 @@ def bluesky_retry(func: Callable):
         yield from bpp.contingency_wrapper(
             func(*args, **kwargs), except_plan=log_and_retry, auto_raise=False
         )
+        # See https://github.com/bluesky/bluesky/issues/1795 for why we need to specify a group
+        yield from bps.wait("unused group ")
 
     return newfunc
 


### PR DESCRIPTION
Fixes #1031

Horrible fix for a horrible issue, but it's safer than using `bluesky_retry` without these extra lines

I tried a few other things, but they got even uglier

### Instructions to reviewer on how to test:

1. Confirm newly added test replicates conditions in issue
2. Check that the test fails without the added for loop
3. Check test passes with the extra for loop

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
