### PR TITLE
Update I24 blueapi config

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/blueapi_config.yaml
+++ b/src/mx_bluesky/beamlines/i24/serial/blueapi_config.yaml
@@ -14,4 +14,4 @@ api:
       - "*"
 stomp:
   enabled: true
-  host: http://i24-control.diamond.ac.uk:61613
+  url: http://i24-control.diamond.ac.uk:61613

--- a/src/mx_bluesky/beamlines/i24/serial/blueapi_config.yaml
+++ b/src/mx_bluesky/beamlines/i24/serial/blueapi_config.yaml
@@ -7,11 +7,11 @@ env:
   events:
     broadcast_status_events: false
 api:
-  port: 25565
+  url: http://localhost:25565
   cors:
     allow_credentials: True
     origins: 
       - "*"
 stomp:
   enabled: true
-  host: i24-control.diamond.ac.uk
+  host: http://i24-control.diamond.ac.uk:61613


### PR DESCRIPTION
Fixes #1168 

### Instructions to reviewer on how to test:

1. Start a blueapi server with 
```bash
blueapi -c src/mx_bluesky/beamlines/i24/serial/blueapi_config.yaml serve
``` 
and verify it connects without configuration errors

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
