### PR TITLE
Only enable code coverage reporting in GitHub CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run tests
         # Longer timeout for CI due to likelihood of cold caches,
         # cloud infra hw contention etc.
-        run: tox -e tests -- -m "not dlstbx" --timeout=2
+        run: tox -e tests -- -m "not dlstbx" --timeout=2 --cov=mx_bluesky --cov-report term --cov-report xml:cov.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/docs/developer/general/how-to/dev-ops/run-tests.rst
+++ b/docs/developer/general/how-to/dev-ops/run-tests.rst
@@ -6,7 +6,7 @@ like tests`_, and run them to check for errors. You can run it with::
 
     $ tox -e tests
 
-It will also report coverage to the commandline and to ``cov.xml``.
+When the tests are run in GitHub CI it will also report coverage to ``codecov.io``.
 
 .. _pytest: https://pytest.org/
 .. _look like tests: https://docs.pytest.org/explanation/goodpractices.html#test-discovery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ allowlist_externals =
 commands =
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     type-checking: pyright src tests {posargs}
-    tests: pytest --cov=mx_bluesky --cov-report term --cov-report xml:cov.xml {posargs}
+    tests: pytest {posargs}
     docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html
 commands_pre =
     docs: /usr/bin/bash -c "{toxinidir}/utility_scripts/generate_plantuml.py > \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,6 +361,7 @@ def RE():
 
         RE.loop.call_soon_threadsafe(stop_event_loop)
         stopped_event.wait(10)
+        # RE.loop.close()
     del RE
 
 


### PR DESCRIPTION
Disable code coverage when running unit tests locally; this provides a signfiicant (~27s) speedup on my workstation.
It also seems to eliminate the 1s timeout failures when running the tests.

Code coverage is still enabled for Github CI tests.

This also adds a one line change to close the RunEngine fixture event loop after usage; this was generating some confusing error messages when I was writing unit tests, due to the `ResourceWarning`/`UnraisableExceptionWarning` errors which occurred when the event loop was eventually garbage collected.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Tests pass
2. GH CI still generates code coverage

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
