### PR TITLE
Remove --skip-startup-connection startup option and associated device warmup

### DIFF
--- a/docs/developer/hyperion/reference/readme.md
+++ b/docs/developer/hyperion/reference/readme.md
@@ -25,9 +25,14 @@ Note that because Hyperion makes heavy use of [Dodal](https://github.com/Diamond
 
 ## Starting the bluesky runner
 
-You can start the bluesky runner by running `run_hyperion.sh`. Note that this will fail on a developer machine unless you have a simulated beamline running, instead you should do `run_hyperion.sh --dev --skip-startup-connection`, which will give you a running instance (note that without hardware trying to run a plan on this will fail). The `--dev` flag ensures that logging will not be sent to the production Graylog.
+The bluesky runner is (re)started in production by GDA when it invokes `run_hyperion.sh`. 
 
-This script will determine whether you are on a beamline or a production machine based on the `BEAMLINE` environment variable. If on a beamline Hyperion will run with `INFO` level logging, sending its logs to both production graylog and to the beamline/log/bluesky/hyperion.log on the shared file system.
+If you wish to attempt to run from a developer machine, then (if you are able to connect all devices) 
+you may `run_hyperion.sh --dev --beamline=<beamline>`, which will give you a running instance albeit with
+read-only devices. The `--dev` flag ensures that logging will not be sent to the production Graylog/output folders.
+
+This script will determine which beamline you are on based on the `BEAMLINE` environment variable. If on a 
+beamline Hyperion will run with `INFO` level logging, sending its logs to both production graylog and to the beamline/log/bluesky/hyperion.log on the shared file system.
 
 If in a dev environment Hyperion will log to a local graylog instance instead and into a file at `./tmp/dev/hyperion.log`. A local instance of graylog will need to be running for this to work correctly. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
 
@@ -39,12 +44,6 @@ The hyperion python module can also be run directly without the startup script. 
 
 ```
 python -m hyperion --dev --verbose-event-logging
-```
-
-Lastly, you can choose to skip running the hardware connection scripts on startup with the flag
-
-```
-python -m hyperion --skip-startup-connection
 ```
 
 ## Testing

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -2,7 +2,6 @@
 
 STOP=0
 START=1
-SKIP_STARTUP_CONNECTION=false
 VERBOSE_EVENT_LOGGING=false
 IN_DEV=false
 
@@ -17,9 +16,6 @@ for option in "$@"; do
             ;;
         --no-start)
             START=0
-            ;;
-        --skip-startup-connection)
-            SKIP_STARTUP_CONNECTION=true
             ;;
         --dev)
             IN_DEV=true
@@ -114,10 +110,8 @@ if [[ $START == 1 ]]; then
     source .venv/bin/activate
 
     #Add future arguments here
-    declare -A h_only_args=(        ["SKIP_STARTUP_CONNECTION"]="$SKIP_STARTUP_CONNECTION"
-                                    ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
-    declare -A h_only_arg_strings=( ["SKIP_STARTUP_CONNECTION"]="--skip-startup-connection"
-                                    ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
+    declare -A h_only_args=( ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
+    declare -A h_only_arg_strings=( ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
 
     declare -A h_and_cb_args=( ["IN_DEV"]="$IN_DEV" )
     declare -A h_and_cb_arg_strings=( ["IN_DEV"]="--dev" )

--- a/src/mx_bluesky/hyperion/parameters/cli.py
+++ b/src/mx_bluesky/hyperion/parameters/cli.py
@@ -9,7 +9,6 @@ from mx_bluesky._version import version
 class HyperionArgs:
     dev_mode: bool = False
     verbose_event_logging: bool = False
-    skip_startup_connection: bool = False
 
 
 def _add_callback_relevant_args(parser: argparse.ArgumentParser) -> None:
@@ -32,19 +31,13 @@ def parse_callback_dev_mode_arg() -> bool:
 def parse_cli_args() -> HyperionArgs:
     """Parses all arguments relevant to hyperion. Returns an HyperionArgs dataclass with
     the fields: (verbose_event_logging: bool,
-                 dev_mode: bool,
-                 skip_startup_connection: bool)"""
+                 dev_mode: bool)"""
     parser = argparse.ArgumentParser()
     _add_callback_relevant_args(parser)
     parser.add_argument(
         "--verbose-event-logging",
         action="store_true",
         help="Log all bluesky event documents to graylog",
-    )
-    parser.add_argument(
-        "--skip-startup-connection",
-        action="store_true",
-        help="Skip connecting to EPICS PVs on startup",
     )
     parser.add_argument(
         "--version",
@@ -56,5 +49,4 @@ def parse_cli_args() -> HyperionArgs:
     return HyperionArgs(
         verbose_event_logging=args.verbose_event_logging or False,
         dev_mode=args.dev or False,
-        skip_startup_connection=args.skip_startup_connection or False,
     )

--- a/src/mx_bluesky/hyperion/utils/context.py
+++ b/src/mx_bluesky/hyperion/utils/context.py
@@ -5,14 +5,11 @@ import mx_bluesky.hyperion.experiment_plans as hyperion_plans
 from mx_bluesky.common.utils.log import LOGGER
 
 
-def setup_context(wait_for_connection: bool = True) -> BlueskyContext:
+def setup_context() -> BlueskyContext:
     context = BlueskyContext()
     context.with_plan_module(hyperion_plans)
 
-    context.with_dodal_module(
-        get_beamline_based_on_environment_variable(),
-        wait_for_connection=wait_for_connection,
-    )
+    context.with_dodal_module(get_beamline_based_on_environment_variable())
 
     LOGGER.info(f"Plans found in context: {context.plan_functions.keys()}")
 

--- a/utility_scripts/docker/entrypoint.sh
+++ b/utility_scripts/docker/entrypoint.sh
@@ -4,9 +4,6 @@
 
 for option in "$@"; do
     case $option in
-        --skip-startup-connection)
-            SKIP_STARTUP_CONNECTION=true
-            ;;
         --dev)
             IN_DEV=true
             ;;
@@ -42,10 +39,8 @@ start_log_path=$LOG_DIR/start_log.log
 callback_start_log_path=$LOG_DIR/callback_start_log.log
 
 #Add future arguments here
-declare -A h_only_args=(        ["SKIP_STARTUP_CONNECTION"]="$SKIP_STARTUP_CONNECTION"
-                                ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
-declare -A h_only_arg_strings=( ["SKIP_STARTUP_CONNECTION"]="--skip-startup-connection"
-                                ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
+declare -A h_only_args=( ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING" )
+declare -A h_only_arg_strings=( ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging" )
 
 declare -A h_and_cb_args=( ["IN_DEV"]="$IN_DEV" )
 declare -A h_and_cb_arg_strings=( ["IN_DEV"]="--dev" )


### PR DESCRIPTION
This removes the `--skip-startup-connection` option, which no longer does anything, since 

* https://github.com/DiamondLightSource/blueapi/pull/751
which implements ADR

https://diamondlightsource.github.io/blueapi/main/explanations/decisions/0005-connect-devices.html

This also removes the preloading of devices that occurs by calling the `create_devices` methods of all the entry points, since standard blueapi beamline loading already connects all the devices.

Also solves the following outdated issues:
* #253 
* #284 

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Tests pass
2. mx-bluesky still launches

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
