### PR TITLE
Format request parameter exceptions nicely in graylog

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -490,7 +490,9 @@ def run_aborted_plan(pmac: PMAC, dcid: DCID, exception: Exception):
         either by pressing the Abort button or because of a timeout, and to reset the \
         P variable.
     """
-    SSX_LOGGER.warning(f"Data Collection Aborted: {format_exception(exception)}")
+    SSX_LOGGER.warning(
+        f"Data Collection Aborted: {''.join(format_exception(exception))}"
+    )
     yield from bps.trigger(pmac.abort_program, wait=True)
 
     end_time = datetime.now()

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -218,7 +218,7 @@ class RunExperiment(Resource):
                 status_and_message = self.runner.start(plan, params, plan_name)
             except Exception as e:
                 status_and_message = make_error_status_and_message(e)
-                LOGGER.error(format_exception(e))
+                LOGGER.error("".join(format_exception(e)))
 
         elif action == Actions.STOP.value:
             status_and_message = self.runner.stop()

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -55,6 +55,7 @@ In order to avoid threads which get left alive forever after test completion
 
 
 autospec_patch = functools.partial(patch, autospec=True, spec_set=True)
+_MULTILINE_MESSAGE = "This is a\nmultiline log\nmessage."
 
 
 @pytest.fixture()
@@ -447,19 +448,40 @@ def test_log_on_invalid_json_params(test_env: ClientAndRunEngine):
     assert response.get("exception_type") == "ValueError"
 
 
-@pytest.mark.skip(
-    reason="See https://github.com/DiamondLightSource/hyperion/issues/777"
-)
+@pytest.mark.timeout(2)
 def test_warn_exception_during_plan_causes_warning_in_log(
     caplog: pytest.LogCaptureFixture, test_env: ClientAndRunEngine, test_params
 ):
     test_env.client.put(START_ENDPOINT, data=test_params)
-    test_env.mock_run_engine.error = WarningException("D'Oh")
+    test_env.mock_run_engine.error = WarningException(_MULTILINE_MESSAGE)
     response_json = wait_for_run_engine_status(test_env.client)
     assert response_json["status"] == Status.FAILED.value
-    assert response_json["message"] == 'WarningException("D\'Oh")'
+    assert response_json["message"] == repr(test_env.mock_run_engine.error)
     assert response_json["exception_type"] == "WarningException"
-    assert caplog.records[-1].levelname == "WARNING"
+    log_record = [r for r in caplog.records if r.funcName == "wait_on_queue"][0]
+    assert (
+        log_record.levelname == "WARNING" and _MULTILINE_MESSAGE in log_record.exc_text
+    )
+
+
+def _raise_exception(*args, **kwargs):
+    raise WarningException(_MULTILINE_MESSAGE)
+
+
+@patch.dict(
+    "mx_bluesky.hyperion.__main__.PLAN_REGISTRY",
+    {"pin_tip_centre_then_xray_centre": {"param_type": _raise_exception}},
+)
+def test_exception_during_parameter_decodde_generates_nicely_formatted_log_message(
+    caplog: pytest.LogCaptureFixture, test_env: ClientAndRunEngine, test_params
+):
+    response = test_env.client.put(START_ENDPOINT, data=test_params)
+    assert response.json["status"] == Status.FAILED.value
+    logrecord = [
+        r for r in caplog.records if r.funcName == "put" and r.filename == "__main__.py"
+    ][0]
+    assert logrecord.levelname == "ERROR"
+    assert _MULTILINE_MESSAGE in logrecord.message
 
 
 @pytest.mark.parametrize("dev_mode", [True, False])

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -78,8 +78,6 @@ class MockRunEngine:
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         time = 0.0
         while self.RE_takes_time:
-            sleep(SECS_PER_RUNENGINE_LOOP)
-            time += SECS_PER_RUNENGINE_LOOP
             if self.error:
                 raise self.error
             if time > RUNENGINE_TAKES_TIME_TIMEOUT:
@@ -88,14 +86,16 @@ class MockRunEngine:
                     "without an error. Most likely you should initialise with "
                     "RE_takes_time=false, or set RE.error from another thread."
                 )
+            sleep(SECS_PER_RUNENGINE_LOOP)
+            time += SECS_PER_RUNENGINE_LOOP
         if self.error:
             raise self.error
 
     def abort(self):
         while self.aborting_takes_time:
-            sleep(SECS_PER_RUNENGINE_LOOP)
             if self.error:
                 raise self.error
+            sleep(SECS_PER_RUNENGINE_LOOP)
         self.RE_takes_time = False
 
     def subscribe(self, *args):

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -460,7 +460,7 @@ def test_warn_exception_during_plan_causes_warning_in_log(
     assert response_json["exception_type"] == "WarningException"
     log_record = [r for r in caplog.records if r.funcName == "wait_on_queue"][0]
     assert log_record.levelname == "WARNING" and _MULTILINE_MESSAGE in getattr(
-        log_record.exc_text, ""
+        log_record, "exc_text", ""
     )
 
 

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -459,8 +459,8 @@ def test_warn_exception_during_plan_causes_warning_in_log(
     assert response_json["message"] == repr(test_env.mock_run_engine.error)
     assert response_json["exception_type"] == "WarningException"
     log_record = [r for r in caplog.records if r.funcName == "wait_on_queue"][0]
-    assert (
-        log_record.levelname == "WARNING" and _MULTILINE_MESSAGE in log_record.exc_text
+    assert log_record.levelname == "WARNING" and _MULTILINE_MESSAGE in getattr(
+        log_record.exc_text, ""
     )
 
 
@@ -476,7 +476,7 @@ def test_exception_during_parameter_decodde_generates_nicely_formatted_log_messa
     caplog: pytest.LogCaptureFixture, test_env: ClientAndRunEngine, test_params
 ):
     response = test_env.client.put(START_ENDPOINT, data=test_params)
-    assert response.json["status"] == Status.FAILED.value
+    assert response.json["status"] == Status.FAILED.value  # type: ignore
     logrecord = [
         r for r in caplog.records if r.funcName == "put" and r.filename == "__main__.py"
     ][0]


### PR DESCRIPTION
Fixes #1136 

This formats parameter requests more nicely in graylog, by correctly expanding the output of `format_exception()`

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
