### PR TITLE
Fix broken system tests

### DIFF
--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -224,6 +224,7 @@ async def zocalo_for_fake_zocalo(zocalo_env) -> ZocaloResults:
 @pytest.fixture
 def zocalo_for_system_test() -> Generator[ZocaloResults, None, None]:
     zocalo = i03.zocalo(connect_immediately=True, mock=True)
+    zocalo.timeout_s = 10
     old_zocalo_trigger = zocalo.trigger
     zocalo.my_zocalo_result = deepcopy(TEST_RESULT_MEDIUM)
     zocalo.my_zocalo_result[0]["sample_id"] = SimConstants.ST_SAMPLE_ID  # type: ignore
@@ -231,7 +232,9 @@ def zocalo_for_system_test() -> Generator[ZocaloResults, None, None]:
     @AsyncStatus.wrap
     async def mock_zocalo_complete():
         fake_recipe_wrapper = MagicMock(spec=RecipeWrapper)
-        fake_recipe_wrapper.recipe_step = {"parameters": {"dcid": 1234, "dcgid": 123}}
+        fake_recipe_wrapper.recipe_step = {
+            "parameters": {"dcid": 1234, "dcgid": 123, "gpu": True}
+        }
         message = {
             "results": zocalo.my_zocalo_result  # type: ignore
         }

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -191,7 +191,7 @@ GRID_DC_1_EXPECTED_VALUES = {
     "overlap": 0,
     "omegastart": 90,
     "startimagenumber": 1,
-    "wavelength": 0.976254,
+    "wavelength": 1.11697,
     "xbeam": 75.6027,
     "ybeam": 79.4935,
     "xtalsnapshotfullpath1": "{tmp_data}/123457/xraycentring/snapshots/robot_load_centring_file_1_90_grid_overlay.png",
@@ -223,7 +223,7 @@ ROTATION_DC_EXPECTED_VALUES = {
     "axisStart": 10,
     "axisEnd": -350,
     # "chiStart": 0, mx-bluesky 325
-    "wavelength": 0.976254,
+    "wavelength": 1.11697,
     "beamSizeAtSampleX": 0.02,
     "beamSizeAtSampleY": 0.02,
     "exposureTime": 0.004,


### PR DESCRIPTION
* Update the expected wavelength in load_centre_collect_full test now that the DCM fixture motors are all patched.
* Make fake zocalo results come from the GPU now that we are ignoring CPU results

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. System tests pass
https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/jobs/267350


### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
