### PR TITLE
751 fix run hyperion in dev mode

### DIFF
--- a/docs/developer/hyperion/reference/readme.md
+++ b/docs/developer/hyperion/reference/readme.md
@@ -25,14 +25,17 @@ Note that because Hyperion makes heavy use of [Dodal](https://github.com/Diamond
 
 ## Starting the bluesky runner
 
-The bluesky runner is (re)started in production by GDA when it invokes `run_hyperion.sh`. 
+The bluesky runner is (re)started in production by GDA when it invokes `run_hyperion.sh`.
+
+
+This script will determine which beamline you are on based on the `BEAMLINE` environment variable. If on a 
+beamline Hyperion will run with `INFO` level logging, sending its logs to both production graylog and to the
+beamline/log/bluesky/hyperion.log on the shared file system.
 
 If you wish to attempt to run from a developer machine, then (if you are able to connect all devices) 
 you may `run_hyperion.sh --dev --beamline=<beamline>`, which will give you a running instance albeit with
-read-only devices. The `--dev` flag ensures that logging will not be sent to the production Graylog/output folders.
-
-This script will determine which beamline you are on based on the `BEAMLINE` environment variable. If on a 
-beamline Hyperion will run with `INFO` level logging, sending its logs to both production graylog and to the beamline/log/bluesky/hyperion.log on the shared file system.
+read-only devices. The `--dev` flag ensures that logging will not be sent to the production Graylog/output folders
+and that hyperion will create mock devices.
 
 If in a dev environment Hyperion will log to a local graylog instance instead and into a file at `./tmp/dev/hyperion.log`. A local instance of graylog will need to be running for this to work correctly. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
 

--- a/docs/developer/hyperion/reference/readme.md
+++ b/docs/developer/hyperion/reference/readme.md
@@ -43,12 +43,6 @@ This uses the generic defaults for a local graylog instance. It can be accessed 
 
 The hyperion python module can also be run directly without the startup script. It takes the same command line options, including:
 
-`INFO` level logging of the Bluesky event documents can be enabled with the flag
-
-```
-python -m hyperion --dev --verbose-event-logging
-```
-
 ## Testing
 
 Unit tests can be run with `pytest --random-order`. To see log output from tests you can turn on logging with the `--logging` command line option and then use the `-s` command line option to print logs into the console. So to run the unit tests such that all logs are at printed to the terminal, you can use `python -m pytest --random-order --logging -s`. Note that this will likely overrun your terminal buffer, so you can narrow the selection of tests with the `-k "<test name pattern>"` option.

--- a/helmcharts/hyperion/templates/deployment.yaml
+++ b/helmcharts/hyperion/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           hostPath:
             type: Directory
             path: "{{ .Values.application.logDir }}"
+        - name: debuglogs
+          hostPath:
+            type: Directory
+            path: "{{ .Values.application.debugLogDir }}"
         - name: data
           hostPath:
             type: Directory
@@ -108,6 +112,8 @@ spec:
         env:
           - name: LOG_DIR
             value: /var/log/bluesky
+          - name: DEBUG_LOG_DIR
+            value: /var/log/bluesky-debug
           - name: BEAMLINE
             value: "{{ .Values.application.beamline }}"
           {{- if not .Values.application.dev }}
@@ -147,6 +153,8 @@ spec:
             name: dodal
           - mountPath: "/var/log/bluesky"
             name: logs
+          - mountPath: "/var/log/bluesky-debug"
+            name: debuglogs
           - mountPath: "/dls/{{ .Values.application.beamline }}/data"
             name: data
       hostNetwork: true

--- a/helmcharts/hyperion/values.yaml
+++ b/helmcharts/hyperion/values.yaml
@@ -9,6 +9,7 @@ application:
   beamline: i03
   dev: false
   logDir: "/dls_sw/i03/logs/bluesky/hyperion-k8s"
+  debugLogDir: "/dls/tmp/i03/logs/bluesky"
   dataDir: "/dls/i03/data"
   # These should be overridden at install time
   projectDir: SET_ON_INSTALL

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -4,7 +4,6 @@
 
 STOP=0
 START=1
-VERBOSE_EVENT_LOGGING=false
 IN_DEV=false
 
 for option in "$@"; do
@@ -23,9 +22,6 @@ for option in "$@"; do
         --dev)
             IN_DEV=true
             ;;
-        --verbose-event-logging)
-            VERBOSE_EVENT_LOGGING=true
-            ;;
 
         --help|--info|--h)
             source .venv/bin/activate
@@ -42,7 +38,6 @@ Options:
   --skip-startup-connection
                           Do not connect to devices at startup
   --dev                   Enable dev mode to run from a local workspace on a development machine.
-  --verbose-event-logging Enable verbose event logging
   --help                  This help
 
 By default this script will start an Hyperion server unless the --no-start flag is specified.
