### PR TITLE
Use sample id from zocalo after XRC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@9f9809f1f152a0df4a95906df8f6478a53c4c3db",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@53a7ab512c0ac824471381283ca742951f088c11",
 ]
 
 

--- a/src/mx_bluesky/common/experiment_plans/common_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/common/experiment_plans/common_flyscan_xray_centre_plan.py
@@ -288,6 +288,7 @@ def _xrc_result_in_boxes_to_result_in_mm(
         ),
         max_count=xrc_result["max_count"],
         total_count=xrc_result["total_count"],
+        sample_id=xrc_result["sample_id"],
     )
 
 

--- a/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
+++ b/src/mx_bluesky/common/external_interaction/ispyb/ispyb_store.py
@@ -41,7 +41,6 @@ class IspybIds(BaseModel):
 class StoreInIspyb:
     def __init__(self, ispyb_config: str) -> None:
         self.ISPYB_CONFIG_PATH: str = ispyb_config
-        self._data_collection_group_id: int | None
 
     def begin_deposition(
         self,

--- a/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
+++ b/src/mx_bluesky/common/external_interaction/nexus/write_nexus.py
@@ -20,13 +20,13 @@ from mx_bluesky.common.external_interaction.nexus.nexus_utils import (
     create_goniometer_axes,
     get_start_and_predicted_end_time,
 )
-from mx_bluesky.common.parameters.components import DiffractionExperimentWithSample
+from mx_bluesky.common.parameters.components import DiffractionExperiment
 
 
 class NexusWriter:
     def __init__(
         self,
-        parameters: DiffractionExperimentWithSample,
+        parameters: DiffractionExperiment,
         data_shape: tuple[int, int, int],
         scan_points: AxesPoints,
         *,

--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -244,8 +244,8 @@ class TopNByMaxCountForEachSampleSelection(MultiXtalSelection):
 
 
 class WithCentreSelection(BaseModel):
-    select_centres: TopNByMaxCountSelection = Field(
-        discriminator="name", default=TopNByMaxCountSelection(n=1)
+    select_centres: TopNByMaxCountSelection | TopNByMaxCountForEachSampleSelection = (
+        Field(discriminator="name", default=TopNByMaxCountSelection(n=1))
     )
 
     @property

--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -238,6 +238,11 @@ class TopNByMaxCountSelection(MultiXtalSelection):
     n: int
 
 
+class TopNByMaxCountForEachSampleSelection(MultiXtalSelection):
+    name: Literal["TopNByMaxCountForEachSample"] = "TopNByMaxCountForEachSample"  #  pyright: ignore [reportIncompatibleVariableOverride]
+    n: int
+
+
 class WithCentreSelection(BaseModel):
     select_centres: TopNByMaxCountSelection = Field(
         discriminator="name", default=TopNByMaxCountSelection(n=1)

--- a/src/mx_bluesky/common/xrc_result.py
+++ b/src/mx_bluesky/common/xrc_result.py
@@ -47,7 +47,7 @@ class XRayCentreResult:
     bounding_box_mm: tuple[np.ndarray, np.ndarray]
     max_count: int
     total_count: int
-    sample_id: int
+    sample_id: int | None
 
     def __eq__(self, o):
         return (
@@ -71,14 +71,14 @@ def top_n_by_max_count(
 def top_n_by_max_count_for_each_sample(
     unfiltered: Sequence[XRayCentreResult], n: int
 ) -> Sequence[XRayCentreResult]:
-    sample_counts: dict[int, list[XRayCentreResult]] = defaultdict(
+    xrc_results_by_sample_id: dict[int, list[XRayCentreResult]] = defaultdict(
         list[XRayCentreResult]
     )
     for result in unfiltered:
-        sample_counts[result.sample_id].append(result)
+        xrc_results_by_sample_id[result.sample_id].append(result)
     return [
         result
-        for results in sample_counts.values()
+        for results in xrc_results_by_sample_id.values()
         for result in sorted(results, key=lambda x: x.max_count, reverse=True)[:n]
     ]
 

--- a/src/mx_bluesky/common/xrc_result.py
+++ b/src/mx_bluesky/common/xrc_result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
 
@@ -39,18 +40,21 @@ class XRayCentreResult:
             containing the crystal
         max_count: The maximum spot count encountered in any one grid box in the crystal
         total_count: The total count across all boxes in the crystal.
+        sample_id: The sample id associated with the centre.
     """
 
     centre_of_mass_mm: np.ndarray
     bounding_box_mm: tuple[np.ndarray, np.ndarray]
     max_count: int
     total_count: int
+    sample_id: int
 
     def __eq__(self, o):
         return (
             isinstance(o, XRayCentreResult)
             and o.max_count == self.max_count
             and o.total_count == self.total_count
+            and o.sample_id == self.sample_id
             and all(o.centre_of_mass_mm == self.centre_of_mass_mm)
             and all(o.bounding_box_mm[0] == self.bounding_box_mm[0])
             and all(o.bounding_box_mm[1] == self.bounding_box_mm[1])
@@ -62,6 +66,21 @@ def top_n_by_max_count(
 ) -> Sequence[XRayCentreResult]:
     sorted_hits = sorted(unfiltered, key=lambda result: result.max_count, reverse=True)
     return sorted_hits[:n]
+
+
+def top_n_by_max_count_for_each_sample(
+    unfiltered: Sequence[XRayCentreResult], n: int
+) -> Sequence[XRayCentreResult]:
+    sample_counts: dict[int, list[XRayCentreResult]] = defaultdict(
+        list[XRayCentreResult]
+    )
+    for result in unfiltered:
+        sample_counts[result.sample_id].append(result)
+    return [
+        result
+        for results in sample_counts.values()
+        for result in sorted(results, key=lambda x: x.max_count, reverse=True)[:n]
+    ]
 
 
 def resolve_selection_fn(

--- a/src/mx_bluesky/common/xrc_result.py
+++ b/src/mx_bluesky/common/xrc_result.py
@@ -11,6 +11,7 @@ from event_model import RunStart
 
 from mx_bluesky.common.parameters.components import (
     MultiXtalSelection,
+    TopNByMaxCountForEachSampleSelection,
     TopNByMaxCountSelection,
 )
 
@@ -86,6 +87,9 @@ def top_n_by_max_count_for_each_sample(
 def resolve_selection_fn(
     params: MultiXtalSelection,
 ) -> Callable[[Sequence[XRayCentreResult]], Sequence[XRayCentreResult]]:
-    if isinstance(params, TopNByMaxCountSelection):
-        return partial(top_n_by_max_count, n=params.n)
+    match params:
+        case TopNByMaxCountSelection():
+            return partial(top_n_by_max_count, n=params.n)
+        case TopNByMaxCountForEachSampleSelection():
+            return partial(top_n_by_max_count_for_each_sample, n=params.n)
     raise ValueError(f"Invalid selection function {params.name}")

--- a/src/mx_bluesky/common/xrc_result.py
+++ b/src/mx_bluesky/common/xrc_result.py
@@ -72,7 +72,7 @@ def top_n_by_max_count(
 def top_n_by_max_count_for_each_sample(
     unfiltered: Sequence[XRayCentreResult], n: int
 ) -> Sequence[XRayCentreResult]:
-    xrc_results_by_sample_id: dict[int, list[XRayCentreResult]] = defaultdict(
+    xrc_results_by_sample_id: dict[int | None, list[XRayCentreResult]] = defaultdict(
         list[XRayCentreResult]
     )
     for result in unfiltered:

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -76,7 +76,8 @@ def load_centre_collect_full(
             flyscan_event_handler,
         )
 
-        locations_to_collect_um: list[np.ndarray] = []
+        locations_to_collect_um: list[np.ndarray]
+        samples_to_collect: list[int]
 
         if flyscan_event_handler.xray_centre_results:
             selection_func = flyscan_result.resolve_selection_fn(
@@ -84,6 +85,7 @@ def load_centre_collect_full(
             )
             hits = selection_func(flyscan_event_handler.xray_centre_results)
             locations_to_collect_um = [hit.centre_of_mass_mm * 1000 for hit in hits]
+            samples_to_collect = [hit.sample_id for hit in hits]
 
             LOGGER.info(
                 f"Selected hits {hits} using {selection_func}, args={parameters.selection_params}"
@@ -98,6 +100,7 @@ def load_centre_collect_full(
             locations_to_collect_um = [
                 np.array([initial_x_mm, initial_y_mm, initial_z_mm]) * 1000
             ]
+            samples_to_collect = [parameters.sample_id]
 
         multi_rotation = parameters.multi_rotation_scan
         rotation_template = multi_rotation.rotation_scans.copy()
@@ -108,9 +111,11 @@ def load_centre_collect_full(
 
         generator = rotation_scan_generator(is_alternating)
         next(generator)
-        for location in locations_to_collect_um:
+        for location, sample_id in zip(
+            locations_to_collect_um, samples_to_collect, strict=True
+        ):
             for rot in rotation_template:
-                combination = generator.send((rot, location))
+                combination = generator.send((rot, location, sample_id))
                 multi_rotation.rotation_scans.append(combination)
         multi_rotation = RotationScan.model_validate(multi_rotation)
 
@@ -125,8 +130,10 @@ def load_centre_collect_full(
 
 def rotation_scan_generator(
     is_alternating: bool,
-) -> Generator[RotationScanPerSweep, tuple[RotationScanPerSweep, np.ndarray], None]:
-    scan_template, location = yield  # type: ignore
+) -> Generator[
+    RotationScanPerSweep, tuple[RotationScanPerSweep, np.ndarray, int], None
+]:
+    scan_template, location, sample_id = yield  # type: ignore
     next_rotation_direction = scan_template.rotation_direction
     while True:
         scan = scan_template.model_copy()
@@ -135,6 +142,7 @@ def rotation_scan_generator(
             scan.y_start_um,
             scan.z_start_um,
         ) = location
+        scan.sample_id = sample_id
         if is_alternating:
             if next_rotation_direction != scan.rotation_direction:
                 # If originally specified direction of the current scan is different
@@ -146,4 +154,4 @@ def rotation_scan_generator(
                 scan.rotation_direction = next_rotation_direction
             next_rotation_direction = next_rotation_direction.opposite
 
-        scan_template, location = yield scan
+        scan_template, location, sample_id = yield scan

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -84,11 +84,21 @@ def load_centre_collect_full(
                 parameters.selection_params
             )
             hits = selection_func(flyscan_event_handler.xray_centre_results)
-            locations_to_collect_um = [hit.centre_of_mass_mm * 1000 for hit in hits]
-            samples_to_collect = [hit.sample_id for hit in hits]
+            hits_to_collect = []
+            for hit in hits:
+                if hit.sample_id is None:
+                    LOGGER.warning(
+                        f"Diffracting centre {hit} not collected because no sample id was assigned."
+                    )
+                else:
+                    hits_to_collect.append(hit)
 
+            locations_to_collect_um = [
+                hit.centre_of_mass_mm * 1000 for hit in hits_to_collect
+            ]
+            samples_to_collect = [hit.sample_id for hit in hits_to_collect]
             LOGGER.info(
-                f"Selected hits {hits} using {selection_func}, args={parameters.selection_params}"
+                f"Selected hits {hits_to_collect} using {selection_func}, args={parameters.selection_params}"
             )
         else:
             # If the xray centring hasn't found a result but has not thrown an error it

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -54,6 +54,7 @@ class RotationISPyBCallback(BaseISPyBCallback):
         super().__init__(emit=emit)
         self.last_sample_id: int | None = None
         self.ispyb_ids: IspybIds = IspybIds()
+        self.ispyb = StoreInIspyb(self.ispyb_config)
 
     def activity_gated_start(self, doc: RunStart):
         if doc.get("subplan_name") == CONST.PLAN.ROTATION_OUTER:
@@ -82,7 +83,6 @@ class RotationISPyBCallback(BaseISPyBCallback):
                     f"Collection is {self.params.ispyb_experiment_type} - storing sampleID to bundle images"
                 )
                 self.last_sample_id = self.params.sample_id
-            self.ispyb = StoreInIspyb(self.ispyb_config)
             ISPYB_ZOCALO_CALLBACK_LOGGER.info("Beginning ispyb deposition")
             data_collection_group_info = populate_data_collection_group(self.params)
             data_collection_info = populate_data_collection_info_for_rotation(

--- a/src/mx_bluesky/hyperion/parameters/load_centre_collect.py
+++ b/src/mx_bluesky/hyperion/parameters/load_centre_collect.py
@@ -75,6 +75,10 @@ class LoadCentreCollect(
         assert not (duplicated_multi_rotation_scan_keys), (
             f"Unexpected keys in multi_rotation_scan: {', '.join(duplicated_multi_rotation_scan_keys)}"
         )
+
+        for rotation in values["multi_rotation_scan"]["rotation_scans"]:
+            rotation["sample_id"] = values["sample_id"]
+
         new_robot_load_then_centre_params = construct_from_values(
             values, values["robot_load_then_centre"], RobotLoadThenCentre
         )

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -19,6 +19,7 @@ from scanspec.specs import Line
 
 from mx_bluesky.common.parameters.components import (
     DiffractionExperiment,
+    DiffractionExperimentWithSample,
     IspybExperimentType,
     OptionalGonioAngleStarts,
     OptionalXyzStarts,
@@ -106,7 +107,9 @@ class RotationExperiment(DiffractionExperiment, WithHyperionUDCFeatures):
             return aperture_position
 
 
-class SingleRotationScan(WithScan, RotationScanPerSweep, RotationExperiment):
+class SingleRotationScan(
+    WithScan, RotationScanPerSweep, RotationExperiment, DiffractionExperimentWithSample
+):
     @property
     def detector_params(self):
         return self._detector_params(self.omega_start_deg)

--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -18,12 +18,13 @@ from scanspec.core import Path as ScanPath
 from scanspec.specs import Line
 
 from mx_bluesky.common.parameters.components import (
-    DiffractionExperimentWithSample,
+    DiffractionExperiment,
     IspybExperimentType,
     OptionalGonioAngleStarts,
     OptionalXyzStarts,
     RotationAxis,
     SplitScan,
+    WithSample,
     WithScan,
 )
 from mx_bluesky.hyperion.parameters.components import WithHyperionUDCFeatures
@@ -33,7 +34,7 @@ from mx_bluesky.hyperion.parameters.constants import (
 )
 
 
-class RotationScanPerSweep(OptionalGonioAngleStarts, OptionalXyzStarts):
+class RotationScanPerSweep(OptionalGonioAngleStarts, OptionalXyzStarts, WithSample):
     """
     Describes a rotation scan about the specified axis.
 
@@ -54,7 +55,7 @@ class RotationScanPerSweep(OptionalGonioAngleStarts, OptionalXyzStarts):
     nexus_vds_start_img: int = Field(default=0, ge=0)
 
 
-class RotationExperiment(DiffractionExperimentWithSample, WithHyperionUDCFeatures):
+class RotationExperiment(DiffractionExperiment, WithHyperionUDCFeatures):
     shutter_opening_time_s: float = Field(default=CONST.I03.SHUTTER_TIME_S)
     rotation_increment_deg: float = Field(default=0.1, gt=0)
     ispyb_experiment_type: IspybExperimentType = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ TEST_RESULT_LARGE = [
         "n_voxels": 35,
         "total_count": 2387574,
         "bounding_box": [[2, 2, 2], [8, 8, 7]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_MEDIUM = [
@@ -124,6 +125,7 @@ TEST_RESULT_MEDIUM = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[1, 2, 3], [3, 4, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_SMALL = [
@@ -134,6 +136,7 @@ TEST_RESULT_SMALL = [
         "n_voxels": 35,
         "total_count": 1000,
         "bounding_box": [[2, 2, 2], [3, 3, 3]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_BELOW_THRESHOLD = [
@@ -144,6 +147,7 @@ TEST_RESULT_BELOW_THRESHOLD = [
         "n_voxels": 1,
         "total_count": 2,
         "bounding_box": [[1, 2, 3], [2, 3, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 
@@ -156,6 +160,7 @@ TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -167,6 +172,7 @@ TEST_RESULT_IN_BOUNDS_TOP_LEFT_GRID_CORNER = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -178,6 +184,7 @@ TEST_RESULT_OUT_OF_BOUNDS_COM = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -189,6 +196,7 @@ TEST_RESULT_OUT_OF_BOUNDS_BB = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[-1, -1, -1], [3, 4, 4]],
+        "sample_id": ZocaloResults.NO_SAMPLE_ID,
     }
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1736,7 +1736,6 @@ def dummy_rotation_params(tmp_path):
             tmp_path,
         )
     )
-    dummy_params.sample_id = TEST_SAMPLE_ID
     return dummy_params
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,7 @@ class SimConstants:
     # The following are values present in the system test ispyb database
     ST_VISIT = "cm14451-2"
     ST_SAMPLE_ID = 398810
+    ST_MSP_SAMPLE_IDS = [398816, 398819]
     ST_CONTAINER_ID = 34864
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ from dodal.devices.xbpm_feedback import XBPMFeedback
 from dodal.devices.zebra.zebra import ArmDemand, Zebra
 from dodal.devices.zebra.zebra_controlled_shutter import ZebraShutter
 from dodal.devices.zocalo import ZocaloResults
+from dodal.devices.zocalo.zocalo_results import _NO_SAMPLE_ID
 from dodal.log import LOGGER as dodal_logger
 from dodal.log import set_up_all_logging_handlers
 from dodal.utils import AnyDeviceFactory, collect_factories
@@ -114,7 +115,7 @@ TEST_RESULT_LARGE = [
         "n_voxels": 35,
         "total_count": 2387574,
         "bounding_box": [[2, 2, 2], [8, 8, 7]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_MEDIUM = [
@@ -125,7 +126,7 @@ TEST_RESULT_MEDIUM = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[1, 2, 3], [3, 4, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_SMALL = [
@@ -136,7 +137,7 @@ TEST_RESULT_SMALL = [
         "n_voxels": 35,
         "total_count": 1000,
         "bounding_box": [[2, 2, 2], [3, 3, 3]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 TEST_RESULT_BELOW_THRESHOLD = [
@@ -147,7 +148,7 @@ TEST_RESULT_BELOW_THRESHOLD = [
         "n_voxels": 1,
         "total_count": 2,
         "bounding_box": [[1, 2, 3], [2, 3, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 
@@ -160,7 +161,7 @@ TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -172,7 +173,7 @@ TEST_RESULT_IN_BOUNDS_TOP_LEFT_GRID_CORNER = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -184,7 +185,7 @@ TEST_RESULT_OUT_OF_BOUNDS_COM = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[0, 0, 0], [3, 4, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 # These are the uncorrected coordinate from zocalo
@@ -196,7 +197,7 @@ TEST_RESULT_OUT_OF_BOUNDS_BB = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[-1, -1, -1], [3, 4, 4]],
-        "sample_id": ZocaloResults.NO_SAMPLE_ID,
+        "sample_id": _NO_SAMPLE_ID,
     }
 ]
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -226,7 +226,7 @@ def zocalo_for_system_test() -> Generator[ZocaloResults, None, None]:
     zocalo = i03.zocalo(connect_immediately=True, mock=True)
     old_zocalo_trigger = zocalo.trigger
     zocalo.my_zocalo_result = deepcopy(TEST_RESULT_MEDIUM)
-    zocalo.my_zocalo_result[0]["sample_id"] = SimConstants.ST_SAMPLE_ID
+    zocalo.my_zocalo_result[0]["sample_id"] = SimConstants.ST_SAMPLE_ID  # type: ignore
 
     @AsyncStatus.wrap
     async def mock_zocalo_complete():

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -389,7 +389,7 @@ def params_for_rotation_scan(
     test_rotation_params.exposure_time_s = 0.023
     test_rotation_params.detector_params.expected_energy_ev = 0.71
     test_rotation_params.visit = SimConstants.ST_VISIT
-    test_rotation_params.sample_id = SimConstants.ST_SAMPLE_ID
+    test_rotation_params.rotation_scans[0].sample_id = SimConstants.ST_SAMPLE_ID
     return test_rotation_params
 
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Callable, Generator, Sequence
+from copy import deepcopy
 from functools import partial
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -224,7 +225,8 @@ async def zocalo_for_fake_zocalo(zocalo_env) -> ZocaloResults:
 def zocalo_for_system_test() -> Generator[ZocaloResults, None, None]:
     zocalo = i03.zocalo(connect_immediately=True, mock=True)
     old_zocalo_trigger = zocalo.trigger
-    zocalo.my_zocalo_result = TEST_RESULT_MEDIUM
+    zocalo.my_zocalo_result = deepcopy(TEST_RESULT_MEDIUM)
+    zocalo.my_zocalo_result[0]["sample_id"] = SimConstants.ST_SAMPLE_ID
 
     @AsyncStatus.wrap
     async def mock_zocalo_complete():

--- a/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
@@ -51,6 +51,7 @@ EXPECTED_ROTATION_PARAMS = {
             scan_width_deg=360,
             rotation_direction=RotationDirection.POSITIVE,
             chi_start_deg=0.0,
+            sample_id=12345,
         )
     ],
 }

--- a/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
@@ -16,9 +16,6 @@ from mx_bluesky.hyperion.external_interaction.agamemnon import (
     populate_parameters_from_agamemnon,
 )
 from mx_bluesky.hyperion.parameters.load_centre_collect import LoadCentreCollect
-from mx_bluesky.hyperion.parameters.rotation import (
-    RotationScanPerSweep,
-)
 
 EXPECTED_ROBOT_LOAD_AND_CENTRE_PARAMS = {
     "storage_directory": "/dls/tmp/data/year/cm00000-0/auto/test/xraycentring",
@@ -45,14 +42,14 @@ EXPECTED_ROTATION_PARAMS = {
     "transmission_frac": 0.5,
     "ispyb_experiment_type": IspybExperimentType.CHARACTERIZATION,
     "rotation_scans": [
-        RotationScanPerSweep(
-            omega_start_deg=0.0,
-            phi_start_deg=0.0,
-            scan_width_deg=360,
-            rotation_direction=RotationDirection.POSITIVE,
-            chi_start_deg=0.0,
-            sample_id=12345,
-        )
+        {
+            "omega_start_deg": 0.0,
+            "phi_start_deg": 0.0,
+            "scan_width_deg": 360,
+            "rotation_direction": RotationDirection.POSITIVE,
+            "chi_start_deg": 0.0,
+            "sample_id": 12345,
+        }
     ],
 }
 

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -305,7 +305,7 @@ def test_execute_load_centre_collect_full(
         load_centre_collect_params.visit
     )
     expected_sample_id = load_centre_collect_params.sample_id
-    robot_load_cb.expeye.start_robot_action.assert_called_once_with(
+    robot_load_cb.expeye.start_robot_action.assert_called_once_with(  # type: ignore
         "LOAD", expected_proposal, expected_visit, expected_sample_id
     )
     # TODO re-enable this https://github.com/DiamondLightSource/mx-bluesky/issues/690
@@ -315,7 +315,7 @@ def test_execute_load_centre_collect_full(
     #     "{tmp_data}/123457/xraycentring/snapshots/160705_webcam_after_load.png",
     #     "/tmp/snapshot1.png",
     # )
-    robot_load_cb.expeye.end_robot_action.assert_called_once_with(1234, "success", "OK")
+    robot_load_cb.expeye.end_robot_action.assert_called_once_with(1234, "success", "OK")  # type: ignore
 
     # Compare gridscan collection
     compare_actual_and_expected(
@@ -877,7 +877,7 @@ def test_load_centre_collect_multisample_pin_reports_correct_sample_ids_robot_lo
     expected_proposal, expected_visit = get_proposal_and_session_from_visit_string(
         load_centre_collect_msp_params.visit
     )
-    robot_load_cb.expeye.start_load.assert_called_once_with(
+    robot_load_cb.expeye.start_load.assert_called_once_with(  # type: ignore
         expected_proposal, expected_visit, expected_sample_id, 2, 6
     )
 

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterable
 from contextlib import nullcontext
+from functools import partial
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -33,6 +34,7 @@ from mx_bluesky.common.external_interaction.callbacks.sample_handling.sample_han
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
+from mx_bluesky.common.parameters.components import TopNByMaxCountForEachSampleSelection
 from mx_bluesky.common.utils.exceptions import (
     CrystalNotFoundException,
     WarningException,
@@ -41,6 +43,7 @@ from mx_bluesky.hyperion.experiment_plans.load_centre_collect_full_plan import (
     LoadCentreCollectComposite,
     load_centre_collect_full,
 )
+from mx_bluesky.hyperion.experiment_plans.rotation_scan_plan import _move_and_rotation
 from mx_bluesky.hyperion.external_interaction.callbacks.robot_actions.ispyb_callback import (
     RobotLoadISPyBCallback,
 )
@@ -60,6 +63,7 @@ from ....conftest import (
     TEST_RESULT_MEDIUM,
     TEST_RESULT_OUT_OF_BOUNDS_BB,
     TEST_RESULT_OUT_OF_BOUNDS_COM,
+    TEST_RESULT_SMALL,
     SimConstants,
     assert_images_pixelwise_equal,
     raw_params_from_file,
@@ -79,6 +83,7 @@ SNAPSHOT_GENERATION_ZOCALO_RESULT = [
         "n_voxels": 35,
         "total_count": 100000,
         "bounding_box": [[1, 2, 3], [3, 4, 4]],
+        "sample_id": SimConstants.ST_SAMPLE_ID,
     }
 ]
 
@@ -92,6 +97,18 @@ def load_centre_collect_params(tmp_path):
     json_dict["visit"] = SimConstants.ST_VISIT
     json_dict["sample_id"] = SimConstants.ST_SAMPLE_ID
     return LoadCentreCollect(**json_dict)
+
+
+@pytest.fixture
+def load_centre_collect_msp_params(load_centre_collect_params):
+    load_centre_collect_params.select_centres = TopNByMaxCountForEachSampleSelection(
+        n=5
+    )
+    load_centre_collect_params.sample_id = SimConstants.ST_MSP_SAMPLE_IDS[0]
+    load_centre_collect_params.robot_load_then_centre.sample_id = (
+        load_centre_collect_params.sample_id
+    )
+    return load_centre_collect_params
 
 
 @pytest.fixture
@@ -140,6 +157,15 @@ def load_centre_collect_composite(
     set_mock_value(composite.dcm.bragg_in_degrees.user_readback, 5)
 
     yield composite
+
+
+@pytest.fixture
+def robot_load_cb() -> RobotLoadISPyBCallback:
+    robot_load_cb = RobotLoadISPyBCallback()
+    robot_load_cb.expeye.start_robot_action = MagicMock(return_value=1234)
+    robot_load_cb.expeye.end_robot_action = MagicMock()
+    robot_load_cb.expeye.update_robot_action = MagicMock()
+    return robot_load_cb
 
 
 GRID_DC_1_EXPECTED_VALUES = {
@@ -254,17 +280,13 @@ def test_execute_load_centre_collect_full(
     fetch_datacollection_ids_for_group_id: Callable[..., Any],
     fetch_blsample: Callable[[int], BLSample],
     tmp_path,
+    robot_load_cb: RobotLoadISPyBCallback,
 ):
     ispyb_gridscan_cb = GridscanISPyBCallback(
         param_type=GridCommonWithHyperionDetectorParams
     )
     ispyb_rotation_cb = RotationISPyBCallback()
     snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
-    robot_load_cb = RobotLoadISPyBCallback()
-    # robot_load_cb.expeye = MagicMock()
-    robot_load_cb.expeye.start_robot_action = MagicMock(return_value=1234)
-    robot_load_cb.expeye.end_robot_action = MagicMock()
-    robot_load_cb.expeye.update_robot_action = MagicMock()
     set_mock_value(
         load_centre_collect_composite.undulator_dcm.undulator_ref().current_gap, 1.11
     )
@@ -571,17 +593,16 @@ def test_load_centre_collect_gridscan_result_at_edge_of_grid(
     load_centre_collect_composite: LoadCentreCollectComposite,
     load_centre_collect_params: LoadCentreCollect,
     oav_parameters_for_rotation: OAVParameters,
+    robot_load_cb: RobotLoadISPyBCallback,
     RE: RunEngine,
 ):
-    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
+    load_centre_collect_composite.zocalo.my_zocalo_result = _with_sample_ids(
+        zocalo_result, [SimConstants.ST_SAMPLE_ID]
+    )
     ispyb_gridscan_cb = GridscanISPyBCallback(
         param_type=GridCommonWithHyperionDetectorParams
     )
     ispyb_rotation_cb = RotationISPyBCallback()
-    robot_load_cb = RobotLoadISPyBCallback()
-    robot_load_cb.expeye.start_robot_action = MagicMock(return_value=1234)
-    robot_load_cb.expeye.end_robot_action = MagicMock()
-    robot_load_cb.expeye.update_robot_action = MagicMock()
     set_mock_value(
         load_centre_collect_composite.undulator_dcm.undulator_ref().current_gap, 1.11
     )
@@ -660,6 +681,273 @@ def test_execute_load_centre_collect_capture_rotation_snapshots(
         assert_images_pixelwise_equal(
             filename, "tests/test_data/test_images/generate_snapshot_output.png"
         )
+
+
+def _with_sample_ids(zocalo_results: list[dict], sample_ids: Iterable[int]):
+    copied_results = [zr.copy() for zr in zocalo_results]
+    for result, sample_id in zip(copied_results, sample_ids, strict=False):
+        result["sample_id"] = sample_id
+    return copied_results
+
+
+@pytest.mark.system_test
+@pytest.mark.parametrize(
+    "zocalo_result",
+    [
+        _with_sample_ids(
+            TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX + TEST_RESULT_MEDIUM + TEST_RESULT_SMALL,
+            [
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[1],
+            ],
+        )
+    ],
+)
+def test_load_centre_collect_multisample_pin_reports_correct_sample_ids_in_ispyb_gridscan(
+    zocalo_result,
+    load_centre_collect_composite: LoadCentreCollectComposite,
+    load_centre_collect_msp_params: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+    RE: RunEngine,
+    robot_load_cb: RobotLoadISPyBCallback,
+    fetch_datacollectiongroup_attribute: Callable[..., Any],
+    fetch_datacollection_attribute: Callable[..., Any],
+):
+    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
+    ispyb_gridscan_cb = GridscanISPyBCallback(
+        param_type=GridCommonWithHyperionDetectorParams
+    )
+    ispyb_rotation_cb = RotationISPyBCallback()
+    snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
+
+    RE.subscribe(ispyb_gridscan_cb)
+    RE.subscribe(snapshot_cb)
+    RE.subscribe(robot_load_cb)
+
+    RE(
+        load_centre_collect_full(
+            load_centre_collect_composite,
+            load_centre_collect_msp_params,
+            oav_parameters_for_rotation,
+        )
+    )
+
+    expected_sample_id = load_centre_collect_msp_params.sample_id
+
+    compare_actual_and_expected(
+        ispyb_gridscan_cb.ispyb_ids.data_collection_group_id,
+        {"blSampleId": expected_sample_id},
+        fetch_datacollectiongroup_attribute,
+    )
+
+    compare_actual_and_expected(
+        ispyb_gridscan_cb.ispyb_ids.data_collection_ids[0],
+        {"BLSAMPLEID": expected_sample_id},
+        fetch_datacollection_attribute,
+    )
+    compare_actual_and_expected(
+        ispyb_gridscan_cb.ispyb_ids.data_collection_ids[1],
+        {"BLSAMPLEID": expected_sample_id},
+        fetch_datacollection_attribute,
+    )
+
+
+@pytest.mark.system_test
+@pytest.mark.parametrize(
+    "zocalo_result",
+    [
+        _with_sample_ids(
+            TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX + TEST_RESULT_MEDIUM + TEST_RESULT_SMALL,
+            [
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[1],
+            ],
+        )
+    ],
+)
+def test_load_centre_collect_multisample_pin_reports_correct_sample_ids_in_ispyb_rotation(
+    zocalo_result,
+    load_centre_collect_composite: LoadCentreCollectComposite,
+    load_centre_collect_msp_params: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+    RE: RunEngine,
+    robot_load_cb: RobotLoadISPyBCallback,
+    fetch_datacollectiongroup_attribute: Callable[..., Any],
+    fetch_datacollection_attribute: Callable[..., Any],
+    fetch_datacollection_ids_for_group_id: Callable[..., Any],
+):
+    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
+    ispyb_gridscan_cb = GridscanISPyBCallback(
+        param_type=GridCommonWithHyperionDetectorParams
+    )
+    ispyb_rotation_cb = RotationISPyBCallback()
+    snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
+    RE.subscribe(ispyb_gridscan_cb)
+    RE.subscribe(snapshot_cb)
+    RE.subscribe(robot_load_cb)
+
+    original_upsert_dcg = ispyb_rotation_cb.ispyb._upsert_data_collection_group
+    captured_upsert_dcg_ids = []
+
+    def intercept_upserts(conn, params):
+        dcg_id = original_upsert_dcg(conn, params)
+        nonlocal captured_upsert_dcg_ids
+        if dcg_id not in captured_upsert_dcg_ids:
+            captured_upsert_dcg_ids.append(dcg_id)
+        return dcg_id
+
+    with patch.object(
+        ispyb_rotation_cb.ispyb,
+        "_upsert_data_collection_group",
+        side_effect=intercept_upserts,
+    ):
+        RE(
+            load_centre_collect_full(
+                load_centre_collect_composite,
+                load_centre_collect_msp_params,
+                oav_parameters_for_rotation,
+            )
+        )
+
+    assert len(captured_upsert_dcg_ids) == 2
+    for dcg_id, expected_sample_id in zip(
+        captured_upsert_dcg_ids, SimConstants.ST_MSP_SAMPLE_IDS, strict=True
+    ):
+        compare_actual_and_expected(
+            dcg_id,
+            {"blSampleId": expected_sample_id},
+            fetch_datacollectiongroup_attribute,
+        )
+        dc_ids = fetch_datacollection_ids_for_group_id(dcg_id)
+        compare_actual_and_expected(
+            dc_ids[0],
+            {"BLSAMPLEID": expected_sample_id},
+            fetch_datacollection_attribute,
+        )
+        compare_actual_and_expected(
+            dc_ids[1],
+            {"BLSAMPLEID": expected_sample_id},
+            fetch_datacollection_attribute,
+        )
+
+
+@pytest.mark.parametrize(
+    "zocalo_result",
+    [
+        _with_sample_ids(
+            TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX + TEST_RESULT_MEDIUM + TEST_RESULT_SMALL,
+            [
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[1],
+            ],
+        )
+    ],
+)
+@pytest.mark.system_test
+def test_load_centre_collect_multisample_pin_reports_correct_sample_ids_robot_load(
+    zocalo_result,
+    load_centre_collect_composite: LoadCentreCollectComposite,
+    load_centre_collect_msp_params: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+    RE: RunEngine,
+    robot_load_cb: RobotLoadISPyBCallback,
+):
+    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
+    ispyb_gridscan_cb = GridscanISPyBCallback(
+        param_type=GridCommonWithHyperionDetectorParams
+    )
+    ispyb_rotation_cb = RotationISPyBCallback()
+    snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
+    RE.subscribe(ispyb_gridscan_cb)
+    RE.subscribe(snapshot_cb)
+    RE.subscribe(robot_load_cb)
+
+    RE(
+        load_centre_collect_full(
+            load_centre_collect_composite,
+            load_centre_collect_msp_params,
+            oav_parameters_for_rotation,
+        )
+    )
+
+    expected_sample_id = load_centre_collect_msp_params.sample_id
+    expected_proposal, expected_visit = get_proposal_and_session_from_visit_string(
+        load_centre_collect_msp_params.visit
+    )
+    robot_load_cb.expeye.start_load.assert_called_once_with(
+        expected_proposal, expected_visit, expected_sample_id, 2, 6
+    )
+
+
+@pytest.mark.parametrize(
+    "zocalo_result",
+    [
+        _with_sample_ids(
+            TEST_RESULT_IN_BOUNDS_TOP_LEFT_BOX + TEST_RESULT_MEDIUM + TEST_RESULT_SMALL,
+            [
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[0],
+                SimConstants.ST_MSP_SAMPLE_IDS[1],
+            ],
+        )
+    ],
+)
+@pytest.mark.system_test
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan._move_and_rotation",
+    new=MagicMock(side_effect=AssertionError("Simulated error in rotation")),
+)
+def test_load_centre_collect_multisample_pin_updates_sample_status_for_parent_sample_when_error_in_rotation_on_child_sample(
+    zocalo_result,
+    load_centre_collect_composite: LoadCentreCollectComposite,
+    load_centre_collect_msp_params: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+    RE: RunEngine,
+    robot_load_cb: RobotLoadISPyBCallback,
+    fetch_blsample: Callable[..., Any],
+):
+    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
+    ispyb_gridscan_cb = GridscanISPyBCallback(
+        param_type=GridCommonWithHyperionDetectorParams
+    )
+    ispyb_rotation_cb = RotationISPyBCallback()
+    snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
+    sample_handling_cb = SampleHandlingCallback()
+    RE.subscribe(ispyb_gridscan_cb)
+    RE.subscribe(snapshot_cb)
+    RE.subscribe(robot_load_cb)
+    RE.subscribe(sample_handling_cb)
+
+    unpatched_move_and_rotation = _move_and_rotation
+    num_calls = 0
+
+    def throw_on_third_call_wrapper(plan, *args, **kwargs):
+        nonlocal num_calls
+        num_calls += 1
+        if num_calls == 3:
+            raise AssertionError("Simulated error in rotation")
+        yield from plan(*args, **kwargs)
+
+    with patch(
+        "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan._move_and_rotation",
+        partial(throw_on_third_call_wrapper, unpatched_move_and_rotation),
+    ):
+        with pytest.raises(AssertionError, match="Simulated error in rotation"):
+            RE(
+                load_centre_collect_full(
+                    load_centre_collect_composite,
+                    load_centre_collect_msp_params,
+                    oav_parameters_for_rotation,
+                )
+            )
+
+    assert (
+        fetch_blsample(SimConstants.ST_MSP_SAMPLE_IDS[0]).blSampleStatus
+        == "ERROR - beamline"
+    )
 
 
 @pytest.fixture

--- a/tests/test_data/parameter_json_files/good_test_multi_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_multi_rotation_scan_parameters.json
@@ -9,41 +9,47 @@
     "insertion_prefix": "SR03S",
     "file_name": "file_name",
     "run_number": 0,
-    "sample_id": 123456,
     "shutter_opening_time_s": 0.6,
     "visit": "cm31105-4",
     "transmission_frac": 0.1,
     "rotation_increment_deg": 0.1,
     "selected_aperture": "SMALL_APERTURE",
-    "rotation_scans": [{
-        "rotation_axis": "omega",
-        "rotation_direction": "Negative",
-        "scan_width_deg": 180.0,
-        "omega_start_deg": 0.0,
-        "phi_start_deg": 0.47,
-        "chi_start_deg": 23.85,
-        "x_start_um": 1.0,
-        "y_start_um": 2.0,
-        "z_start_um": 3.0
-    },{
-        "rotation_axis": "omega",
-        "rotation_direction": "Negative",
-        "scan_width_deg": 180.0,
-        "omega_start_deg": 180.0,
-        "phi_start_deg": 0.47,
-        "chi_start_deg": 4.7,
-        "x_start_um": 3.0,
-        "y_start_um": 2.0,
-        "z_start_um": 1.0
-    },{
-        "rotation_axis": "omega",
-        "rotation_direction": "Positive",
-        "scan_width_deg": 180.0,
-        "omega_start_deg": 270.0,
-        "phi_start_deg": 0.47,
-        "chi_start_deg": 45,
-        "x_start_um": 6.0,
-        "y_start_um": 7.0,
-        "z_start_um": 8.0
-    }]
+    "rotation_scans": [
+        {
+            "rotation_axis": "omega",
+            "rotation_direction": "Negative",
+            "scan_width_deg": 180.0,
+            "omega_start_deg": 0.0,
+            "phi_start_deg": 0.47,
+            "chi_start_deg": 23.85,
+            "x_start_um": 1.0,
+            "y_start_um": 2.0,
+            "z_start_um": 3.0,
+            "sample_id": 123456
+        },
+        {
+            "rotation_axis": "omega",
+            "rotation_direction": "Negative",
+            "scan_width_deg": 180.0,
+            "omega_start_deg": 180.0,
+            "phi_start_deg": 0.47,
+            "chi_start_deg": 4.7,
+            "x_start_um": 3.0,
+            "y_start_um": 2.0,
+            "z_start_um": 1.0,
+            "sample_id": 123456
+        },
+        {
+            "rotation_axis": "omega",
+            "rotation_direction": "Positive",
+            "scan_width_deg": 180.0,
+            "omega_start_deg": 270.0,
+            "phi_start_deg": 0.47,
+            "chi_start_deg": 45,
+            "x_start_um": 6.0,
+            "y_start_um": 7.0,
+            "z_start_um": 8.0,
+            "sample_id": 123456
+        }
+    ]
 }

--- a/tests/test_data/parameter_json_files/good_test_one_multi_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_one_multi_rotation_scan_parameters.json
@@ -11,7 +11,6 @@
     "visit": "cm31105-4",
     "transmission_frac": 0.1,
     "run_number": 0,
-    "sample_id": 123456,
     "rotation_increment_deg": 0.1,
     "shutter_opening_time_s": 0.6,
     "selected_aperture": "SMALL_APERTURE",
@@ -25,7 +24,8 @@
             "chi_start_deg": 23.85,
             "x_start_um": 1.0,
             "y_start_um": 2.0,
-            "z_start_um": 3.0
+            "z_start_um": 3.0,
+            "sample_id": 123456
         }
     ],
     "snapshot_omegas_deg": [

--- a/tests/test_data/parameter_json_files/good_test_one_multi_rotation_scan_parameters_nomove.json
+++ b/tests/test_data/parameter_json_files/good_test_one_multi_rotation_scan_parameters_nomove.json
@@ -10,7 +10,6 @@
     "file_name": "file_name",
     "rotation_increment_deg": 0.1,
     "run_number": 0,
-    "sample_id": 123456,
     "shutter_opening_time_s": 0.6,
     "visit": "cm31105-4",
     "transmission_frac": 0.1,
@@ -20,7 +19,8 @@
             "rotation_axis": "omega",
             "rotation_direction": "Negative",
             "scan_width_deg": 180.0,
-            "omega_start_deg": 0.0
+            "omega_start_deg": 0.0,
+            "sample_id": 123456
         }
     ]
 }

--- a/tests/unit_tests/common/experiment_plans/test_change_aperture_then_move_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_change_aperture_then_move_plan.py
@@ -20,6 +20,7 @@ def simple_flyscan_hit():
         ),
         max_count=20,
         total_count=57,
+        sample_id=12345,
     )
 
 

--- a/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
@@ -620,6 +620,7 @@ class TestFlyscanXrayCentrePlan:
             ),
             max_count=105062,
             total_count=2387574,
+            sample_id=12345,
         )
         assert actual and len(actual) == 1
         assert all(isclose(actual[0].centre_of_mass_mm, expected.centre_of_mass_mm))

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -319,6 +319,7 @@ async def fake_fgs_composite(
         "n_voxels": 321,
         "total_count": 999999,
         "bounding_box": [[3, 3, 3], [9, 9, 9]],
+        "sample_id": 12345,
     }
 
     @AsyncStatus.wrap

--- a/tests/unit_tests/hyperion/experiment_plans/common/test_flyscan_result.py
+++ b/tests/unit_tests/hyperion/experiment_plans/common/test_flyscan_result.py
@@ -7,6 +7,7 @@ from tests.unit_tests.hyperion.experiment_plans.conftest import (
 
 from mx_bluesky.common.xrc_result import (
     top_n_by_max_count,
+    top_n_by_max_count_for_each_sample,
 )
 
 
@@ -24,3 +25,31 @@ from mx_bluesky.common.xrc_result import (
 def test_top_n_by_max_count(input_sequence, expected_sequence, n):
     actual_sequence = top_n_by_max_count(input_sequence, n)
     assert actual_sequence == expected_sequence
+
+
+@pytest.mark.parametrize(
+    "input_sequence, expected_sequence, n",
+    [
+        [
+            [FLYSCAN_RESULT_LOW, FLYSCAN_RESULT_MED, FLYSCAN_RESULT_HIGH],
+            [FLYSCAN_RESULT_MED, FLYSCAN_RESULT_HIGH],
+            1,
+        ],
+        [
+            [FLYSCAN_RESULT_LOW, FLYSCAN_RESULT_MED, FLYSCAN_RESULT_HIGH],
+            [FLYSCAN_RESULT_LOW, FLYSCAN_RESULT_MED, FLYSCAN_RESULT_HIGH],
+            2,
+        ],
+        [
+            [FLYSCAN_RESULT_MED, FLYSCAN_RESULT_MED, FLYSCAN_RESULT_LOW],
+            [FLYSCAN_RESULT_MED, FLYSCAN_RESULT_MED],
+            2,
+        ],
+    ],
+)
+def test_top_n_by_max_count_for_each_sample(input_sequence, expected_sequence, n):
+    actual_sequence = top_n_by_max_count_for_each_sample(input_sequence, n)
+    # Assert lists are equal, order is not relevant
+    assert len(actual_sequence) == len(expected_sequence)
+    for result in expected_sequence:
+        assert result in actual_sequence

--- a/tests/unit_tests/hyperion/experiment_plans/conftest.py
+++ b/tests/unit_tests/hyperion/experiment_plans/conftest.py
@@ -54,6 +54,13 @@ FLYSCAN_RESULT_LOW = XRayCentreResult(
     total_count=140,
     sample_id=1,
 )
+FLYSCAN_RESULT_HIGH_NO_SAMPLE_ID = XRayCentreResult(
+    centre_of_mass_mm=np.array([0.1, 0.2, 0.3]),
+    bounding_box_mm=(np.array([0.09, 0.19, 0.29]), np.array([0.11, 0.21, 0.31])),
+    max_count=30,
+    total_count=100,
+    sample_id=None,
+)
 
 
 def make_event_doc(data, descriptor="abc123") -> Event:

--- a/tests/unit_tests/hyperion/experiment_plans/conftest.py
+++ b/tests/unit_tests/hyperion/experiment_plans/conftest.py
@@ -38,18 +38,21 @@ FLYSCAN_RESULT_HIGH = XRayCentreResult(
     bounding_box_mm=(np.array([0.09, 0.19, 0.29]), np.array([0.11, 0.21, 0.31])),
     max_count=30,
     total_count=100,
+    sample_id=2,
 )
 FLYSCAN_RESULT_MED = XRayCentreResult(
     centre_of_mass_mm=np.array([0.4, 0.5, 0.6]),
     bounding_box_mm=(np.array([0.09, 0.19, 0.29]), np.array([0.11, 0.21, 0.31])),
     max_count=20,
     total_count=120,
+    sample_id=1,
 )
 FLYSCAN_RESULT_LOW = XRayCentreResult(
     centre_of_mass_mm=np.array([0.7, 0.8, 0.9]),
     bounding_box_mm=(np.array([0.09, 0.19, 0.29]), np.array([0.11, 0.21, 0.31])),
     max_count=10,
     total_count=140,
+    sample_id=1,
 )
 
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_hyperion_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_hyperion_flyscan_xray_centre_plan.py
@@ -9,6 +9,7 @@ from bluesky.utils import Msg
 from dodal.devices.aperturescatterguard import (
     ApertureValue,
 )
+from dodal.devices.zocalo.zocalo_results import _NO_SAMPLE_ID
 from ophyd.sim import NullStatus
 from ophyd.status import Status
 from ophyd_async.fastcs.panda import DatasetTable, PandaHdf5DatasetType
@@ -180,6 +181,7 @@ class TestFlyscanXrayCentrePlan:
         sim_run_engine.add_read_handler_for(
             zocalo.bounding_box, [np.array([[3, 3, 3], [9, 9, 9]])]
         )
+        sim_run_engine.add_read_handler_for(zocalo.sample_id, [_NO_SAMPLE_ID])
         msgs = sim_run_engine.simulate_plan(
             common_flyscan_xray_centre(
                 hyperion_flyscan_xrc_composite,

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -17,6 +17,7 @@ from ophyd.sim import NullStatus
 from ophyd_async.testing import set_mock_value
 from pydantic import ValidationError
 
+from mx_bluesky.common.parameters.components import TopNByMaxCountForEachSampleSelection
 from mx_bluesky.common.utils.exceptions import (
     CrystalNotFoundException,
     WarningException,
@@ -140,6 +141,33 @@ def load_centre_collect_with_top_n_params(tmp_path):
         tmp_path,
     )
     return LoadCentreCollect(**params)
+
+
+@pytest.fixture
+def load_centre_collect_with_top_n_for_each_sample(
+    load_centre_collect_with_top_n_params,
+):
+    load_centre_collect_with_top_n_params.select_centres = (
+        TopNByMaxCountForEachSampleSelection(n=5)
+    )
+    return load_centre_collect_with_top_n_params
+
+
+@pytest.fixture
+def mock_multi_rotation_scan():
+    with (
+        patch(
+            "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.robot_load_and_change_energy_plan",
+            new=MagicMock(
+                return_value=iter([Msg(command="robot_load_and_change_energy")])
+            ),
+        ),
+        patch(
+            "mx_bluesky.hyperion.experiment_plans.load_centre_collect_full_plan.rotation_scan_internal",
+            side_effect=lambda _, __, ___: iter([Msg(command="multi_rotation_scan")]),
+        ) as mock_rotation,
+    ):
+        yield mock_rotation
 
 
 def test_can_serialize_load_centre_collect_params(load_centre_collect_params):
@@ -538,14 +566,6 @@ def test_default_select_centres_is_top_n_by_max_count_n_is_1(
         )
     ),
 )
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.robot_load_and_change_energy_plan",
-    new=MagicMock(return_value=iter([Msg(command="robot_load_and_change_energy")])),
-)
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.load_centre_collect_full_plan.rotation_scan_internal",
-    side_effect=lambda _, __, ___: iter([Msg(command="multi_rotation_scan")]),
-)
 def test_load_centre_collect_full_plan_multiple_centres(
     mock_multi_rotation_scan: MagicMock,
     sim_run_engine: RunEngineSimulator,
@@ -653,14 +673,6 @@ def _rotation_at(
     ),
 )
 @patch(
-    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.robot_load_and_change_energy_plan",
-    new=MagicMock(return_value=iter([Msg(command="robot_load_and_change_energy")])),
-)
-@patch(
-    "mx_bluesky.hyperion.experiment_plans.load_centre_collect_full_plan.rotation_scan_internal",
-    side_effect=lambda _, __, ___: iter([Msg(command="multi_rotation_scan")]),
-)
-@patch(
     "mx_bluesky.common.external_interaction.config_server.FeatureFlags.update_self_from_server",
     autospec=True,
 )
@@ -762,6 +774,59 @@ def test_load_centre_collect_full_plan_alternates_rotation_with_multiple_centres
     assert isinstance(rotation_scan_params, RotationScan)
     _compare_rotation_scans(expected_scans, rotation_scan_params.rotation_scans)
     assert rotation_scan_params.transmission_frac == 0.05
+
+
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.pin_centre_then_flyscan_plan",
+    new=MagicMock(
+        side_effect=lambda *args, **kwargs: iter(
+            [
+                Msg(
+                    "open_run",
+                    xray_centre_results=[
+                        dataclasses.asdict(r)
+                        for r in [
+                            FLYSCAN_RESULT_HIGH,
+                            FLYSCAN_RESULT_MED,
+                        ]
+                    ],
+                    run=CONST.PLAN.FLYSCAN_RESULTS,
+                ),
+                Msg("close_run"),
+            ]
+        )
+    ),
+)
+def test_load_centre_collect_full_plan_assigns_sample_ids_to_rotations_according_to_zocalo_assignment(
+    mock_multi_rotation_scan: MagicMock,
+    sim_run_engine: RunEngineSimulator,
+    composite: LoadCentreCollectComposite,
+    load_centre_collect_with_top_n_for_each_sample: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+):
+    sim_run_engine.add_handler_for_callback_subscribes()
+    sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
+    sim_run_engine.simulate_plan(
+        load_centre_collect_full(
+            composite,
+            load_centre_collect_with_top_n_for_each_sample,
+            oav_parameters_for_rotation,
+        )
+    )
+
+    parameters: RotationScan = mock_multi_rotation_scan.mock_calls[0].args[1]
+    assert len(parameters.rotation_scans) == 4
+    assert [
+        (rs.x_start_um, rs.y_start_um, rs.z_start_um)
+        for rs in parameters.rotation_scans
+    ] == [
+        (100.0, 200.0, 300.0),
+        (100.0, 200.0, 300.0),
+        (400.0, 500.0, 600.0),
+        (400.0, 500.0, 600.0),
+    ]
+
+    assert [rs.sample_id for rs in parameters.rotation_scans] == [2, 2, 1, 1]
 
 
 def _compare_rotation_scans(

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -1435,7 +1435,7 @@ def test_full_multi_rotation_plan_arms_eiger_asynchronously_and_disarms(
     "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan.check_topup_and_wait_if_necessary",
     autospec=True,
 )
-def test_zocalo_callback_end_only_gets_called_at_the_end_of_all_collections(
+def test_zocalo_callback_end_only_gets_called_after_eiger_unstage(
     _,
     mock_ispyb_store: MagicMock,
     RE: RunEngine,
@@ -1591,6 +1591,44 @@ def test_zocalo_start_and_end_called_once_for_each_collection(
     assert zocalo_callback.zocalo_interactor.run_end.call_count == len(
         test_multi_rotation_params.rotation_scans
     )
+
+
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreInIspyb"
+)
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan.check_topup_and_wait_if_necessary",
+    autospec=True,
+)
+def test_given_different_sample_ids_for_each_collection_then_each_ispyb_entry_uses_a_different_sample_id(
+    _,
+    mock_ispyb_store: MagicMock,
+    RE: RunEngine,
+    test_multi_rotation_params: RotationScan,
+    fake_create_rotation_devices: RotationScanComposite,
+    oav_parameters_for_rotation: OAVParameters,
+):
+    _, ispyb_callback = create_rotation_callbacks()
+
+    mock_ispyb_store.return_value = MagicMock(spec=StoreInIspyb)
+    deposition = mock_ispyb_store.return_value.begin_deposition
+    deposition.return_value = IspybIds(data_collection_ids=(123,))
+    ispyb_callback.emit_cb = MagicMock()
+
+    test_multi_rotation_params.rotation_scans[0].sample_id = 123
+    test_multi_rotation_params.rotation_scans[1].sample_id = 456
+    test_multi_rotation_params.rotation_scans[2].sample_id = 789
+
+    _run_multi_rotation_plan(
+        RE,
+        test_multi_rotation_params,
+        fake_create_rotation_devices,
+        [ispyb_callback],
+        oav_parameters_for_rotation,
+    )
+    assert deposition.mock_calls[0].args[1][0].data_collection_info.sample_id == 123
+    assert deposition.mock_calls[1].args[1][0].data_collection_info.sample_id == 456
+    assert deposition.mock_calls[2].args[1][0].data_collection_info.sample_id == 789
 
 
 def test_multi_rotation_scan_does_not_change_transmission_back_until_after_data_collected(

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/rotation/test_ispyb_callback.py
@@ -9,13 +9,14 @@ from ......conftest import (
     EXPECTED_START_TIME,
     TEST_DATA_COLLECTION_GROUP_ID,
     TEST_DATA_COLLECTION_IDS,
-    TEST_SAMPLE_ID,
     TEST_SESSION_ID,
     assert_upsert_call_with,
     mx_acquisition_from_conn,
     remap_upsert_columns,
     replace_all_tmp_paths,
 )
+
+TEST_SAMPLE_ID = 123456
 
 EXPECTED_DATA_COLLECTION = {
     "visitid": TEST_SESSION_ID,

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
@@ -156,7 +156,8 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
     RE.subscribe(ispyb_cb)
 
     for sample_id, same_dcgid in test_cases:
-        params.sample_id = sample_id
+        for sweep in params.rotation_scans:
+            sweep.sample_id = sample_id
 
         RE(
             rotation_scan(

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
@@ -9,6 +9,7 @@ from mx_bluesky.common.external_interaction.ispyb.data_model import (
 )
 from mx_bluesky.common.external_interaction.ispyb.ispyb_store import (
     IspybIds,
+    StoreInIspyb,
 )
 from mx_bluesky.common.parameters.components import IspybExperimentType
 from mx_bluesky.hyperion.experiment_plans.rotation_scan_plan import rotation_scan
@@ -99,9 +100,6 @@ def test_nexus_handler_only_writes_once(
     "mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback.ZocaloTrigger",
     autospec=True,
 )
-@patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreInIspyb"
-)
 def test_ispyb_handler_receives_two_stops_but_only_ends_deposition_on_inner_one(
     ispyb_store, zocalo, RE: RunEngine, do_rotation_scan
 ):
@@ -113,9 +111,10 @@ def test_ispyb_handler_receives_two_stops_but_only_ends_deposition_on_inner_one(
     ispyb_callback.activity_gated_stop = MagicMock(
         autospec=True, side_effect=ispyb_callback.activity_gated_stop
     )
-
+    ispyb_store = MagicMock(spec=StoreInIspyb)
+    ispyb_callback.ispyb = ispyb_store
     parent_mock = MagicMock()
-    parent_mock.attach_mock(ispyb_store.return_value.end_deposition, "end_deposition")
+    parent_mock.attach_mock(ispyb_store.end_deposition, "end_deposition")
     parent_mock.attach_mock(ispyb_callback.activity_gated_stop, "callback_stopped")
 
     RE.subscribe(ispyb_callback)
@@ -126,15 +125,10 @@ def test_ispyb_handler_receives_two_stops_but_only_ends_deposition_on_inner_one(
 
 
 @patch(
-    "mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreInIspyb",
-    autospec=True,
-)
-@patch(
     "mx_bluesky.hyperion.experiment_plans.rotation_scan_plan._move_and_rotation",
     MagicMock(),
 )
 def test_ispyb_reuses_dcgid_on_same_sampleID(
-    rotation_ispyb: MagicMock,
     RE: RunEngine,
     params: RotationScan,
     fake_create_rotation_devices,
@@ -143,7 +137,9 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
     ispyb_cb = RotationISPyBCallback()
     ispyb_cb.active = True
     ispyb_ids = IspybIds(data_collection_group_id=23, data_collection_ids=(45,))
-    rotation_ispyb.return_value.begin_deposition.return_value = ispyb_ids
+    rotation_ispyb = MagicMock(spec=StoreInIspyb)
+    rotation_ispyb.begin_deposition.return_value = ispyb_ids
+    ispyb_cb.ispyb = rotation_ispyb
 
     test_cases = zip(
         [123, 123, 123, 456, 123],
@@ -166,7 +162,7 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
         )
 
         begin_deposition_scan_data: ScanDataInfo = (
-            rotation_ispyb.return_value.begin_deposition.call_args.args[1][0]
+            rotation_ispyb.begin_deposition.call_args.args[1][0]
         )
         if same_dcgid:
             assert begin_deposition_scan_data.data_collection_info.parent_id is not None

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_rotation_callbacks.py
@@ -215,14 +215,14 @@ def test_ispyb_handler_stores_sampleid_for_full_collection_not_screening(
         "time": 0,
         "uid": "abc123",
     }
-    params.sample_id = 987678
     for scan_params in params.rotation_scans:
+        scan_params.sample_id = 987678
         scan_params.scan_width_deg = n_images / 10
     if n_images < 200:
         params.ispyb_experiment_type = IspybExperimentType.CHARACTERIZATION
     assert params.num_images == n_images
     doc["subplan_name"] = CONST.PLAN.ROTATION_OUTER  # type: ignore
-    doc["mx_bluesky_parameters"] = params.model_dump_json()  # type: ignore
+    doc["mx_bluesky_parameters"] = next(params.single_rotation_scans).model_dump_json()  # type: ignore
 
     cb.start(doc)
     assert (cb.last_sample_id == 987678) is store_id

--- a/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
@@ -391,9 +391,6 @@ def test_populate_parameters_from_agamemnon_contains_expected_rotation_data(
         assert rotation_params.comment == "Complete_P1_sweep1 "
         assert rotation_params.ispyb_experiment_type == "OSC"
 
-        assert rotation_params.sample_puck == 5
-        assert rotation_params.sample_pin == 4
-
         assert rotation_params.demand_energy_ev == 12700.045934258673
         assert str(rotation_params.parameter_model_version) == "5.3.0"
         assert (


### PR DESCRIPTION
Fixes #1038

Link to dodal PR (if required):

* https://github.com/DiamondLightSource/dodal/pull/1298

Implements the following changes:
* The sample ID is now retrieved from Zocalo processing results. 
* The `sample_id` attribute in the hyperion request parameters is now taken to be the "parent" sample id under which robot load and gridscan results are reported in Ispyb and for which BLSampleStatus field is set in the event of sample or beamline errors
* There is a new selection algorithm `TopNByMaxCountForEachSample` that can be specified in `select_centres` in the request, this selects the top n diffracting centres for each sample ID that is returned by zocalo.
* If no sample ID attribution is made in a result from zocalo, a warning is logged and the diffracting centre is skipped.



### Instructions to reviewer on how to test:

1. Tests pass
2. Multisample pins report rotation DataCollections against each of the samples for which XRC crystals are found, and gridscan DataCollections against the first sample ID.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
