### PR TITLE
Create setup beamstop plan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@35016aacfdd121f2811e8ba9061d86a660095758",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@51363d36670c939279d560e10fc81f1928fdb644",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@35016aacfdd121f2811e8ba9061d86a660095758",
 ]
 
 

--- a/src/mx_bluesky/hyperion/device_setup_plans/utils.py
+++ b/src/mx_bluesky/hyperion/device_setup_plans/utils.py
@@ -8,8 +8,8 @@ from dodal.devices.detector import (
 )
 from dodal.devices.detector.detector_motion import DetectorMotion, ShutterState
 from dodal.devices.eiger import EigerDetector
-from dodal.devices.i03 import Beamstop
 from dodal.devices.i03.dcm import DCM
+from dodal.devices.mx_phase1.beamstop import Beamstop, BeamstopPositions
 
 from mx_bluesky.common.device_setup_plans.check_beamstop import check_beamstop
 from mx_bluesky.common.device_setup_plans.position_detector import (
@@ -52,6 +52,9 @@ def start_preparing_data_collection_then_do_plan(
         yield from set_shutter(detector_motion, ShutterState.OPEN, group)
         yield from plan_to_run
 
+    yield from bps.abs_set(
+        beamstop.selected_pos, BeamstopPositions.DATA_COLLECTION, wait=True
+    )
     yield from check_beamstop(beamstop)
     yield from bpp.contingency_wrapper(
         wrapped_plan(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -561,12 +561,17 @@ def beamstop_i03(
         set_mock_value(beamstop.y_mm.user_readback, 44.78)
         set_mock_value(beamstop.z_mm.user_readback, 30.0)
 
+        # sim_run_engine.add_read_handler_for(
+        #     beamstop.selected_pos, BeamstopPositions.DATA_COLLECTION
+        # )
+        # Can uncomment and remove below when https://github.com/bluesky/bluesky/issues/1906 is fixed
         def locate_beamstop(_):
             return {"readback": BeamstopPositions.DATA_COLLECTION}
 
         sim_run_engine.add_handler(
             "locate", locate_beamstop, beamstop.selected_pos.name
         )
+
         yield beamstop
         beamline_utils.clear_devices()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 import numpy
 import pydantic
 import pytest
-from bluesky.protocols import Location
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator
 from bluesky.utils import Msg
@@ -562,14 +561,12 @@ def beamstop_i03(
         set_mock_value(beamstop.y_mm.user_readback, 44.78)
         set_mock_value(beamstop.z_mm.user_readback, 30.0)
 
-        beamstop.selected_pos.locate = MagicMock()
-        beamstop.selected_pos.locate.return_value = Location(
-            readback=BeamstopPositions.DATA_COLLECTION
-        )
+        def locate_beamstop(_):
+            return {"readback": BeamstopPositions.DATA_COLLECTION}
 
-        # sim_run_engine.add_read_handler_for(
-        #     beamstop.selected_pos, BeamstopPositions.DATA_COLLECTION
-        # )
+        sim_run_engine.add_handler(
+            "locate", locate_beamstop, beamstop.selected_pos.name
+        )
         yield beamstop
         beamline_utils.clear_devices()
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -412,16 +412,25 @@ def test_load_centre_collect_fails_with_exception_when_no_beamstop(
     oav_parameters_for_rotation: OAVParameters,
     sim_run_engine: RunEngineSimulator,
 ):
-    sim_run_engine.add_read_handler_for(
-        composite.beamstop.selected_pos, BeamstopPositions.UNKNOWN
-    )
+    # sim_run_engine.add_read_handler_for(
+    #     composite.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # )
+    # Can uncomment and remove below when https://github.com/bluesky/bluesky/issues/1906 is fixed
+    def locate_beamstop(_):
+        return {"readback": BeamstopPositions.UNKNOWN}
 
-    with pytest.raises(BeamstopException):
-        sim_run_engine.simulate_plan(
-            load_centre_collect_full(
-                composite, load_centre_collect_params, oav_parameters_for_rotation
+    sim_run_engine.add_handler(
+        "locate",
+        locate_beamstop,
+        composite.beamstop.selected_pos.name,
+    )
+    with patch("mx_bluesky.hyperion.device_setup_plans.utils.bps.abs_set"):
+        with pytest.raises(BeamstopException):
+            sim_run_engine.simulate_plan(
+                load_centre_collect_full(
+                    composite, load_centre_collect_params, oav_parameters_for_rotation
+                )
             )
-        )
 
 
 def test_can_deserialize_top_n_by_max_count_params(

--- a/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -363,12 +363,22 @@ def test_pin_tip_centre_then_xray_centre_fails_with_exception_when_no_beamstop(
     grid_detect_devices: GridDetectThenXRayCentreComposite,
     test_pin_centre_then_xray_centre_params: PinTipCentreThenXrayCentre,
 ):
-    sim_run_engine.add_read_handler_for(
-        grid_detect_devices.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # sim_run_engine.add_read_handler_for(
+    #     grid_detect_devices.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # )
+    # Can uncomment and remove below when https://github.com/bluesky/bluesky/issues/1906 is fixed
+    def locate_beamstop(_):
+        return {"readback": BeamstopPositions.UNKNOWN}
+
+    sim_run_engine.add_handler(
+        "locate",
+        locate_beamstop,
+        grid_detect_devices.beamstop.selected_pos.name,
     )
-    with pytest.raises(BeamstopException):
-        sim_run_engine.simulate_plan(
-            pin_tip_centre_then_xray_centre(
-                grid_detect_devices, test_pin_centre_then_xray_centre_params
+    with patch("mx_bluesky.hyperion.device_setup_plans.utils.bps.abs_set"):
+        with pytest.raises(BeamstopException):
+            sim_run_engine.simulate_plan(
+                pin_tip_centre_then_xray_centre(
+                    grid_detect_devices, test_pin_centre_then_xray_centre_params
+                )
             )
-        )

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_then_centre.py
@@ -441,15 +441,25 @@ def test_robot_load_then_centre_fails_with_exception_when_no_beamstop(
     robot_load_composite: RobotLoadThenCentreComposite,
     robot_load_then_centre_params: RobotLoadThenCentre,
 ):
-    sim_run_engine.add_read_handler_for(
-        robot_load_composite.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # sim_run_engine.add_read_handler_for(
+    #     robot_load_composite.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # )
+    # Can uncomment and remove below when https://github.com/bluesky/bluesky/issues/1906 is fixed
+    def locate_beamstop(_):
+        return {"readback": BeamstopPositions.UNKNOWN}
+
+    sim_run_engine.add_handler(
+        "locate",
+        locate_beamstop,
+        robot_load_composite.beamstop.selected_pos.name,
     )
-    with pytest.raises(BeamstopException):
-        sim_run_engine.simulate_plan(
-            robot_load_then_xray_centre(
-                robot_load_composite, robot_load_then_centre_params
+    with patch("mx_bluesky.hyperion.device_setup_plans.utils.bps.abs_set"):
+        with pytest.raises(BeamstopException):
+            sim_run_engine.simulate_plan(
+                robot_load_then_xray_centre(
+                    robot_load_composite, robot_load_then_centre_params
+                )
             )
-        )
 
 
 @pytest.mark.timeout(2)

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -753,17 +753,27 @@ def test_rotation_scan_fails_with_exception_when_no_beamstop(
     test_rotation_params: MultiRotationScan,
     oav_parameters_for_rotation: OAVParameters,
 ):
-    sim_run_engine.add_read_handler_for(
-        fake_create_rotation_devices.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # sim_run_engine.add_read_handler_for(
+    #     fake_create_rotation_devices.beamstop.selected_pos, BeamstopPositions.UNKNOWN
+    # )
+    # Can uncomment and remove below when https://github.com/bluesky/bluesky/issues/1906 is fixed
+    def locate_beamstop(_):
+        return {"readback": BeamstopPositions.UNKNOWN}
+
+    sim_run_engine.add_handler(
+        "locate",
+        locate_beamstop,
+        fake_create_rotation_devices.beamstop.selected_pos.name,
     )
-    with pytest.raises(BeamstopException):
-        sim_run_engine.simulate_plan(
-            multi_rotation_scan(
-                fake_create_rotation_devices,
-                test_rotation_params,
-                oav_parameters_for_rotation,
+    with patch("mx_bluesky.hyperion.device_setup_plans.utils.bps.abs_set"):
+        with pytest.raises(BeamstopException):
+            sim_run_engine.simulate_plan(
+                multi_rotation_scan(
+                    fake_create_rotation_devices,
+                    test_rotation_params,
+                    oav_parameters_for_rotation,
+                )
             )
-        )
 
 
 @pytest.mark.timeout(2)


### PR DESCRIPTION
Fixes #1060

Link to dodal PR (if required): [#1227](https://github.com/DiamondLightSource/dodal/pull/1227)

Uses the changes to beamstop in the dodal PR above to move the beamstop into position in every plan. If the beamstop is already in position, nothing should happen and this should add no time. The `check_beamstop` plan is still in place after this so if the beamstop is not in place at that point, this will raise an exception.

### Instructions to reviewer on how to test:

1. Move beamstop out of position
2. Confirm beamstop moves back into position before xray centring

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
