### PR TITLE
Move debug logs into `/tmp`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@0f79ecf28236c0e7b078e39db09499b591455cf5",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd == 1.9.0",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@0f79ecf28236c0e7b078e39db09499b591455cf5",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -26,7 +26,7 @@ from mx_bluesky.common.external_interaction.callbacks.xray_centre.nexus_callback
 from mx_bluesky.common.utils.log import (
     ISPYB_ZOCALO_CALLBACK_LOGGER,
     NEXUS_LOGGER,
-    _get_logging_dir,
+    _get_logging_dirs,
     tag_filter,
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.robot_load.ispyb_callback import (
@@ -93,14 +93,16 @@ def setup_logging(dev_mode: bool):
         (ISPYB_ZOCALO_CALLBACK_LOGGER, "hyperion_ispyb_callback.log"),
         (NEXUS_LOGGER, "hyperion_nexus_callback.log"),
     ]:
+        logging_path, debug_logging_path = _get_logging_dirs()
         if logger.handlers == []:
             handlers = set_up_all_logging_handlers(
                 logger,
-                _get_logging_dir(),
+                logging_path,
                 filename,
                 dev_mode,
-                error_log_buffer_lines=ERROR_LOG_BUFFER_LINES,
-                graylog_port=CONST.GRAYLOG_PORT,
+                ERROR_LOG_BUFFER_LINES,
+                CONST.GRAYLOG_PORT,
+                debug_logging_path,
             )
             handlers["graylog_handler"].addFilter(tag_filter)
     log_info(f"Loggers initialised with dev_mode={dev_mode}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ from mx_bluesky.common.utils.log import (
     ISPYB_ZOCALO_CALLBACK_LOGGER,
     LOGGER,
     NEXUS_LOGGER,
-    _get_logging_dir,
+    _get_logging_dirs,
     do_default_logging_setup,
 )
 from mx_bluesky.hyperion.parameters.rotation import MultiRotationScan
@@ -269,11 +269,12 @@ def pytest_runtest_setup(item):
             if dodal_logger.handlers == []:
                 print("Initialising Hyperion logger for tests")
                 do_default_logging_setup("dev_log.py", TEST_GRAYLOG_PORT, dev_mode=True)
+        logging_path, _ = _get_logging_dirs()
         if ISPYB_ZOCALO_CALLBACK_LOGGER.handlers == []:
             print("Initialising ISPyB logger for tests")
             set_up_all_logging_handlers(
                 ISPYB_ZOCALO_CALLBACK_LOGGER,
-                _get_logging_dir(),
+                logging_path,
                 "hyperion_ispyb_callback.log",
                 True,
                 10000,
@@ -282,7 +283,7 @@ def pytest_runtest_setup(item):
             print("Initialising nexus logger for tests")
             set_up_all_logging_handlers(
                 NEXUS_LOGGER,
-                _get_logging_dir(),
+                logging_path,
                 "hyperion_ispyb_callback.log",
                 True,
                 10000,


### PR DESCRIPTION
Fixes #1039

Link to dodal PR (if required): https://github.com/DiamondLightSource/dodal/pull/1209

### Instructions to reviewer on how to test:

1. Confirm tests still pass and in prod debug logs will be going into `/tmp`

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
