### PR TITLE
Use latest BlueAPI version number in dockerfile

### DIFF
--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -1,5 +1,5 @@
  # See https://github.com/DiamondLightSource/mx-bluesky/issues/1004
-FROM ghcr.io/diamondlightsource/blueapi:0.10.1
+FROM ghcr.io/diamondlightsource/blueapi:0.17.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -1,4 +1,8 @@
  # See https://github.com/DiamondLightSource/mx-bluesky/issues/1004
+
+ # Before changing this BlueAPI version number, you should check that 
+ # the BlueAPI pin in pyproject.toml is compatible, else the version will
+ # be overridden
 FROM ghcr.io/diamondlightsource/blueapi:0.17.0
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Our Dockerfile for `mx-bluesky-blueapi` had a misleading `BlueAPI` version. 

In our `pyproject.toml`, we had BlueAPI pinned to a version greater than that specified in the Dockerfile. When the image did  `pip install`, it uninstalled the version specified at the top of the Dockerfile and used the pyproject's version instead.

This is confusing when debugging, so we should make sure that the version in the Dockerfile agrees with the pyproject.toml's pinnings

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
