### PR TITLE
Setup beamline for oav before grid detect

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -49,6 +49,9 @@ from mx_bluesky.hyperion.device_setup_plans.utils import (
 from mx_bluesky.hyperion.experiment_plans.hyperion_flyscan_xray_centre_plan import (
     construct_hyperion_specific_features,
 )
+from mx_bluesky.hyperion.experiment_plans.oav_snapshot_plan import (
+    setup_beamline_for_OAV,
+)
 from mx_bluesky.hyperion.parameters.constants import CONST
 from mx_bluesky.hyperion.parameters.device_composites import (
     GridDetectThenXRayCentreComposite,
@@ -105,6 +108,13 @@ def detect_grid_and_do_gridscan(
             parameters.grid_width_um,
             parameters.box_size_um,
         )
+
+    yield from setup_beamline_for_OAV(
+        composite.smargon,
+        composite.backlight,
+        composite.aperture_scatterguard,
+        wait=True,
+    )
 
     if parameters.selected_aperture:
         # Start moving the aperture/scatterguard into position without moving it in

--- a/src/mx_bluesky/hyperion/experiment_plans/oav_snapshot_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/oav_snapshot_plan.py
@@ -29,6 +29,7 @@ def setup_beamline_for_OAV(
     backlight: Backlight,
     aperture_scatterguard: ApertureScatterguard,
     group=CONST.WAIT.READY_FOR_OAV,
+    wait=False,
 ):
     max_vel = yield from bps.rd(smargon.omega.max_velocity)
     yield from bps.abs_set(smargon.omega.velocity, max_vel, group=group)
@@ -36,6 +37,8 @@ def setup_beamline_for_OAV(
     yield from bps.abs_set(
         aperture_scatterguard.selected_aperture, ApertureValue.OUT_OF_BEAM, group=group
     )
+    if wait:
+        yield from bps.wait(group)
 
 
 def oav_snapshot_plan(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,6 +417,7 @@ def smargon(RE: RunEngine) -> Generator[Smargon, None, None]:
     set_mock_value(smargon.y.low_limit_travel, -2)
     set_mock_value(smargon.z.high_limit_travel, 2)
     set_mock_value(smargon.z.low_limit_travel, -2)
+    set_mock_value(smargon.omega.max_velocity, 1)
 
     with (
         patch_async_motor(smargon.omega),

--- a/tests/unit_tests/hyperion/experiment_plans/test_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_grid_detect_then_xray_centre_plan.py
@@ -112,6 +112,60 @@ async def test_detect_grid_and_do_gridscan_in_real_RE(
     mock_flyscan.assert_called_once_with(ANY, ANY, ANY)
 
 
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.GridDetectionCallback",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.create_parameters_for_flyscan_xray_centre",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.change_aperture_then_move_to_xtal",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.common_flyscan_xray_centre",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.grid_detection_plan",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.setup_beamline_for_OAV",
+    autospec=True,
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.grid_detect_then_xray_centre_plan.XRayCentreEventHandler",
+    autospec=True,
+)
+def test_detect_grid_and_do_gridscan_sets_up_beamline_for_OAV(
+    mock_event_handler: MagicMock,
+    mock_setup_beamline_for_oav: MagicMock,
+    mock_grid_detect: MagicMock,
+    mock_flyscan: MagicMock,
+    mock_change_aperture_and_move: MagicMock,
+    mock_create_params: MagicMock,
+    mock_grid_detect_callback: MagicMock,
+    grid_detect_devices_with_oav_config_params: GridDetectThenXRayCentreComposite,
+    sim_run_engine: RunEngineSimulator,
+    test_full_grid_scan_params: GridScanWithEdgeDetect,
+    test_config_files: dict,
+):
+    mock_event_handler.return_value.xray_centre_results = ["dummy"]
+    sim_run_engine.add_handler_for_callback_subscribes()
+    sim_run_engine.simulate_plan(
+        grid_detect_then_xray_centre(
+            grid_detect_devices_with_oav_config_params,
+            test_full_grid_scan_params,
+            oav_config=test_config_files["oav_config_json"],
+        ),
+    )
+
+    mock_setup_beamline_for_oav.assert_called_once()
+
+
 def _do_detect_grid_and_gridscan_then_wait_for_backlight(
     composite, test_config_files, test_full_grid_scan_params
 ):


### PR DESCRIPTION
Fixes #1072

Adds `setup_beamline_for_OAV` plan in `grid_detect_then_xray_centre` plan. Usually the beamline should already be set up for OAV at this point so should do nothing, however I04 sometimes will start the `detect_grid_and_do_gridscan` when not already set up for OAV. This ensures the beamline is always set up for OAV before grid detect.

### Instructions to reviewer on how to test:

1. Run the new `grid_detect_then_xray_centre` plan with beamline not setup for OAV.
2. Confirm the aperture moves out, backlight moves in, and plan completes successfully.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
