### PR TITLE
Fix system tests trying to access /dls/tmp on test collection

### DIFF
--- a/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/system_tests/hyperion/external_interaction/test_agamemnon.py
@@ -53,27 +53,23 @@ EXPECTED_ROTATION_PARAMS = {
     ],
 }
 
-EXPECTED_PARAMETERS = [
-    LoadCentreCollect.model_validate(
-        {
-            "features": {"use_gpu_results": True},
-            "visit": "cm00000-0",
-            "detector_distance_mm": 180.8,
-            "sample_id": 12345,
-            "sample_puck": 1,
-            "sample_pin": 1,
-            "parameter_model_version": SemanticVersion.validate_from_str(
-                str(PARAMETER_VERSION)
-            ),
-            "select_centres": {
-                "name": "TopNByMaxCount",
-                "n": 1,
-            },
-            "robot_load_then_centre": EXPECTED_ROBOT_LOAD_AND_CENTRE_PARAMS,
-            "multi_rotation_scan": EXPECTED_ROTATION_PARAMS,
-        }
-    )
-]
+EXPECTED_PARAMETERS = {
+    "features": {"use_gpu_results": True},
+    "visit": "cm00000-0",
+    "detector_distance_mm": 180.8,
+    "sample_id": 12345,
+    "sample_puck": 1,
+    "sample_pin": 1,
+    "parameter_model_version": SemanticVersion.validate_from_str(
+        str(PARAMETER_VERSION)
+    ),
+    "select_centres": {
+        "name": "TopNByMaxCount",
+        "n": 1,
+    },
+    "robot_load_then_centre": EXPECTED_ROBOT_LOAD_AND_CENTRE_PARAMS,
+    "multi_rotation_scan": EXPECTED_ROTATION_PARAMS,
+}
 
 
 def test_given_test_agamemnon_instruction_then_returns_none_loop_type():
@@ -85,8 +81,9 @@ def test_given_test_agamemnon_instruction_then_returns_none_loop_type():
 def test_given_test_agamemnon_instruction_then_load_centre_collect_parameters_populated():
     params = _get_parameters_from_url(AGAMEMNON_URL + "/example/collect")
     load_centre_collect = populate_parameters_from_agamemnon(params)
+    expected_parameter_model = [LoadCentreCollect.model_validate(EXPECTED_PARAMETERS)]
     difference = DeepDiff(
         load_centre_collect,
-        EXPECTED_PARAMETERS,
+        expected_parameter_model,
     )
     assert not difference


### PR DESCRIPTION
When local system tests are run on a non-diamond machine test collection fails because import of  `test_agamemnon.py` executes a pydantic model validation that tries to access /dls/tmp folder. Even though the tests in this file are not part of the system tests since they aren't decorated as such.

I believe this does not cause issues with the nightly build because inside the system test execution container, everything executes as root so creation of this folder succeeds. However running locally outside of a container, runs into issues.

### Instructions to reviewer on how to test:

1. tox -e `localsystemtests` passes

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
