### PR TITLE
Get usable debug logs when running BlueAPI in pod

### DIFF
--- a/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
@@ -65,7 +65,7 @@ from mx_bluesky.common.parameters.gridscan import GridCommon, SpecifiedThreeDGri
 from mx_bluesky.common.preprocessors.preprocessors import (
     transmission_and_xbpm_feedback_for_collection_decorator,
 )
-from mx_bluesky.common.utils.log import LOGGER
+from mx_bluesky.common.utils.log import LOGGER, setup_debug_logging_for_blueapi_plan
 from mx_bluesky.phase1_zebra.device_setup_plans.setup_zebra import (
     setup_zebra_for_gridscan,
     tidy_up_zebra_after_gridscan,
@@ -110,6 +110,7 @@ def i04_grid_detect_then_xray_centre(
     isn't running in a continious Bluesky UDC loop, we take additional steps in beamline
     tidy-up.
     """
+    setup_debug_logging_for_blueapi_plan()
 
     composite = GridDetectThenXRayCentreComposite(
         eiger,

--- a/src/mx_bluesky/beamlines/i04/thawing_plan.py
+++ b/src/mx_bluesky/beamlines/i04/thawing_plan.py
@@ -13,6 +13,7 @@ from dodal.devices.smargon import Smargon
 from dodal.devices.thawer import OnOff, Thawer
 
 from mx_bluesky.beamlines.i04.callbacks.murko_callback import MurkoCallback
+from mx_bluesky.common.utils.log import setup_debug_logging_for_blueapi_plan
 
 
 def thaw_and_stream_to_redis(
@@ -24,6 +25,7 @@ def thaw_and_stream_to_redis(
     oav: OAV = inject("oav"),
     oav_to_redis_forwarder: OAVToRedisForwarder = inject("oav_to_redis_forwarder"),
 ) -> MsgGenerator:
+    setup_debug_logging_for_blueapi_plan()
     zoom_percentage = yield from bps.rd(oav.zoom_controller.percentage)
     sample_id = yield from bps.rd(robot.sample_id)
 
@@ -90,6 +92,7 @@ def thaw(
     thawer: Thawer = inject("thawer"),
     smargon: Smargon = inject("smargon"),
 ) -> MsgGenerator:
+    setup_debug_logging_for_blueapi_plan()
     yield from _thaw(time_to_thaw, rotation, thawer, smargon)
 
 

--- a/src/mx_bluesky/common/utils/log.py
+++ b/src/mx_bluesky/common/utils/log.py
@@ -9,6 +9,7 @@ from dodal.log import (
     DodalLogHandlers,
     integrate_bluesky_and_ophyd_logging,
     set_up_all_logging_handlers,
+    set_up_DEBUG_memory_handler,
 )
 from dodal.log import LOGGER as dodal_logger
 
@@ -84,6 +85,31 @@ def do_default_logging_setup(
 
     global __logger_handlers
     __logger_handlers = handlers
+
+
+def setup_debug_logging_for_blueapi_plan(filename="mx-bluesky-debug", dev_mode=False):
+    """Set-up debug logging when running a BlueAPI application.
+
+    General logging is managed through BlueAPI helm configuration when running a
+    BlueAPI application. However, there is currently no easy way to save debug logs
+    in a sensible way. Run this function at the entry point to your BlueAPI plan
+    to get debug log files saved with the behaviour specified in set_up_DEBUG_memory_handler.
+
+    IMPORTANT: For these logging files to persist beyond a pods lifetime,
+    within you BlueAPI helm configuration,you must mount the logging directory to a PVC
+
+    See https://github.com/DiamondLightSource/blueapi/issues/1170 for
+    a longer term solution
+    """
+
+    logging_path, debug_logging_path = _get_logging_dirs(dev_mode=dev_mode)
+    set_up_DEBUG_memory_handler(
+        dodal_logger,
+        debug_logging_path or logging_path,
+        filename,
+        ERROR_LOG_BUFFER_LINES,
+    )
+    integrate_bluesky_and_ophyd_logging(dodal_logger)
 
 
 def _get_debug_handler() -> CircularMemoryHandler:


### PR DESCRIPTION
Fixes #1208 
To get the logs to persist, the BlueAPI config (within the ixx-values repo) must mount the debug logging directory to a PVC. I will make a change for this in i04-services as an example of how to use it. This is a short term solution - I think the proper fix may be a long time away.

### Instructions to reviewer on how to test:

1. Is solution sensible and is test sufficient?

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