@@ -122,19 +117,11 @@ if [[ $START == 1 ]]; then
     source .venv/bin/activate
 
     #Add future arguments here
-    declare -A h_only_args=( ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
-    declare -A h_only_arg_strings=( ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
 
     declare -A h_and_cb_args=( ["IN_DEV"]="$IN_DEV" )
     declare -A h_and_cb_arg_strings=( ["IN_DEV"]="--dev" )
 
     h_commands=()
-    for i in "${!h_only_args[@]}"
-    do
-        if [ "${h_only_args[$i]}" != false ]; then 
-            h_commands+="${h_only_arg_strings[$i]} ";
-        fi;
-    done
     cb_commands=()
     for i in "${!h_and_cb_args[@]}"
     do

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -42,7 +42,6 @@ Options:
   --skip-startup-connection
                           Do not connect to devices at startup
   --dev                   Enable dev mode to run from a local workspace on a development machine.
-                          Implied if BEAMLINE is not set.
   --verbose-event-logging Enable verbose event logging
   --help                  This help
 
@@ -73,9 +72,9 @@ check_user () {
 }
 
 if [ -z "${BEAMLINE}" ]; then
-    echo "BEAMLINE parameter not set, assuming running on a dev machine."
-    echo "If you would like to run not in dev use the option -b, --beamline=BEAMLNE to set it manually"
-    IN_DEV=true
+    echo "BEAMLINE environment variable is not set and the --beamline parameter is not specified."
+    echo "Please set the option -b, --beamline=BEAMLINE to set it manually"
+    exit 1
 fi
 
 if [[ $STOP == 1 ]]; then

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -11,6 +11,7 @@ for option in "$@"; do
     case $option in
         -b=*|--beamline=*)
             BEAMLINE="${option#*=}"
+            export BEAMLINE
             shift
             ;;
         --stop)

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -19,9 +19,6 @@ from pydantic.dataclasses import dataclass
 from mx_bluesky.common.external_interaction.callbacks.common.log_uid_tag_callback import (
     LogUidTaggingCallback,
 )
-from mx_bluesky.common.external_interaction.callbacks.common.logging_callback import (
-    VerbosePlanExecutionLoggingCallback,
-)
 from mx_bluesky.common.parameters.components import MxBlueskyParameters
 from mx_bluesky.common.parameters.constants import Actions, Status
 from mx_bluesky.common.utils.exceptions import WarningException
