### PR TITLE
Fix for snapshot system test

### DIFF
--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -58,7 +58,6 @@ from mx_bluesky.hyperion.parameters.rotation import RotationScan
 from ....conftest import (
     TEST_RESULT_MEDIUM,
     SimConstants,
-    fake_read,
     pin_tip_edge_data,
     raw_params_from_file,
 )
@@ -459,8 +458,4 @@ def composite_for_rotation_scan(
     set_mock_value(fake_create_rotation_devices.s4_slit_gaps.xgap.user_readback, 0.123)
     set_mock_value(fake_create_rotation_devices.s4_slit_gaps.ygap.user_readback, 0.234)
 
-    with (
-        patch("bluesky.preprocessors.__read_and_stash_a_motor", fake_read),
-        patch("bluesky.plan_stubs.wait"),
-    ):
-        yield fake_create_rotation_devices
+    yield fake_create_rotation_devices


### PR DESCRIPTION
Fixes breakage in `test_load_centre_collect_generate_rotation_snapshots()`.

This was caused by `bps.wait()` being patched, which silently elided a wait in `rotation_scan_plan.py`:
``        yield from bps.wait(CONST.WAIT.MOVE_GONIO_TO_START)``

This wait was responsible for ensuring that a preding `CombinedMove` on the smargon completed; changes to the smargon to include checks for motor limits changed the timing for this move and meant that the snapshot was no longer in the correct position.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. System tests pass
https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/jobs/270594

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
