### PR TITLE
Make GridCommon class concrete

### DIFF
--- a/src/mx_bluesky/common/parameters/gridscan.py
+++ b/src/mx_bluesky/common/parameters/gridscan.py
@@ -29,7 +29,7 @@ from mx_bluesky.common.parameters.constants import (
 DETECTOR_SIZE_PER_BEAMLINE = {
     "i02-1": EIGER2_X_9M_SIZE,
     "dev": EIGER2_X_16M_SIZE,
-    "I03": EIGER2_X_16M_SIZE,
+    "i03": EIGER2_X_16M_SIZE,
 }
 
 

--- a/src/mx_bluesky/common/parameters/gridscan.py
+++ b/src/mx_bluesky/common/parameters/gridscan.py
@@ -185,34 +185,3 @@ class SpecifiedThreeDGridScan(
     @property
     def num_images(self) -> int:
         return len(self.scan_points["sam_x"])
-
-    @property
-    def detector_params(self):
-        self.det_dist_to_beam_converter_path = (
-            self.det_dist_to_beam_converter_path
-            or DetectorParamConstants.BEAM_XY_LUT_PATH
-        )
-        optional_args = {}
-        if self.run_number:
-            optional_args["run_number"] = self.run_number
-        assert self.detector_distance_mm is not None, (
-            "Detector distance must be filled before generating DetectorParams"
-        )
-        return DetectorParams(
-            detector_size_constants=DETECTOR_SIZE_PER_BEAMLINE[
-                get_beamline_name("dev")
-            ],
-            expected_energy_ev=self.demand_energy_ev,
-            exposure_time_s=self.exposure_time_s,
-            directory=self.storage_directory,
-            prefix=self.file_name,
-            detector_distance=self.detector_distance_mm,
-            omega_start=self.omega_start_deg or 0,
-            omega_increment=0,
-            num_images_per_trigger=1,
-            num_triggers=self.num_images,
-            use_roi_mode=self.use_roi_mode,
-            det_dist_to_beam_converter_path=self.det_dist_to_beam_converter_path,
-            trigger_mode=self.trigger_mode,
-            **optional_args,
-        )

--- a/src/mx_bluesky/common/parameters/gridscan.py
+++ b/src/mx_bluesky/common/parameters/gridscan.py
@@ -26,7 +26,11 @@ from mx_bluesky.common.parameters.constants import (
     HardwareConstants,
 )
 
-DETECTOR_SIZE_PER_BEAMLINE = {"i02-1": EIGER2_X_9M_SIZE, "dev": EIGER2_X_16M_SIZE}
+DETECTOR_SIZE_PER_BEAMLINE = {
+    "i02-1": EIGER2_X_9M_SIZE,
+    "dev": EIGER2_X_16M_SIZE,
+    "I03": EIGER2_X_16M_SIZE,
+}
 
 
 class GridCommon(

--- a/src/mx_bluesky/common/parameters/gridscan.py
+++ b/src/mx_bluesky/common/parameters/gridscan.py
@@ -50,6 +50,37 @@ class GridCommon(
 
     tip_offset_um: float = Field(default=HardwareConstants.TIP_OFFSET_UM)
 
+    @property
+    def detector_params(self):
+        self.det_dist_to_beam_converter_path = (
+            self.det_dist_to_beam_converter_path
+            or DetectorParamConstants.BEAM_XY_LUT_PATH
+        )
+        optional_args = {}
+        if self.run_number:
+            optional_args["run_number"] = self.run_number
+        assert self.detector_distance_mm is not None, (
+            "Detector distance must be filled before generating DetectorParams"
+        )
+        return DetectorParams(
+            detector_size_constants=DETECTOR_SIZE_PER_BEAMLINE[
+                get_beamline_name("dev")
+            ],
+            expected_energy_ev=self.demand_energy_ev,
+            exposure_time_s=self.exposure_time_s,
+            directory=self.storage_directory,
+            prefix=self.file_name,
+            detector_distance=self.detector_distance_mm,
+            omega_start=self.omega_start_deg or 0,
+            omega_increment=0,
+            num_images_per_trigger=1,
+            num_triggers=self.num_images,
+            use_roi_mode=self.use_roi_mode,
+            det_dist_to_beam_converter_path=self.det_dist_to_beam_converter_path,
+            trigger_mode=self.trigger_mode,
+            **optional_args,
+        )
+
 
 class SpecifiedGrid(XyzStarts, WithScan):
     """A specified grid is one which has defined values for the start position,

--- a/src/mx_bluesky/hyperion/parameters/gridscan.py
+++ b/src/mx_bluesky/hyperion/parameters/gridscan.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from dodal.devices.detector import (
-    DetectorParams,
-)
 from dodal.devices.fast_grid_scan import (
     PandAGridScanParams,
     ZebraGridScanParams,
@@ -13,7 +10,6 @@ from mx_bluesky.common.parameters.gridscan import (
     SpecifiedThreeDGridScan,
 )
 from mx_bluesky.hyperion.parameters.components import WithHyperionUDCFeatures
-from mx_bluesky.hyperion.parameters.constants import CONST, I03Constants
 
 
 class GridCommonWithHyperionDetectorParams(GridCommon, WithHyperionUDCFeatures):
@@ -23,34 +19,11 @@ class GridCommonWithHyperionDetectorParams(GridCommon, WithHyperionUDCFeatures):
     # https://github.com/DiamondLightSource/hyperion/issues/1395"""
     @property
     def detector_params(self):
-        self.det_dist_to_beam_converter_path = (
-            self.det_dist_to_beam_converter_path
-            or CONST.PARAM.DETECTOR.BEAM_XY_LUT_PATH
+        params = super().detector_params
+        params.enable_dev_shm = (
+            self.features.compare_cpu_and_gpu_zocalo or self.features.use_gpu_results
         )
-        optional_args = {}
-        if self.run_number:
-            optional_args["run_number"] = self.run_number
-        assert self.detector_distance_mm is not None, (
-            "Detector distance must be filled before generating DetectorParams"
-        )
-        return DetectorParams(
-            detector_size_constants=I03Constants.DETECTOR,
-            expected_energy_ev=self.demand_energy_ev,
-            exposure_time_s=self.exposure_time_s,
-            directory=self.storage_directory,
-            prefix=self.file_name,
-            detector_distance=self.detector_distance_mm,
-            omega_start=self.omega_start_deg or 0,
-            omega_increment=0,
-            num_images_per_trigger=1,
-            num_triggers=self.num_images,
-            use_roi_mode=self.use_roi_mode,
-            det_dist_to_beam_converter_path=self.det_dist_to_beam_converter_path,
-            trigger_mode=self.trigger_mode,
-            enable_dev_shm=self.features.compare_cpu_and_gpu_zocalo
-            or self.features.use_gpu_results,
-            **optional_args,
-        )
+        return params
 
 
 class HyperionSpecifiedThreeDGridScan(WithHyperionUDCFeatures, SpecifiedThreeDGridScan):
@@ -58,36 +31,14 @@ class HyperionSpecifiedThreeDGridScan(WithHyperionUDCFeatures, SpecifiedThreeDGr
 
     # These detector params only exist so that we can properly select enable_dev_shm. Remove in
     # https://github.com/DiamondLightSource/hyperion/issues/1395"""
+
     @property
     def detector_params(self):
-        self.det_dist_to_beam_converter_path = (
-            self.det_dist_to_beam_converter_path
-            or CONST.PARAM.DETECTOR.BEAM_XY_LUT_PATH
+        params = super().detector_params
+        params.enable_dev_shm = (
+            self.features.compare_cpu_and_gpu_zocalo or self.features.use_gpu_results
         )
-        optional_args = {}
-        if self.run_number:
-            optional_args["run_number"] = self.run_number
-        assert self.detector_distance_mm is not None, (
-            "Detector distance must be filled before generating DetectorParams"
-        )
-        return DetectorParams(
-            detector_size_constants=I03Constants.DETECTOR,
-            expected_energy_ev=self.demand_energy_ev,
-            exposure_time_s=self.exposure_time_s,
-            directory=self.storage_directory,
-            prefix=self.file_name,
-            detector_distance=self.detector_distance_mm,
-            omega_start=self.omega_start_deg or 0,
-            omega_increment=0,
-            num_images_per_trigger=1,
-            num_triggers=self.num_images,
-            use_roi_mode=self.use_roi_mode,
-            det_dist_to_beam_converter_path=self.det_dist_to_beam_converter_path,
-            trigger_mode=self.trigger_mode,
-            enable_dev_shm=self.features.compare_cpu_and_gpu_zocalo
-            or self.features.use_gpu_results,
-            **optional_args,
-        )
+        return params
 
     # Relative to common grid scan, stub offsets are defined by config server
     @property

--- a/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/hyperion/external_interaction/nexus/test_write_nexus.py
@@ -342,14 +342,14 @@ def test_nexus_writer_writes_width_and_height_correctly(single_dummy_file: Nexus
     )
 
 
-@patch.dict(os.environ, {"BEAMLINE": "I03"})
+@patch.dict(os.environ, {"BEAMLINE": "i03"})
 def test_nexus_writer_writes_beamline_name_correctly(
     test_fgs_params: HyperionSpecifiedThreeDGridScan,
 ):
     d_size = test_fgs_params.detector_params.detector_size_constants.det_size_pixels
     data_shape = (test_fgs_params.num_images, d_size.width, d_size.height)
     nexus_writer = NexusWriter(test_fgs_params, data_shape, test_fgs_params.scan_points)
-    assert nexus_writer.source.beamline == "I03"
+    assert nexus_writer.source.beamline == "i03"
 
 
 def check_validity_through_zocalo(nexus_writers: tuple[NexusWriter, NexusWriter]):


### PR DESCRIPTION
Fixes #1058

Added `detector_params` to `GridCommon` to make it a concrete class, and changed `GridCommonWithHyperionDetectorParams`and `HyperionSpecifiedThreeDGridScan` to use the `detector_params` they now inherit.

### Instructions to reviewer on how to test:

1. Confirm this is the right thing to do
2. Check Hyperion classes still function as intended

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