@@ -42,8 +39,6 @@ from mx_bluesky.hyperion.external_interaction.agamemnon import (
 from mx_bluesky.hyperion.parameters.cli import parse_cli_args
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.utils.context import setup_context
-
-VERBOSE_EVENT_LOGGING: bool | None = None
 
 
 @dataclass
@@ -96,9 +91,6 @@ class BlueskyRunner:
         LOGGER.info("Connecting to external callback ZMQ proxy...")
         self.publisher = Publisher(f"localhost:{CONST.CALLBACK_0MQ_PROXY_PORTS[0]}")
         RE.subscribe(self.publisher)
-
-        if VERBOSE_EVENT_LOGGING:
-            RE.subscribe(VerbosePlanExecutionLoggingCallback())
 
     def start(
         self,
@@ -273,9 +265,7 @@ def create_app(
     RE: RunEngine = RunEngine({}),
     dev_mode: bool = False,
 ) -> tuple[Flask, BlueskyRunner]:
-    context = setup_context(
-        dev_mode=dev_mode
-    )
+    context = setup_context(dev_mode=dev_mode)
     runner = BlueskyRunner(
         RE,
         context=context,
@@ -308,9 +298,7 @@ def create_targets():
         CONST.LOG_FILE_NAME, CONST.GRAYLOG_PORT, dev_mode=args.dev_mode
     )
     LOGGER.info(f"Hyperion launched with args:{argv}")
-    app, runner = create_app(
-        dev_mode=args.dev_mode
-    )
+    app, runner = create_app(dev_mode=args.dev_mode)
     return app, runner, hyperion_port, args.dev_mode
 
 

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -271,8 +271,11 @@ class FlushLogs(Resource):
 def create_app(
     test_config=None,
     RE: RunEngine = RunEngine({}),
+    dev_mode: bool = False,
 ) -> tuple[Flask, BlueskyRunner]:
-    context = setup_context()
+    context = setup_context(
+        dev_mode=dev_mode
+    )
     runner = BlueskyRunner(
         RE,
         context=context,
@@ -305,7 +308,9 @@ def create_targets():
         CONST.LOG_FILE_NAME, CONST.GRAYLOG_PORT, dev_mode=args.dev_mode
     )
     LOGGER.info(f"Hyperion launched with args:{argv}")
-    app, runner = create_app()
+    app, runner = create_app(
+        dev_mode=args.dev_mode
+    )
     return app, runner, hyperion_port, args.dev_mode
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -93,7 +93,7 @@ def setup_logging(dev_mode: bool):
         (ISPYB_ZOCALO_CALLBACK_LOGGER, "hyperion_ispyb_callback.log"),
         (NEXUS_LOGGER, "hyperion_nexus_callback.log"),
     ]:
-        logging_path, debug_logging_path = _get_logging_dirs()
+        logging_path, debug_logging_path = _get_logging_dirs(dev_mode)
         if logger.handlers == []:
             handlers = set_up_all_logging_handlers(
                 logger,

--- a/src/mx_bluesky/hyperion/parameters/cli.py
+++ b/src/mx_bluesky/hyperion/parameters/cli.py
@@ -8,7 +8,6 @@ from mx_bluesky._version import version
 @dataclass
 class HyperionArgs:
     dev_mode: bool = False
-    verbose_event_logging: bool = False
 
 
 def _add_callback_relevant_args(parser: argparse.ArgumentParser) -> None:
@@ -29,16 +28,11 @@ def parse_callback_dev_mode_arg() -> bool:
 
 
 def parse_cli_args() -> HyperionArgs:
-    """Parses all arguments relevant to hyperion. Returns an HyperionArgs dataclass with
-    the fields: (verbose_event_logging: bool,
-                 dev_mode: bool)"""
+    """Parses all arguments relevant to hyperion.
+    Returns:
+         an HyperionArgs dataclass with the fields: (dev_mode: bool)"""
     parser = argparse.ArgumentParser()
     _add_callback_relevant_args(parser)
-    parser.add_argument(
-        "--verbose-event-logging",
-        action="store_true",
-        help="Log all bluesky event documents to graylog",
-    )
     parser.add_argument(
         "--version",
         help="Print hyperion version string",
@@ -47,6 +41,5 @@ def parse_cli_args() -> HyperionArgs:
     )
     args = parser.parse_args()
     return HyperionArgs(
-        verbose_event_logging=args.verbose_event_logging or False,
         dev_mode=args.dev or False,
     )

--- a/src/mx_bluesky/hyperion/utils/context.py
+++ b/src/mx_bluesky/hyperion/utils/context.py
@@ -5,11 +5,16 @@ import mx_bluesky.hyperion.experiment_plans as hyperion_plans
 from mx_bluesky.common.utils.log import LOGGER
 
 
-def setup_context() -> BlueskyContext:
+def setup_context(
+    dev_mode: bool = False
+) -> BlueskyContext:
     context = BlueskyContext()
     context.with_plan_module(hyperion_plans)
 
-    context.with_dodal_module(get_beamline_based_on_environment_variable())
+    context.with_dodal_module(
+        get_beamline_based_on_environment_variable(),
+        mock=dev_mode,
+    )
 
     LOGGER.info(f"Plans found in context: {context.plan_functions.keys()}")
 

--- a/src/mx_bluesky/hyperion/utils/context.py
+++ b/src/mx_bluesky/hyperion/utils/context.py
@@ -5,9 +5,7 @@ import mx_bluesky.hyperion.experiment_plans as hyperion_plans
 from mx_bluesky.common.utils.log import LOGGER
 
 
-def setup_context(
-    dev_mode: bool = False
-) -> BlueskyContext:
+def setup_context(dev_mode: bool = False) -> BlueskyContext:
     context = BlueskyContext()
     context.with_plan_module(hyperion_plans)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,7 +271,7 @@ def pytest_runtest_setup(item):
             if dodal_logger.handlers == []:
                 print("Initialising Hyperion logger for tests")
                 do_default_logging_setup("dev_log.py", TEST_GRAYLOG_PORT, dev_mode=True)
-        logging_path, _ = _get_logging_dirs()
+        logging_path, _ = _get_logging_dirs(True)
         if ISPYB_ZOCALO_CALLBACK_LOGGER.handlers == []:
             print("Initialising ISPyB logger for tests")
             set_up_all_logging_handlers(

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from sys import argv
 from time import sleep
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from blueapi.core import BlueskyContext
@@ -118,6 +118,15 @@ TEST_EXPTS = {
         "param_type": HyperionSpecifiedThreeDGridScan,
     },
 }
+
+
+@pytest.fixture
+def mock_setup_context(request: pytest.FixtureRequest):
+    with (
+        patch("mx_bluesky.hyperion.__main__.setup_context") as mock_setup_context,
+        patch("mx_bluesky.hyperion.__main__.BlueskyRunner"),
+    ):
+        yield mock_setup_context
 
 
 @pytest.fixture
@@ -458,12 +467,13 @@ def test_warn_exception_during_plan_causes_warning_in_log(
     assert caplog.records[-1].levelname == "WARNING"
 
 
+@pytest.mark.parametrize("dev_mode", [True, False])
 @patch(
     "dodal.devices.i03.undulator_dcm.get_beamline_parameters",
     return_value={"DCM_Perp_Offset_FIXED": 111},
 )
 def test_when_context_created_then_contains_expected_number_of_plans(
-    get_beamline_parameters,
+    get_beamline_parameters, dev_mode
 ):
     from dodal.beamlines import i03
 
@@ -475,8 +485,9 @@ def test_when_context_created_then_contains_expected_number_of_plans(
     ):
         with patch(
             "mx_bluesky.hyperion.utils.context.BlueskyContext.with_dodal_module"
-        ):
-            context = setup_context()
+        ) as mock_with_dodal_module:
+            context = setup_context(dev_mode=dev_mode)
+            mock_with_dodal_module.assert_called_once_with(ANY, mock=dev_mode)
         plan_names = context.plans.keys()
 
         # assert "rotation_scan" in plan_names
@@ -484,3 +495,14 @@ def test_when_context_created_then_contains_expected_number_of_plans(
         assert "multi_rotation_scan" in plan_names
         assert "grid_detect_then_xray_centre" in plan_names
         assert "pin_tip_centre_then_xray_centre" in plan_names
+
+
+@pytest.mark.parametrize("dev_mode", [False, True])
+def test_create_app_passes_through_dev_mode(
+    dev_mode: bool, mock_setup_context: MagicMock
+):
+    mock_run_engine = MagicMock()
+
+    create_app({"TESTING": True}, mock_run_engine, dev_mode=dev_mode)
+
+    mock_setup_context.assert_called_once_with(dev_mode=dev_mode)

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -354,23 +354,15 @@ def test_start_with_json_file_with_extras_gives_error(test_env: ClientAndRunEngi
             [
                 "--dev",
             ],
-            (True, False),
+            (True,),
         ),
-        ([], (False, False)),
-        (
-            [
-                "--dev",
-                "--verbose-event-logging",
-            ],
-            (True, True),
-        ),
+        ([], (False,)),
     ],
 )
 def test_cli_args_parse(arg_list, parsed_arg_values):
     argv[1:] = arg_list
     test_args = parse_cli_args()
     assert test_args.dev_mode == parsed_arg_values[0]
-    assert test_args.verbose_event_logging == parsed_arg_values[1]
 
 
 @pytest.mark.skip(

--- a/utility_scripts/docker/entrypoint.sh
+++ b/utility_scripts/docker/entrypoint.sh
@@ -7,10 +7,6 @@ for option in "$@"; do
         --dev)
             IN_DEV=true
             ;;
-        --verbose-event-logging)
-            VERBOSE_EVENT_LOGGING=true
-            ;;
-
         --help|--info|--h)
             echo "Arguments:"
             echo "  --dev start in development mode without external callbacks"
