### PR TITLE
Fix smargon constructor call in unit tests

### DIFF
--- a/tests/unit_tests/beamlines/i04/test_thawing.py
+++ b/tests/unit_tests/beamlines/i04/test_thawing.py
@@ -65,7 +65,7 @@ async def oav(RE: RunEngine) -> OAV:
 
 @pytest.fixture
 async def smargon(RE: RunEngine) -> AsyncGenerator[Smargon, None]:
-    smargon = Smargon(name="smargon")
+    smargon = Smargon(prefix="BL04I-MO-SGON-01:", name="smargon")
     await smargon.connect(mock=True)
 
     set_mock_value(smargon.omega.user_readback, 0.0)


### PR DESCRIPTION
Fixes unit test breakage following merge of dodal
* DiamondLightSource/dodal#1388

(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
