### PR TITLE
1149 collect samples in order starting from the tip of the pin

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 
 import bluesky.plan_stubs as bps
 import numpy as np
@@ -84,41 +84,12 @@ def load_centre_collect_full(
             flyscan_event_handler,
         )
 
-        locations_to_collect_um: list[np.ndarray]
-        samples_to_collect: list[int]
-
-        if flyscan_event_handler.xray_centre_results:
-            selection_func = flyscan_result.resolve_selection_fn(
-                parameters.selection_params
+        sample_ids_and_locations = yield from (
+            _samples_and_locations_to_collect(
+                flyscan_event_handler.xray_centre_results, parameters, composite
             )
-            hits = selection_func(flyscan_event_handler.xray_centre_results)
-            hits_to_collect = []
-            for hit in hits:
-                if hit.sample_id is None:
-                    LOGGER.warning(
-                        f"Diffracting centre {hit} not collected because no sample id was assigned."
-                    )
-                else:
-                    hits_to_collect.append(hit)
-
-            locations_to_collect_um = [
-                hit.centre_of_mass_mm * 1000 for hit in hits_to_collect
-            ]
-            samples_to_collect = [hit.sample_id for hit in hits_to_collect]
-            LOGGER.info(
-                f"Selected hits {hits_to_collect} using {selection_func}, args={parameters.selection_params}"
-            )
-        else:
-            # If the xray centring hasn't found a result but has not thrown an error it
-            # means that we do not need to recentre and can collect where we are
-            initial_x_mm = yield from bps.rd(composite.smargon.x.user_readback)
-            initial_y_mm = yield from bps.rd(composite.smargon.y.user_readback)
-            initial_z_mm = yield from bps.rd(composite.smargon.z.user_readback)
-
-            locations_to_collect_um = [
-                np.array([initial_x_mm, initial_y_mm, initial_z_mm]) * 1000
-            ]
-            samples_to_collect = [parameters.sample_id]
+        )
+        sample_ids_and_locations.sort(key=_x_coordinate)
 
         multi_rotation = parameters.multi_rotation_scan
         rotation_template = multi_rotation.rotation_scans.copy()
@@ -129,9 +100,7 @@ def load_centre_collect_full(
 
         generator = rotation_scan_generator(is_alternating)
         next(generator)
-        for location, sample_id in zip(
-            locations_to_collect_um, samples_to_collect, strict=True
-        ):
+        for sample_id, location in sample_ids_and_locations:
             for rot in rotation_template:
                 combination = generator.send((rot, location, sample_id))
                 multi_rotation.rotation_scans.append(combination)
@@ -144,6 +113,51 @@ def load_centre_collect_full(
         yield from rotation_scan_internal(composite, multi_rotation, oav_params)
 
     yield from plan_with_callback_subs()
+
+
+def _samples_and_locations_to_collect(
+    xrc_results: Sequence[flyscan_result.XRayCentreResult] | None,
+    parameters: LoadCentreCollect,
+    composite: LoadCentreCollectComposite,
+) -> MsgGenerator[list[tuple[int, np.ndarray]]]:
+    if xrc_results:
+        selection_func = flyscan_result.resolve_selection_fn(
+            parameters.selection_params
+        )
+        hits = selection_func(xrc_results)
+        hits_to_collect = []
+        for hit in hits:
+            if hit.sample_id is None:
+                LOGGER.warning(
+                    f"Diffracting centre {hit} not collected because no sample id was assigned."
+                )
+            else:
+                hits_to_collect.append(hit)
+
+        samples_and_locations = [
+            (hit.sample_id, hit.centre_of_mass_mm * 1000) for hit in hits_to_collect
+        ]
+        LOGGER.info(
+            f"Selected hits {hits_to_collect} using {selection_func}, args={parameters.selection_params}"
+        )
+        return samples_and_locations
+    else:
+        # If the xray centring hasn't found a result but has not thrown an error it
+        # means that we do not need to recentre and can collect where we are
+        initial_x_mm = yield from bps.rd(composite.smargon.x.user_readback)
+        initial_y_mm = yield from bps.rd(composite.smargon.y.user_readback)
+        initial_z_mm = yield from bps.rd(composite.smargon.z.user_readback)
+
+        return [
+            (
+                parameters.sample_id,
+                np.array([initial_x_mm, initial_y_mm, initial_z_mm]) * 1000,
+            )
+        ]
+
+
+def _x_coordinate(sample_and_location: tuple[int, np.ndarray]) -> float:
+    return sample_and_location[1][0]  # type: ignore
 
 
 def rotation_scan_generator(

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import numpy as np
 import pytest
 from bluesky.protocols import Location
 from bluesky.run_engine import RunEngine
@@ -61,6 +62,23 @@ POS_MED = {
     "y_start_um": 500,
     "z_start_um": 600,
 }
+
+(
+    FLYSCAN_RESULT_POS_1,
+    FLYSCAN_RESULT_POS_2,
+    FLYSCAN_RESULT_POS_3,
+    FLYSCAN_RESULT_POS_4,
+    FLYSCAN_RESULT_POS_5,
+) = [
+    dataclasses.replace(FLYSCAN_RESULT_MED, centre_of_mass_mm=np.array(coords))
+    for coords in [
+        [0.01, 0.02, 0.03],
+        [0.02, 0.02, 0.03],
+        [0.03, 0.02, 0.03],
+        [0.04, 0.02, 0.03],
+        [0.05, 0.02, 0.03],
+    ]
+]
 
 
 @pytest.fixture
@@ -637,6 +655,78 @@ def test_load_centre_collect_full_plan_multiple_centres(
         expected_rotation_scans, rotation_scan_params.rotation_scans
     )
     assert rotation_scan_params.transmission_frac == 0.05
+
+
+@patch(
+    "mx_bluesky.hyperion.experiment_plans.robot_load_then_centre_plan.pin_centre_then_flyscan_plan",
+    new=MagicMock(
+        return_value=iter(
+            [
+                Msg(
+                    "open_run",
+                    xray_centre_results=[
+                        dataclasses.asdict(r)
+                        for r in [
+                            FLYSCAN_RESULT_POS_2,
+                            FLYSCAN_RESULT_POS_3,
+                            FLYSCAN_RESULT_POS_1,
+                            FLYSCAN_RESULT_POS_5,
+                            FLYSCAN_RESULT_POS_4,
+                        ]
+                    ],
+                    run=CONST.PLAN.FLYSCAN_RESULTS,
+                ),
+                Msg("close_run"),
+            ]
+        )
+    ),
+)
+def test_load_centre_collect_full_sorts_collections_by_distance_from_pin_tip(
+    mock_multi_rotation_scan: MagicMock,
+    sim_run_engine: RunEngineSimulator,
+    load_centre_collect_with_top_n_params: LoadCentreCollect,
+    oav_parameters_for_rotation: OAVParameters,
+    composite: LoadCentreCollectComposite,
+):
+    sim_run_engine.add_handler_for_callback_subscribes()
+    sim_fire_event_on_open_run(sim_run_engine, CONST.PLAN.FLYSCAN_RESULTS)
+    sim_run_engine.simulate_plan(
+        load_centre_collect_full(
+            composite,
+            load_centre_collect_with_top_n_params,
+            oav_parameters_for_rotation,
+        )
+    )
+
+    expected_xyz = [
+        [
+            (10.0, 20.0, 30.0, 0.0),
+            (10.0, 20.0, 30.0, 30.0),
+            (20.0, 20.0, 30.0, 0.0),
+            (20.0, 20.0, 30.0, 30.0),
+            (30.0, 20.0, 30.0, 0.0),
+            (30.0, 20.0, 30.0, 30.0),
+            (40.0, 20.0, 30.0, 0.0),
+            (40.0, 20.0, 30.0, 30.0),
+            (50.0, 20.0, 30.0, 0.0),
+            (50.0, 20.0, 30.0, 30.0),
+        ]
+    ]
+
+    def assert_rotation_scan_call(
+        mock_call, expected_coords: list[tuple[float, float, float, float]]
+    ):
+        params: RotationScan = mock_call.args[1]
+        actual_coords = [
+            (scan.x_start_um, scan.y_start_um, scan.z_start_um, scan.chi_start_deg)
+            for scan in list(params.single_rotation_scans)
+        ]
+        assert actual_coords == expected_coords
+
+    for mock_call, expected_coords in zip(
+        mock_multi_rotation_scan.mock_calls, expected_xyz, strict=True
+    ):
+        assert_rotation_scan_call(mock_call, expected_coords)
 
 
 def _rotation_at(

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -70,13 +70,15 @@ POS_MED = {
     FLYSCAN_RESULT_POS_4,
     FLYSCAN_RESULT_POS_5,
 ) = [
-    dataclasses.replace(FLYSCAN_RESULT_MED, centre_of_mass_mm=np.array(coords))
-    for coords in [
-        [0.01, 0.02, 0.03],
-        [0.02, 0.02, 0.03],
-        [0.03, 0.02, 0.03],
-        [0.04, 0.02, 0.03],
-        [0.05, 0.02, 0.03],
+    dataclasses.replace(
+        FLYSCAN_RESULT_MED, centre_of_mass_mm=np.array(coords), sample_id=sample_id
+    )
+    for (coords, sample_id) in [
+        ([0.01, 0.02, 0.03], 1),
+        ([0.02, 0.02, 0.03], 2),
+        ([0.03, 0.02, 0.03], 3),
+        ([0.04, 0.02, 0.03], 4),
+        ([0.05, 0.02, 0.03], 5),
     ]
 ]
 
@@ -699,34 +701,29 @@ def test_load_centre_collect_full_sorts_collections_by_distance_from_pin_tip(
     )
 
     expected_xyz = [
-        [
-            (10.0, 20.0, 30.0, 0.0),
-            (10.0, 20.0, 30.0, 30.0),
-            (20.0, 20.0, 30.0, 0.0),
-            (20.0, 20.0, 30.0, 30.0),
-            (30.0, 20.0, 30.0, 0.0),
-            (30.0, 20.0, 30.0, 30.0),
-            (40.0, 20.0, 30.0, 0.0),
-            (40.0, 20.0, 30.0, 30.0),
-            (50.0, 20.0, 30.0, 0.0),
-            (50.0, 20.0, 30.0, 30.0),
-        ]
+        (10.0, 20.0, 30.0, 0.0),
+        (10.0, 20.0, 30.0, 30.0),
+        (20.0, 20.0, 30.0, 0.0),
+        (20.0, 20.0, 30.0, 30.0),
+        (30.0, 20.0, 30.0, 0.0),
+        (30.0, 20.0, 30.0, 30.0),
+        (40.0, 20.0, 30.0, 0.0),
+        (40.0, 20.0, 30.0, 30.0),
+        (50.0, 20.0, 30.0, 0.0),
+        (50.0, 20.0, 30.0, 30.0),
     ]
 
-    def assert_rotation_scan_call(
-        mock_call, expected_coords: list[tuple[float, float, float, float]]
-    ):
-        params: RotationScan = mock_call.args[1]
-        actual_coords = [
-            (scan.x_start_um, scan.y_start_um, scan.z_start_um, scan.chi_start_deg)
-            for scan in list(params.single_rotation_scans)
-        ]
-        assert actual_coords == expected_coords
+    expected_sample_ids = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
 
-    for mock_call, expected_coords in zip(
-        mock_multi_rotation_scan.mock_calls, expected_xyz, strict=True
-    ):
-        assert_rotation_scan_call(mock_call, expected_coords)
+    mock_multi_rotation_scan.assert_called_once()
+    params: RotationScan = mock_multi_rotation_scan.mock_calls[0].args[1]
+    actual_coords = [
+        (scan.x_start_um, scan.y_start_um, scan.z_start_um, scan.chi_start_deg)
+        for scan in list(params.single_rotation_scans)
+    ]
+    assert actual_coords == expected_xyz
+    actual_ids = [scan.sample_id for scan in list(params.single_rotation_scans)]
+    assert actual_ids == expected_sample_ids
 
 
 def _rotation_at(


### PR DESCRIPTION
Fixes

* #1149

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

When multiple centres are selected, collections should now be collected in order of ascending x-coordinate

### Instructions to reviewer on how to test:

1. MSPs are collected in order starting from the end of the tip. Sample IDs are still assigned correctly.
2. Tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