@@ -39,19 +35,10 @@ start_log_path=$LOG_DIR/start_log.log
 callback_start_log_path=$LOG_DIR/callback_start_log.log
 
 #Add future arguments here
-declare -A h_only_args=( ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
-declare -A h_only_arg_strings=( ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
-
 declare -A h_and_cb_args=( ["IN_DEV"]="$IN_DEV" )
 declare -A h_and_cb_arg_strings=( ["IN_DEV"]="--dev" )
 
 h_commands=()
-for i in "${!h_only_args[@]}"
-do
-    if [ "${h_only_args[$i]}" != false ]; then 
-        h_commands+="${h_only_arg_strings[$i]} ";
-    fi;
-done
 cb_commands=()
 for i in "${!h_and_cb_args[@]}"
 do


### PR DESCRIPTION
Fixes

* #751 

Note that the issue was likely caused by launching hyperion directly with the --dev parameter, not via `run_hyperion.sh`

Changes to the `run_hyperion.sh` script consist of the following minor tidyups/fixes:
* Better documentation of options, and don't defer to python for generating the first bit of the help text
* Always specify `ZOCALO_CONFIG` and `ISPYB_CONFIG` with `--dev` so that we don't try to talk to production servers
* Require BEAMLINE to be always set in the environment or specified as a parameter

This PR also changes `--dev-mode` so that now it creates mock devices instead of real ones, ensuring that hyperion can be started without access to the beamline network.

This also addresses some issues arising from

* #1039 

* DEBUG_LOG_DIR can now be specified for use by containers
* the default debug logging dir of /dls/tmp/{beamline} is now applied even when LOG_DIR is specified
* if --dev-mode is specified, when launching hyperion the production logging directories will not be applied

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Debug logging dirs are now applied when hyperion is started from GDA or in a container
2.  if --dev-mode is specified, when launching hyperion the production logging directories will not be applied
3. --dev-mode now works from a desktop machine

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
