### PR TITLE
Fix system tests following dodal 1388

### DIFF
--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -215,7 +215,7 @@ async def zocalo_for_fake_zocalo(zocalo_env) -> ZocaloResults:
     """
     This attempts to connect to a fake zocalo via rabbitmq
     """
-    zd = ZocaloResults()
+    zd = ZocaloResults("zocalo")
     zd.timeout_s = 10
     await zd.connect()
     return zd


### PR DESCRIPTION
Fixes system test breakage from 
* DiamondLightSource/dodal#1388

Reinstates the test fixture name now that it is no longer defaulted in the `ZocaloResults` constructor

(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. System tests pass
https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/jobs/267710

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
