### PR TITLE
Make the debug logging dir work when Hyperion is launched

### DIFF
--- a/helmcharts/hyperion/templates/deployment.yaml
+++ b/helmcharts/hyperion/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           hostPath:
             type: Directory
             path: "{{ .Values.application.logDir }}"
+        - name: debuglogs
+          hostPath:
+            type: Directory
+            path: "{{ .Values.application.debugLogDir }}"
         - name: data
           hostPath:
             type: Directory
@@ -108,6 +112,8 @@ spec:
         env:
           - name: LOG_DIR
             value: /var/log/bluesky
+          - name: DEBUG_LOG_DIR
+            value: /var/log/bluesky-debug
           - name: BEAMLINE
             value: "{{ .Values.application.beamline }}"
           {{- if not .Values.application.dev }}
@@ -147,6 +153,8 @@ spec:
             name: dodal
           - mountPath: "/var/log/bluesky"
             name: logs
+          - mountPath: "/var/log/bluesky-debug"
+            name: debuglogs
           - mountPath: "/dls/{{ .Values.application.beamline }}/data"
             name: data
       hostNetwork: true

--- a/helmcharts/hyperion/values.yaml
+++ b/helmcharts/hyperion/values.yaml
@@ -9,6 +9,7 @@ application:
   beamline: i03
   dev: false
   logDir: "/dls_sw/i03/logs/bluesky/hyperion-k8s"
+  debugLogDir: "/dls/tmp/i03/logs/bluesky"
   dataDir: "/dls/i03/data"
   # These should be overridden at install time
   projectDir: SET_ON_INSTALL

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -93,7 +93,7 @@ def setup_logging(dev_mode: bool):
         (ISPYB_ZOCALO_CALLBACK_LOGGER, "hyperion_ispyb_callback.log"),
         (NEXUS_LOGGER, "hyperion_nexus_callback.log"),
     ]:
-        logging_path, debug_logging_path = _get_logging_dirs()
+        logging_path, debug_logging_path = _get_logging_dirs(dev_mode)
         if logger.handlers == []:
             handlers = set_up_all_logging_handlers(
                 logger,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,7 +276,7 @@ def pytest_runtest_setup(item):
             if dodal_logger.handlers == []:
                 print("Initialising Hyperion logger for tests")
                 do_default_logging_setup("dev_log.py", TEST_GRAYLOG_PORT, dev_mode=True)
-        logging_path, _ = _get_logging_dirs()
+        logging_path, _ = _get_logging_dirs(True)
         if ISPYB_ZOCALO_CALLBACK_LOGGER.handlers == []:
             print("Initialising ISPyB logger for tests")
             set_up_all_logging_handlers(


### PR DESCRIPTION
This addresses some issues arising from

* #1039 

* DEBUG_LOG_DIR can now be specified for use by containers
* the default debug logging dir of /dls/tmp/{beamline} is now applied even when LOG_DIR is specified
* if --dev-mode is specified, when launching hyperion the production logging directories will not be applied

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Debug logging dirs are now applied when hyperion is started from GDA or in a container

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
