### PR TITLE
Pin daq config server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # as by default pip-install will not upgrade to a pre-release.
     #
     "blueapi >= 0.5.0",
-    "daq-config-server >= 0.1.1",
+    "daq-config-server == 0.1.1",
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",


### PR DESCRIPTION
I will soon be making a release for the daq-config-server, which will break `mx-bluesky` in quite a few places, this PR is pre-emptively pinning it to the compatible version. See https://github.com/DiamondLightSource/mx-bluesky/issues/1097 for unpinning.

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
