### PR TITLE
Add zocalo config to helm chart as a configmap

### DIFF
--- a/docs/developer/hyperion/deploying-hyperion.rst
+++ b/docs/developer/hyperion/deploying-hyperion.rst
@@ -68,7 +68,17 @@ For further information, see https://github.com/containers/podman/issues/2542
 Deploying to kubernetes
 -----------------------
 
-Once the docker image is built, the image can be deployed to kubernetes using the ``deploy_hyperion_to_k8s.sh`` script
+Once the docker image is built, the image can be deployed to kubernetes using the ``deploy_mx_bluesky_app_to_k8s.sh``
+script.
+
+Secrets
+~~~~~~~
+
+The deployment requires the following secrets to be created with the corresponding zocalo rabbitmq credentials if they
+are not already present:
+
+* ``rmq-creds``
+* ``rmq-api-reader``
 
 Production deployment
 ~~~~~~~~~~~~~~~~~~~~~
@@ -77,12 +87,13 @@ Then create and deploy the helm release
 
 ::
 
-    ./utility_scripts/deploy/deploy_hyperion_to_k8s.sh --beamline=<beamline> --checkout-to-prod hyperion
+    ./utility_scripts/deploy/deploy_mx_bluesky_app_to_k8s.sh --appVersion=x.y.z --beamline=<beamline> --checkout-to-prod hyperion hyperion
 
 This will run the ``deploy_mx_bluesky.py`` script to deploy the latest hyperion to ``/dls_sw``.
 You will be prompted to log into the beamline cluster, then it will create a helm release "hyperion".
 The source folders will be mounted as bind mounts to allow the pod to pick up changes in production.
 For production these are expected to be in the normal place defined in ``values.yaml``.
+If the non-k8s deployment of hyperion has already been performed, then omit ``--checkout-to-prod``.
 
 Development deployment
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -93,7 +104,7 @@ above, you install a dev deployment to the cluster you are currently logged into
 
 ::
 
-    ./utility_scripts/deploy/deploy_hyperion_to_k8s.sh --dev --beamline=<beamline> --repository=<your image repo> hyperion-test
+    ./utility_scripts/deploy/deploy_mx_bluesky_app_to_k8s.sh --dev --beamline=<beamline> --repository=<your image repo> hyperion-test hyperion
 
 
 The dev deployment bind-mounts the current ``hyperion`` workspace and ``../dodal`` into the container so that you can

--- a/helmcharts/hyperion/templates/deployment.yaml
+++ b/helmcharts/hyperion/templates/deployment.yaml
@@ -22,10 +22,6 @@ spec:
           hostPath:
             path: "/dls_sw/{{ .Values.application.beamline }}"
             type: Directory
-        - name: dls-sw-apps
-          hostPath:
-            path: "/dls_sw/apps"
-            type: Directory
         - name: dls-sw-dasc
           hostPath:
             path: "/dls_sw/dasc"
@@ -146,10 +142,6 @@ spec:
         volumeMounts:
           - mountPath: "/dls_sw/{{ .Values.application.beamline }}"
             name: dls-sw-bl
-            readOnly: true
-            mountPropagation: HostToContainer
-          - mountPath: "/dls_sw/apps"
-            name: dls-sw-apps
             readOnly: true
             mountPropagation: HostToContainer
           - mountPath: "/dls_sw/dasc"

--- a/helmcharts/hyperion/templates/deployment.yaml
+++ b/helmcharts/hyperion/templates/deployment.yaml
@@ -59,6 +59,19 @@ spec:
           hostPath:
             type: Directory
             path: "{{ .Values.application.dataDir }}"
+        - name: zocalo-config
+          configMap:
+            name: "{{ .Release.Name }}-zocalo-config"
+        - name: zocalo-secrets
+          projected:
+            defaultMode: 0444
+            sources:
+            {{- if .Values.zocalo.secrets }}
+            {{- range .Values.zocalo.secrets }}
+            - secret:
+                name: {{ .secretName }}
+            {{- end -}} {{/* range */}}
+            {{- end -}} {{/* if */}}
       containers:
       - name: hyperion
         image: {{ .Values.application.imageRepository}}/mx-bluesky:{{ .Values.application.appVersion }}
@@ -122,7 +135,7 @@ spec:
           - name: ZOCALO_GO_HOSTNAME
             value: "{{ .Values.application.beamline }}-control"
           - name: ZOCALO_CONFIG
-            value: "/dls_sw/apps/zocalo/live/configuration.yaml"
+            value: "/zocalo/config/configuration.yaml"
           - name: ISPYB_CONFIG_PATH
             value: "/dls_sw/dasc/mariadb/credentials/ispyb-hyperion-{{ .Values.application.beamline }}.cfg"
           {{- end }}
@@ -157,4 +170,8 @@ spec:
             name: debuglogs
           - mountPath: "/dls/{{ .Values.application.beamline }}/data"
             name: data
