### PR TITLE
Convert numpy types for ispyb

### DIFF
--- a/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
+++ b/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import ispyb
 import ispyb.sqlalchemy
+import numpy as np
 from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
 from ispyb.sp.mxacquisition import MXAcquisition
 from ispyb.strictordereddict import StrictOrderedDict
@@ -280,7 +281,9 @@ class StoreInIspyb:
                 conn, data_collection_info.visit_string
             )
         params |= {
-            k: v for k, v in asdict(data_collection_info).items() if k != "visit_string"
+            k: v.item() if isinstance(v, np.generic) else v  # Convert to native types
+            for k, v in asdict(data_collection_info).items()
+            if k != "visit_string"
         }
 
         return params


### PR DESCRIPTION
Fixes #1066 

Converts numpy data types to native python types before sending to ispyb. This allows data collection info to contain numpy numbers without causing an error.

### Instructions to reviewer on how to test:

1. Send data collection params containing floats to ispyb.
2. Confirm this works with no error

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
