### PR TITLE
(#1141) Fix another set call in progress for dev_shm_enable on CrystalNotFoundException

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
@@ -103,8 +103,11 @@ def _generic_tidy(
     # Turn off dev/shm streaming to avoid filling disk, see https://github.com/DiamondLightSource/hyperion/issues/1395
     LOGGER.info("Turning off Eiger dev/shm streaming")
     # Fix types in ophyd-async (https://github.com/DiamondLightSource/mx-bluesky/issues/855)
-    yield from bps.abs_set(  # type: ignore
-        xrc_composite.eiger.odin.fan.dev_shm_enable, 0, group=group, wait=wait
+    yield from bps.abs_set(
+        xrc_composite.eiger.odin.fan.dev_shm_enable,  # type: ignore
+        0,
+        group=group,
+        wait=wait,
     )
 
 

--- a/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
@@ -103,9 +103,9 @@ def _generic_tidy(
     # Turn off dev/shm streaming to avoid filling disk, see https://github.com/DiamondLightSource/hyperion/issues/1395
     LOGGER.info("Turning off Eiger dev/shm streaming")
     # Fix types in ophyd-async (https://github.com/DiamondLightSource/mx-bluesky/issues/855)
-    yield from bps.abs_set(
+    yield from bps.abs_set(  # type: ignore
         xrc_composite.eiger.odin.fan.dev_shm_enable, 0, group=group, wait=wait
-    )  # type: ignore
+    )
 
 
 def _panda_tidy(xrc_composite: HyperionFlyScanXRayCentreComposite):

--- a/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
@@ -103,7 +103,9 @@ def _generic_tidy(
     # Turn off dev/shm streaming to avoid filling disk, see https://github.com/DiamondLightSource/hyperion/issues/1395
     LOGGER.info("Turning off Eiger dev/shm streaming")
     # Fix types in ophyd-async (https://github.com/DiamondLightSource/mx-bluesky/issues/855)
-    yield from bps.abs_set(xrc_composite.eiger.odin.fan.dev_shm_enable, 0, wait=True)  # type: ignore
+    yield from bps.abs_set(
+        xrc_composite.eiger.odin.fan.dev_shm_enable, 0, group=group, wait=wait
+    )  # type: ignore
 
 
 def _panda_tidy(xrc_composite: HyperionFlyScanXRayCentreComposite):

--- a/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
@@ -102,7 +102,8 @@ def _generic_tidy(
 
     # Turn off dev/shm streaming to avoid filling disk, see https://github.com/DiamondLightSource/hyperion/issues/1395
     LOGGER.info("Turning off Eiger dev/shm streaming")
-    yield from bps.abs_set(xrc_composite.eiger.odin.fan.dev_shm_enable, 0)  # type: ignore # Fix types in ophyd-async (https://github.com/DiamondLightSource/mx-bluesky/issues/855)
+    # Fix types in ophyd-async (https://github.com/DiamondLightSource/mx-bluesky/issues/855)
+    yield from bps.abs_set(xrc_composite.eiger.odin.fan.dev_shm_enable, 0, wait=True)  # type: ignore
 
 
 def _panda_tidy(xrc_composite: HyperionFlyScanXRayCentreComposite):

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -356,55 +356,6 @@ def test_execute_load_centre_collect_full(
     assert fetch_blsample(expected_sample_id).blSampleStatus == "LOADED"  # type: ignore
 
 
-@pytest.mark.parametrize(
-    "zocalo_result",
-    [
-        [],
-    ],
-)
-@pytest.mark.system_test
-def test_execute_load_centre_collect_full_no_diffraction(
-    zocalo_result,
-    load_centre_collect_composite: LoadCentreCollectComposite,
-    load_centre_collect_params: LoadCentreCollect,
-    oav_parameters_for_rotation: OAVParameters,
-    RE: RunEngine,
-    fetch_datacollection_attribute: Callable[..., Any],
-    fetch_datacollectiongroup_attribute: Callable[..., Any],
-    fetch_datacollection_ids_for_group_id: Callable[..., Any],
-    fetch_blsample: Callable[[int], BLSample],
-    tmp_path,
-):
-    load_centre_collect_params.features.use_gpu_results = True
-    load_centre_collect_params.robot_load_then_centre.features.use_gpu_results = True
-    ispyb_gridscan_cb = GridscanISPyBCallback(
-        param_type=GridCommonWithHyperionDetectorParams
-    )
-    ispyb_rotation_cb = RotationISPyBCallback()
-    snapshot_cb = BeamDrawingCallback(emit=ispyb_rotation_cb)
-    robot_load_cb = RobotLoadISPyBCallback()
-    # robot_load_cb.expeye = MagicMock()
-    robot_load_cb.expeye.start_robot_action = MagicMock(return_value=1234)
-    robot_load_cb.expeye.end_robot_action = MagicMock()
-    robot_load_cb.expeye.update_robot_action = MagicMock()
-    set_mock_value(
-        load_centre_collect_composite.undulator_dcm.undulator_ref().current_gap, 1.11
-    )
-    load_centre_collect_composite.zocalo.my_zocalo_result = zocalo_result
-
-    RE.subscribe(ispyb_gridscan_cb)
-    RE.subscribe(snapshot_cb)
-    RE.subscribe(robot_load_cb)
-    with pytest.raises(CrystalNotFoundException):
-        RE(
-            load_centre_collect_full(
-                load_centre_collect_composite,
-                load_centre_collect_params,
-                oav_parameters_for_rotation,
-            )
-        )
-
-
 @pytest.mark.system_test
 def test_load_centre_collect_updates_bl_sample_status_robot_load_fail(
     load_centre_collect_composite: LoadCentreCollectComposite,


### PR DESCRIPTION
Fixes
* #1141 

This ensures that the call to reset the `dev_shm_enable` PV occurs with a wait such that any `contingency_wrapper` does not attempt to make a concurrent write to the PV

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
