### PR TITLE
Create setup beamstop plan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@8658495b230c891ca93fe2286730bddda9d1b67a",
 ]
 
 

--- a/src/mx_bluesky/common/device_setup_plans/setup_beamstop.py
+++ b/src/mx_bluesky/common/device_setup_plans/setup_beamstop.py
@@ -1,0 +1,14 @@
+import bluesky.plan_stubs as bps
+from dodal.devices.mx_phase1.beamstop import Beamstop, BeamstopPositions
+
+from mx_bluesky.common.utils.log import LOGGER
+
+
+def setup_beamstop_for_collection(beamstop: Beamstop):
+    current_pos = yield from bps.rd(beamstop.selected_pos)
+    LOGGER.info(f"Beamstop position: {current_pos}")
+    if current_pos != BeamstopPositions.DATA_COLLECTION:
+        LOGGER.info(f"Moving beamstop to {beamstop.in_beam_position_mm}")
+        yield from bps.abs_set(beamstop.x_mm, beamstop.in_beam_position_mm["x"])
+        yield from bps.abs_set(beamstop.y_mm, beamstop.in_beam_position_mm["y"])
+        yield from bps.abs_set(beamstop.z_mm, beamstop.in_beam_position_mm["z"])

--- a/tests/unit_tests/common/device_setup_plans/test_setup_beamstop.py
+++ b/tests/unit_tests/common/device_setup_plans/test_setup_beamstop.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+from bluesky.run_engine import RunEngine
+from dodal.devices.mx_phase1.beamstop import Beamstop
+from ophyd_async.testing import set_mock_value
+
+from mx_bluesky.common.device_setup_plans.setup_beamstop import (
+    setup_beamstop_for_collection,
+)
+
+
+def test_setup_beamstop_does_nothing_when_beamstop_in_beam(
+    beamstop_i03: Beamstop, RE: RunEngine
+):
+    beamstop_i03.x_mm.set = MagicMock()
+    beamstop_i03.y_mm.set = MagicMock()
+    beamstop_i03.z_mm.set = MagicMock()
+
+    set_mock_value(beamstop_i03.x_mm.user_readback, 1.52)
+    set_mock_value(beamstop_i03.y_mm.user_readback, 44.78)
+    set_mock_value(beamstop_i03.z_mm.user_readback, 30.0)
+
+    RE(setup_beamstop_for_collection(beamstop_i03))
+
+    assert beamstop_i03.x_mm.set.call_count == 0
+    assert beamstop_i03.y_mm.set.call_count == 0
+    assert beamstop_i03.z_mm.set.call_count == 0
+
+
+def test_setup_beamstop_moves_beamstop_into_beam_when_not_in_beam(
+    beamstop_i03: Beamstop, RE: RunEngine
+):
+    beamstop_i03.x_mm.set = MagicMock()
+    beamstop_i03.y_mm.set = MagicMock()
+    beamstop_i03.z_mm.set = MagicMock()
+    set_mock_value(beamstop_i03.x_mm.user_readback, 0)
+    set_mock_value(beamstop_i03.y_mm.user_readback, 0)
+    set_mock_value(beamstop_i03.z_mm.user_readback, 0)
+    RE(setup_beamstop_for_collection(beamstop_i03))
+
+    assert beamstop_i03.x_mm.set.call_count == 1
+    assert beamstop_i03.x_mm.set.call_args[0][0] == 1.52
+
+    assert beamstop_i03.y_mm.set.call_count == 1
+    assert beamstop_i03.y_mm.set.call_args[0][0] == 44.78
+
+    assert beamstop_i03.z_mm.set.call_count == 1
+    assert beamstop_i03.z_mm.set.call_args[0][0] == 30.0


### PR DESCRIPTION
Fixes #1060 

Link to dodal PR (if required): #[1227](https://github.com/DiamondLightSource/dodal/pull/1227)

Adds a plan to move the beamstop into position so that it's blocking the beam. We found during testing on i04 that some GDA plans left the beamstop out of position, meaning the grid detect then xray centre plan would crash at the point the `check_beamstop` plan was run.

### Instructions to reviewer on how to test:

1. Confirm the plan moves the beamstop to the correct position
2. Confirm the tests are thorough enough

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
