### PR TITLE
Fix system test failure caused by beamstop changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ version_file = "src/mx_bluesky/_version.py"
 
 [tool.pyright]
 typeCheckingMode = "standard"
-reportMissingImports = false  # Ignore missing stubs in imported modules
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -18,7 +18,6 @@ from ophyd.sim import NullStatus
 from ophyd_async.core import AsyncStatus
 from ophyd_async.testing import set_mock_value
 
-from mx_bluesky.common.device_setup_plans.check_beamstop import BeamstopException
 from mx_bluesky.common.external_interaction.callbacks.common.grid_detection_callback import (
     GridParamUpdate,
 )
@@ -418,33 +417,6 @@ def test_load_centre_collect_updates_bl_sample_status_pin_tip_detection_fail(
     assert (
         fetch_blsample(load_centre_collect_params.sample_id).blSampleStatus
         == "ERROR - sample"
-    )
-
-
-@pytest.mark.system_test
-def test_load_centre_collect_updates_bl_sample_status_no_beamstop(
-    load_centre_collect_composite: LoadCentreCollectComposite,
-    load_centre_collect_params: LoadCentreCollect,
-    oav_parameters_for_rotation: OAVParameters,
-    RE: RunEngine,
-    fetch_blsample: Callable[..., Any],
-):
-    sample_handling_cb = SampleHandlingCallback()
-    RE.subscribe(sample_handling_cb)
-    set_mock_value(load_centre_collect_composite.beamstop.x_mm.user_readback, 1)
-
-    with pytest.raises(BeamstopException, match="Beamstop is not DATA_COLLECTION"):
-        RE(
-            load_centre_collect_full(
-                load_centre_collect_composite,
-                load_centre_collect_params,
-                oav_parameters_for_rotation,
-            )
-        )
-
-    assert (
-        fetch_blsample(load_centre_collect_params.sample_id).blSampleStatus
-        == "ERROR - beamline"
     )
 
 


### PR DESCRIPTION
Fixes failure of the system tests to execute because the `check_beamstop` plan is no longer present
Also removes the pyright flag `reportMissingImports = false` which was causing the broken import to not be reported by `tox -e type-checking`

Link to dodal PR (if required): N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Tests pass
2. System tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
