### PR TITLE
Fix unit tests following ophyd-async changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.10.0a2",
     "bluesky >= 1.13.1",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@1dd148a01046db4ce8be2c0ccdd01b68112dfc3c",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git",
 ]
 
 


### PR DESCRIPTION
Fixes unit tests against the latest ophyd-async (v0.13.2) following
* bluesky/ophyd-async#1032

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Unit tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