+          - mountPath: "/zocalo/config"
+            name: zocalo-config
+          - mountPath: "/zocalo/secrets"
+            name: zocalo-secrets
       hostNetwork: true

--- a/helmcharts/hyperion/templates/zocalo-config.yaml
+++ b/helmcharts/hyperion/templates/zocalo-config.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ $.Release.Name }}-{{ $itemName }}"
+  namespace: "{{ $.Release.Namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ $itemName }}"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}-{{ $itemName }}"
+    app.kubernetes.io/version: "{{ $.Chart.Version }}"
+    app.kubernetes.io/part-of: zocalo 
+data:
+  configuration.yaml: |-
+    version: 1
+
+    graylog:
+      plugin: graylog
+      {{- .Values.zocalo.graylog | toYaml | nindent 6 }}
+
+  {{- if .Values.zocalo.secrets }}
+  {{- range Values.zocalo.secrets }}
+    {{ .name }}: "/zocalo/secrets/{{ .fileName }}"
+  {{- end -}} {{/* range */}}
+  {{- end -}} {{/* if */}}
+
+
+    default-transport:
+      plugin: transport
+      default: {{ .Values.zocalo.defaultTransport }}
+
+    environments:
+
+      bluesky:
+        logging: graylog
+        plugins:
+          - default-transport
+        {{- if .Values.zocalo.secrets }}
+        {{- range .Values.zocalo.secrets }}
+          - {{ .name }}
+        {{- end -}} {{/* range */}}
+        {{- end -}} {{/* if */}}

--- a/helmcharts/hyperion/templates/zocalo-config.yaml
+++ b/helmcharts/hyperion/templates/zocalo-config.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ $.Release.Name }}-{{ $itemName }}"
-  namespace: "{{ $.Release.Namespace }}"
+  name: "{{ .Release.Name }}-zocalo-config"
+  namespace: "{{ .Release.Namespace }}"
   labels:
-    app.kubernetes.io/name: "{{ $itemName }}"
-    app.kubernetes.io/instance: "{{ $.Release.Name }}-{{ $itemName }}"
-    app.kubernetes.io/version: "{{ $.Chart.Version }}"
-    app.kubernetes.io/part-of: zocalo 
+    app.kubernetes.io/name: zocalo-config
+    app.kubernetes.io/instance: "{{ .Release.Name }}-zocalo-config"
+    app.kubernetes.io/version: "{{ .Chart.Version }}"
+    app.kubernetes.io/part-of: hyperion 
 data:
   configuration.yaml: |-
     version: 1
@@ -17,7 +17,7 @@ data:
       {{- .Values.zocalo.graylog | toYaml | nindent 6 }}
 
   {{- if .Values.zocalo.secrets }}
-  {{- range Values.zocalo.secrets }}
+  {{- range .Values.zocalo.secrets }}
     {{ .name }}: "/zocalo/secrets/{{ .fileName }}"
   {{- end -}} {{/* range */}}
   {{- end -}} {{/* if */}}

--- a/helmcharts/hyperion/values.yaml
+++ b/helmcharts/hyperion/values.yaml
@@ -19,3 +19,17 @@ dodal:
   projectDir: SET_ON_INSTALL
 service:
   type: NodePort
+
+zocalo:
+  defaultTransport: "PikaTransport"
+  graylog:
+    host: graylog-log-target.diamond.ac.uk
+    port: 12208
+    protocol: UDP
+  secrets:
+    - name: rabbitmq
+      secretName: rmq-creds
+      fileName: rabbitmq-credentials.yml
+    - name: rabbitmq-api-reader
+      secretName: rmq-api-reader
+      fileName: rabbitmq-api-reader.yml

--- a/utility_scripts/deploy/deploy_mx_bluesky_app_to_k8s.sh
+++ b/utility_scripts/deploy/deploy_mx_bluesky_app_to_k8s.sh
@@ -36,11 +36,17 @@ for option in "$@"; do
             CMD=`basename $0`
             echo "$CMD [options] <release> <app_name>"
             cat <<EOM
-Deploys a mx_bluesky app to kubernetes
+Deploys a mx_bluesky app (either hyperion or redis-to-murko) to kubernetes.
 
 Important!
 If you do not specify --checkout-to-prod YOU MUST run this from the mx_bluesky directory that will be bind-mounted to
 the container, NOT the directory that you built the container image from.
+
+Arguments:
+  release                 Name of the helmchart release
+  app_name                Use either "hyperion" or "redis-to-murko"
+
+Options:
 
   --help                  This help
   --appVersion=version    Version of the image to fetch from the repository otherwise it is deduced


### PR DESCRIPTION
Fixes [python-dlstbx#291](https://github.com/DiamondLightSource/python-dlstbx/issues/291)

### Instructions to reviewer on how to test:

1. Add secrets matching the names of zocalo.secrets added into `values.yaml` into the desired namespace
2. Install helm chart
3. Confirm that communication with zocalo works as expected

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
