### PR TITLE
Remove unrequired wheel install

### DIFF
--- a/utility_scripts/dls_dev_env.sh
+++ b/utility_scripts/dls_dev_env.sh
@@ -31,7 +31,6 @@ python -m venv .venv
 source .venv/bin/activate
 
 pip install --upgrade pip
-pip install wheel
 pip install -e .[dev]
 
 pre-commit install


### PR DESCRIPTION
Fixes issues with `setuptools_dso` trying use `wheel` badly. If `wheel` is installed it will try and use it where it is depreciated and you get an error like:
```
ImportError while loading conftest '/scratch/ffv81422/bluesky_work/dodal/conftest.py'.
conftest.py:14: in <module>
    from ophyd.status import Status
.venv/lib/python3.11/site-packages/ophyd/__init__.py:89: in <module>
    set_cl()
.venv/lib/python3.11/site-packages/ophyd/__init__.py:24: in set_cl
    set_cl(c_type, pv_telemetry=pv_telemetry)
.venv/lib/python3.11/site-packages/ophyd/__init__.py:39: in set_cl
    import epicscorelibs.path.pyepics  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/epicscorelibs/path/__init__.py:6: in <module>
    from setuptools_dso.runtime import dylink_prepare_dso, find_dso
.venv/lib/python3.11/site-packages/setuptools_dso/__init__.py:10: in <module>
    from .dsocmd import DSO, Extension, install, build, build_dso, build_ext, bdist_egg
.venv/lib/python3.11/site-packages/setuptools_dso/dsocmd.py:26: in <module>
    _bdist_wheel = _import_bdist_wheel()
                   ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/setuptools_dso/dsocmd.py:21: in _import_bdist_wheel
    from wheel.bdist_wheel import bdist_wheel
.venv/lib/python3.11/site-packages/wheel/bdist_wheel.py:4: in <module>
    warn(
E   DeprecationWarning: The 'wheel' package is no longer the canonical location of the 'bdist_wheel' command, and will be removed in a future release. Please update to setuptools v70.1 or later which contains an integrated version of this command.
```
We don't actually seem to need `wheel` to run anything so this removes the explicit install of it.

### Instructions to reviewer on how to test:

1. Run `dls_dev_env` on `main` and confirm you get the error above
2. Run on this branch and conform tests pass with no deprecation warning

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
