### PR TITLE
Fix for gridscans failing due to ordering of grid detection

### DIFF
--- a/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
@@ -48,6 +48,7 @@ from mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback imp
 )
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
+    generate_start_info_from_omega_map,
 )
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.nexus_callback import (
     GridscanNexusFileCallback,
@@ -198,7 +199,9 @@ def create_gridscan_callbacks() -> tuple[
         GridscanISPyBCallback(
             param_type=GridCommon,
             emit=ZocaloCallback(
-                PlanNameConstants.DO_FGS, EnvironmentConstants.ZOCALO_ENV
+                PlanNameConstants.DO_FGS,
+                EnvironmentConstants.ZOCALO_ENV,
+                generate_start_info_from_omega_map,
             ),
         ),
     )

--- a/src/mx_bluesky/common/experiment_plans/common_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/common/experiment_plans/common_flyscan_xray_centre_plan.py
@@ -284,7 +284,6 @@ def run_gridscan(
         fgs_composite.eiger,
         fgs_composite.synchrotron,
         [parameters.scan_points_first_grid, parameters.scan_points_second_grid],
-        parameters.scan_indices,
         plan_during_collection=beamline_specific.read_during_collection_plan,
     )
 

--- a/src/mx_bluesky/common/external_interaction/callbacks/common/ispyb_callback_base.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/common/ispyb_callback_base.py
@@ -86,11 +86,11 @@ class BaseISPyBCallback(PlanReactiveCallback):
 
     def activity_gated_start(self, doc: RunStart):
         self._oav_snapshot_event_idx = 0
-        return self._tag_doc(doc)
+        return self.tag_doc(doc)
 
     def activity_gated_descriptor(self, doc: EventDescriptor):
         self.descriptors[doc["uid"]] = doc
-        return self._tag_doc(doc)
+        return self.tag_doc(doc)
 
     def activity_gated_event(self, doc: Event) -> Event:
         """Subclasses should extend this to add a call to set_dcig_tag from
@@ -112,10 +112,10 @@ class BaseISPyBCallback(PlanReactiveCallback):
             case DocDescriptorNames.HARDWARE_READ_DURING:
                 scan_data_infos = self._handle_ispyb_transmission_flux_read(doc)
             case _:
-                return self._tag_doc(doc)
+                return self.tag_doc(doc)
         self.ispyb_ids = self.ispyb.update_deposition(self.ispyb_ids, scan_data_infos)
         ISPYB_ZOCALO_CALLBACK_LOGGER.info(f"Received ISPYB IDs: {self.ispyb_ids}")
-        return self._tag_doc(doc)
+        return self.tag_doc(doc)
 
     def _handle_ispyb_hardware_read(self, doc) -> Sequence[ScanDataInfo]:
         assert self.params, "Event handled before activity_gated_start received params"
@@ -203,7 +203,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
             ISPYB_ZOCALO_CALLBACK_LOGGER.warning(
                 f"Failed to finalise ISPyB deposition on stop document: {format_doc_for_log(doc)} with exception: {e}"
             )
-        return self._tag_doc(doc)
+        return self.tag_doc(doc)
 
     def _append_to_comment(self, id: int, comment: str) -> None:
         assert self.ispyb is not None
@@ -218,7 +218,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
         for id in self.ispyb_ids.data_collection_ids:
             self._append_to_comment(id, comment)
 
-    def _tag_doc(self, doc: D) -> D:
+    def tag_doc(self, doc: D) -> D:
         assert isinstance(doc, dict)
         if self.ispyb_ids:
             doc["ispyb_dcids"] = self.ispyb_ids.data_collection_ids

--- a/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
@@ -29,6 +29,15 @@ class ZocaloCallback(CallbackBase):
 
     Shouldn't be subscribed directly to the RunEngine, instead should be passed to the
     `emit` argument of an ISPyB callback which appends DCIDs to the relevant start doc.
+
+    Args:
+        triggering_plan: Name of the bluesky sub-plan inside of which we generate information
+            to be submitted to zocalo; this is identified by the 'subplan_name' entry in the
+            run start metadata.
+        zocalo_environment: Name of the zocalo environment we use to connect to zocalo
+        start_info_generator_factory: A factory method which returns a Generator,
+            the generator is sent the ZOCALO_HW_READ event document and in return yields
+            one or more ZocaloStartInfo which will each be submitted to zocalo as a job.
     """
 
     def __init__(

--- a/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/common/zocalo_callback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING
 
 from bluesky.callbacks import CallbackBase
@@ -10,10 +11,12 @@ from mx_bluesky.common.parameters.constants import (
 )
 from mx_bluesky.common.utils.exceptions import ISPyBDepositionNotMade
 from mx_bluesky.common.utils.log import ISPYB_ZOCALO_CALLBACK_LOGGER
-from mx_bluesky.common.utils.utils import number_of_frames_from_scan_spec
 
 if TYPE_CHECKING:
     from event_model.documents import Event, EventDescriptor, RunStart, RunStop
+
+
+ZocaloInfoGenerator = Generator[list[ZocaloStartInfo], dict, None]
 
 
 class ZocaloCallback(CallbackBase):
@@ -28,38 +31,34 @@ class ZocaloCallback(CallbackBase):
     `emit` argument of an ISPyB callback which appends DCIDs to the relevant start doc.
     """
 
+    def __init__(
+        self,
+        triggering_plan: str,
+        zocalo_environment: str,
+        start_info_generator_factory: Callable[[], ZocaloInfoGenerator],
+    ):
+        super().__init__()
+        self._info_generator_factory = start_info_generator_factory
+        self.triggering_plan = triggering_plan
+        self.zocalo_interactor = ZocaloTrigger(zocalo_environment)
+        self._reset_state()
+
     def _reset_state(self):
         self.run_uid: str | None = None
         self.zocalo_info: list[ZocaloStartInfo] = []
         self._started_zocalo_collections: list[ZocaloStartInfo] = []
         self.descriptors: dict[str, EventDescriptor] = {}
-        self.start_frame = 0
-
-    def __init__(self, triggering_plan: str, zocalo_environment: str):
-        super().__init__()
-        self.triggering_plan = triggering_plan
-        self.zocalo_interactor = ZocaloTrigger(zocalo_environment)
-        self._reset_state()
+        self._info_generator = self._info_generator_factory()
+        # Prime the generator
+        next(self._info_generator)
 
     def start(self, doc: RunStart):
         ISPYB_ZOCALO_CALLBACK_LOGGER.info("Zocalo handler received start document.")
         if self.triggering_plan and doc.get("subplan_name") == self.triggering_plan:
             self.run_uid = doc.get("uid")
         if self.run_uid:
-            if (
-                isinstance(scan_points := doc.get("scan_points"), list)
-                and isinstance(ispyb_ids := doc.get("ispyb_dcids"), tuple)
-                and len(ispyb_ids) > 0
-            ):
-                ISPYB_ZOCALO_CALLBACK_LOGGER.info(f"Zocalo triggering for {ispyb_ids}")
-                ids_and_shape = list(zip(ispyb_ids, scan_points, strict=False))
-                for idx, id_and_shape in enumerate(ids_and_shape):
-                    id, shape = id_and_shape
-                    num_frames = number_of_frames_from_scan_spec(shape)
-                    self.zocalo_info.append(
-                        ZocaloStartInfo(id, None, self.start_frame, num_frames, idx)
-                    )
-                    self.start_frame += num_frames
+            zocalo_infos = self._info_generator.send(doc)  # type: ignore
+            self.zocalo_info.extend(zocalo_infos)
 
     def descriptor(self, doc: EventDescriptor):
         self.descriptors[doc["uid"]] = doc

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -192,7 +192,6 @@ class GridscanISPyBCallback(BaseISPyBCallback):
         assert self.params, "ISPyB handler didn't receive parameters!"
         assert self.data_collection_group_info, "No data collection group"
         data = doc["data"]
-        data_collection_id = None
         data_collection_info = DataCollectionInfo(
             xtal_snapshot1=data.get("oav-grid_snapshot-last_path_full_overlay"),
             xtal_snapshot2=data.get("oav-grid_snapshot-last_path_outer"),
@@ -245,6 +244,8 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             "Updating ispyb data collection after oav snapshot."
         )
         grid_plane = _smargon_omega_to_xyxz_plane(doc["data"]["smargon-omega"])
+        # Snapshots may be triggered in a different order to gridscans, so save
+        # the mapping to the data collection id in order to trigger Zocalo correctly.
         self._grid_plane_to_id_map[grid_plane] = data_collection_id
 
         self._oav_snapshot_event_idx += 1

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -1,23 +1,28 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from enum import StrEnum
+from math import isclose
 from time import time
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from bluesky import preprocessors as bpp
 from bluesky.utils import MsgGenerator, make_decorator
+from dodal.devices.zocalo import ZocaloStartInfo
 
 from mx_bluesky.common.external_interaction.callbacks.common.ispyb_callback_base import (
     BaseISPyBCallback,
+    D,
 )
 from mx_bluesky.common.external_interaction.callbacks.common.ispyb_mapping import (
     populate_data_collection_group,
     populate_remaining_data_collection_info,
 )
+from mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback import (
+    ZocaloInfoGenerator,
+)
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_mapping import (
     construct_comment_for_gridscan,
-    populate_xy_data_collection_info,
-    populate_xz_data_collection_info,
 )
 from mx_bluesky.common.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
@@ -33,14 +38,21 @@ from mx_bluesky.common.external_interaction.ispyb.ispyb_store import (
 )
 from mx_bluesky.common.parameters.components import DiffractionExperimentWithSample
 from mx_bluesky.common.parameters.constants import DocDescriptorNames, PlanNameConstants
-from mx_bluesky.common.parameters.gridscan import (
-    GridCommon,
-)
+from mx_bluesky.common.parameters.gridscan import GridCommon
 from mx_bluesky.common.utils.exceptions import (
     ISPyBDepositionNotMade,
     SampleException,
 )
 from mx_bluesky.common.utils.log import ISPYB_ZOCALO_CALLBACK_LOGGER, set_dcgid_tag
+from mx_bluesky.common.utils.utils import number_of_frames_from_scan_spec
+
+OMEGA_TOLERANCE = 1
+
+
+class GridscanPlane(StrEnum):
+    OMEGA_XY = "0"
+    OMEGA_XZ = "90"
+
 
 if TYPE_CHECKING:
     from event_model import Event, RunStart, RunStop
@@ -89,10 +101,10 @@ class GridscanISPyBCallback(BaseISPyBCallback):
     ) -> None:
         super().__init__(emit=emit)
         self.ispyb: StoreInIspyb
-        self.ispyb_ids: IspybIds = IspybIds()
         self.param_type = param_type
         self._start_of_fgs_uid: str | None = None
         self._processing_start_time: float | None = None
+        self._omega_to_id_map: dict[GridscanPlane, int] = {}
         self.data_collection_group_info: DataCollectionGroupInfo | None
 
     def activity_gated_start(self, doc: RunStart):
@@ -108,6 +120,7 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             mx_bluesky_parameters = doc.get("mx_bluesky_parameters")
             assert isinstance(mx_bluesky_parameters, str)
             self.params = self.param_type.model_validate_json(mx_bluesky_parameters)
+            assert isinstance(self.params, DiffractionExperimentWithSample)
             self.ispyb = StoreInIspyb(self.ispyb_config)
             self.data_collection_group_info = populate_data_collection_group(
                 self.params
@@ -118,8 +131,8 @@ class GridscanISPyBCallback(BaseISPyBCallback):
                     data_collection_info=populate_remaining_data_collection_info(
                         "MX-Bluesky: Xray centring 1 -",
                         None,
-                        populate_xy_data_collection_info(
-                            self.params.detector_params,
+                        DataCollectionInfo(
+                            data_collection_number=self.params.detector_params.run_number,
                         ),
                         self.params,
                     ),
@@ -128,7 +141,11 @@ class GridscanISPyBCallback(BaseISPyBCallback):
                     data_collection_info=populate_remaining_data_collection_info(
                         "MX-Bluesky: Xray centring 2 -",
                         None,
-                        populate_xz_data_collection_info(self.params.detector_params),
+                        DataCollectionInfo(
+                            data_collection_number=(
+                                self.params.detector_params.run_number + 1
+                            ),
+                        ),
                         self.params,
                     )
                 ),
@@ -214,10 +231,9 @@ class GridscanISPyBCallback(BaseISPyBCallback):
                 f"by {data_collection_grid_info.steps_y} "
             )
 
-        if len(self.ispyb_ids.data_collection_ids) > self._oav_snapshot_event_idx:
-            data_collection_id = self.ispyb_ids.data_collection_ids[
-                self._oav_snapshot_event_idx
-            ]
+        data_collection_id = self.ispyb_ids.data_collection_ids[
+            self._oav_snapshot_event_idx
+        ]
         self._populate_axis_info(data_collection_info, doc["data"]["smargon-omega"])
 
         scan_data_info = ScanDataInfo(
@@ -228,6 +244,9 @@ class GridscanISPyBCallback(BaseISPyBCallback):
         ISPYB_ZOCALO_CALLBACK_LOGGER.info(
             "Updating ispyb data collection after oav snapshot."
         )
+        grid_plane = _smargon_omega_to_xyxz_plane(doc["data"]["smargon-omega"])
+        self._omega_to_id_map[grid_plane] = data_collection_id
+
         self._oav_snapshot_event_idx += 1
         return [scan_data_info]
 
@@ -295,4 +314,39 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             )
             self.data_collection_group_info = None
             return super().activity_gated_stop(doc)
-        return self._tag_doc(doc)
+        return self.tag_doc(doc)
+
+    def tag_doc(self, doc: D) -> D:
+        doc = super().tag_doc(doc)
+        assert isinstance(doc, dict)
+        if self._omega_to_id_map:
+            doc["omega_to_id_map"] = self._omega_to_id_map
+        return doc  # type: ignore
+
+
+def generate_start_info_from_omega_map() -> ZocaloInfoGenerator:
+    """
+    Generate the zocalo trigger info from bluesky runs where the frame number is
+    computed using metadata added to the document by the ISPyB callback and the
+    run start which together can be used to determine the correct frame numbering.
+    """
+    doc = yield []
+    omega_to_scan_spec = doc["omega_to_scan_spec"]
+    start_frame = 0
+    infos = []
+    for i, omega in enumerate([GridscanPlane.OMEGA_XY, GridscanPlane.OMEGA_XZ]):
+        frames = number_of_frames_from_scan_spec(omega_to_scan_spec[omega])
+        infos.append(
+            ZocaloStartInfo(doc["omega_to_id_map"][omega], None, start_frame, frames, i)
+        )
+        start_frame += frames
+    yield infos
+
+
+def _smargon_omega_to_xyxz_plane(smargon_omega: float) -> GridscanPlane:
+    modulo_180 = abs(smargon_omega) % 180
+    is_xy = isclose(modulo_180, 0, abs_tol=OMEGA_TOLERANCE)
+    assert is_xy or isclose(modulo_180, 90, abs_tol=OMEGA_TOLERANCE), (
+        f"Smargon snapshot omega not in tolerance of compass point {smargon_omega}"
+    )
+    return GridscanPlane.OMEGA_XY if is_xy else GridscanPlane.OMEGA_XZ

--- a/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_mapping.py
+++ b/src/mx_bluesky/common/external_interaction/callbacks/xray_centre/ispyb_mapping.py
@@ -1,31 +1,11 @@
 from __future__ import annotations
 
 import numpy
-from dodal.devices.detector import DetectorParams
 from dodal.devices.oav import utils as oav_utils
 
 from mx_bluesky.common.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
-    DataCollectionInfo,
 )
-
-
-def populate_xz_data_collection_info(detector_params: DetectorParams):
-    assert (
-        detector_params.omega_start is not None
-        and detector_params.run_number is not None
-    ), "StoreGridscanInIspyb failed to get parameters"
-    run_number = detector_params.run_number + 1
-    info = DataCollectionInfo(
-        data_collection_number=run_number,
-    )
-    return info
-
-
-def populate_xy_data_collection_info(detector_params: DetectorParams):
-    return DataCollectionInfo(
-        data_collection_number=detector_params.run_number,
-    )
 
 
 def construct_comment_for_gridscan(grid_info: DataCollectionGridInfo) -> str:

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -23,6 +23,7 @@ from mx_bluesky.common.external_interaction.callbacks.sample_handling.sample_han
 )
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
+    generate_start_info_from_omega_map,
 )
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.nexus_callback import (
     GridscanNexusFileCallback,
@@ -41,6 +42,7 @@ from mx_bluesky.hyperion.external_interaction.callbacks.robot_actions.ispyb_call
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback import (
     RotationISPyBCallback,
+    generate_start_info_from_ordered_runs,
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
@@ -66,7 +68,9 @@ def create_gridscan_callbacks() -> tuple[
         GridscanNexusFileCallback(param_type=HyperionSpecifiedThreeDGridScan),
         GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams,
-            emit=ZocaloCallback(CONST.PLAN.DO_FGS, CONST.ZOCALO_ENV),
+            emit=ZocaloCallback(
+                CONST.PLAN.DO_FGS, CONST.ZOCALO_ENV, generate_start_info_from_omega_map
+            ),
         ),
     )
 
@@ -77,7 +81,11 @@ def create_rotation_callbacks() -> tuple[
     return (
         RotationNexusFileCallback(),
         RotationISPyBCallback(
-            emit=ZocaloCallback(CONST.PLAN.ROTATION_MULTI, CONST.ZOCALO_ENV)
+            emit=ZocaloCallback(
+                CONST.PLAN.ROTATION_MULTI,
+                CONST.ZOCALO_ENV,
+                generate_start_info_from_ordered_runs,
+            )
         ),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1341,27 +1341,20 @@ def TestEventData(tmp_path):
     return _TestEventData(tmp_path)
 
 
+_UID_GRIDSCAN_OUTER = "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3"
+_UID_GRID_DETECT_AND_DO_GRIDSCAN = "41b82023-c271-449d-9543-260da8d85641"
+_UID_ROTATION_MAIN = "2093c941-ded1-42c4-ab74-ea99980fbbfd"
+_UID_DO_FGS = "636490db-83da-462c-a537-70e6fe416843"
+
+
 class _TestEventData(OavGridSnapshotTestEvents):
     def __init__(self, tmp_path):
         self._tmp_path = tmp_path
 
     @property
-    def test_start_document(self) -> RunStart:
+    def test_grid_detect_and_gridscan_start_document(self) -> RunStart:
         return {  # type: ignore
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-            "time": 1666604299.6149616,
-            "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
-            "scan_id": 1,
-            "plan_type": "generator",
-            "plan_name": PlanNameConstants.GRIDSCAN_OUTER,
-            "subplan_name": PlanNameConstants.GRIDSCAN_OUTER,
-            "mx_bluesky_parameters": _dummy_params(self._tmp_path).model_dump_json(),
-        }
-
-    @property
-    def test_gridscan3d_start_document(self) -> RunStart:
-        return {  # type: ignore
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "uid": _UID_GRID_DETECT_AND_DO_GRIDSCAN,
             "time": 1666604299.6149616,
             "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
             "scan_id": 1,
@@ -1372,9 +1365,11 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_gridscan3d_stop_document_with_crystal_exception(self) -> RunStop:
+    def test_grid_detect_and_gridscan_stop_document_with_crystal_exception(
+        self,
+    ) -> RunStop:
         return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "run_start": _UID_GRID_DETECT_AND_DO_GRIDSCAN,
             "time": 1666604299.6149616,
             "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
             "exit_status": "fail",
@@ -1382,22 +1377,9 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_gridscan2d_start_document(self):
-        return {
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-            "time": 1666604299.6149616,
-            "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
-            "scan_id": 1,
-            "plan_type": "generator",
-            "plan_name": "test",
-            "subplan_name": PlanNameConstants.GRID_DETECT_AND_DO_GRIDSCAN,
-            "mx_bluesky_parameters": _dummy_params_2d(self._tmp_path).model_dump_json(),
-        }
-
-    @property
     def test_rotation_start_main_document(self):
         return {
-            "uid": "2093c941-ded1-42c4-ab74-ea99980fbbfd",
+            "uid": _UID_ROTATION_MAIN,
             "subplan_name": PlanNameConstants.ROTATION_MAIN,
             "zocalo_environment": EnvironmentConstants.ZOCALO_ENV,
         }
@@ -1405,7 +1387,7 @@ class _TestEventData(OavGridSnapshotTestEvents):
     @property
     def test_gridscan_outer_start_document(self):
         return {
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "uid": _UID_GRIDSCAN_OUTER,
             "time": 1666604299.6149616,
             "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
             "scan_id": 1,
@@ -1442,7 +1424,7 @@ class _TestEventData(OavGridSnapshotTestEvents):
     @property
     def test_rotation_stop_main_document(self) -> RunStop:
         return {
-            "run_start": "2093c941-ded1-42c4-ab74-ea99980fbbfd",
+            "run_start": _UID_ROTATION_MAIN,
             "time": 1666604300.0310638,
             "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
             "exit_status": "success",
@@ -1451,22 +1433,10 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_run_gridscan_start_document(self) -> RunStart:
-        return {  # type: ignore
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-            "time": 1666604299.6149616,
-            "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
-            "scan_id": 1,
-            "plan_type": "generator",
-            "plan_name": PlanNameConstants.GRIDSCAN_AND_MOVE,
-            "subplan_name": PlanNameConstants.GRIDSCAN_MAIN,
-        }
-
-    @property
     def test_do_fgs_start_document(self) -> RunStart:
         specs = create_dummy_scan_spec()
         return {  # type: ignore
-            "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "uid": _UID_DO_FGS,
             "time": 1666604299.6149616,
             "versions": {"ophyd": "1.6.4.post76+g0895f9f", "bluesky": "1.8.3"},
             "scan_id": 1,
@@ -1483,7 +1453,6 @@ class _TestEventData(OavGridSnapshotTestEvents):
     def test_descriptor_document_oav_rotation_snapshot(self) -> EventDescriptor:
         return {
             "uid": "c7d698ce-6d49-4c56-967e-7d081f964573",
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
             "name": DocDescriptorNames.OAV_ROTATION_SNAPSHOT_TRIGGERED,
         }  # type: ignore
 
@@ -1491,7 +1460,6 @@ class _TestEventData(OavGridSnapshotTestEvents):
     def test_descriptor_document_pre_data_collection(self) -> EventDescriptor:
         return {
             "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
             "name": DocDescriptorNames.HARDWARE_READ_PRE,
         }  # type: ignore
 
@@ -1499,7 +1467,6 @@ class _TestEventData(OavGridSnapshotTestEvents):
     def test_descriptor_document_during_data_collection(self) -> EventDescriptor:
         return {
             "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
             "name": DocDescriptorNames.HARDWARE_READ_DURING,
         }  # type: ignore
 
@@ -1507,7 +1474,6 @@ class _TestEventData(OavGridSnapshotTestEvents):
     def test_descriptor_document_zocalo_hardware(self) -> EventDescriptor:
         return {
             "uid": "f082901b-7453-4150-8ae5-c5f98bb34406",
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
             "name": DocDescriptorNames.ZOCALO_HW_READ,
         }  # type: ignore
 
@@ -1584,9 +1550,9 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_stop_document(self) -> RunStop:
+    def test_gridscan_outer_stop_document(self) -> RunStop:
         return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "run_start": _UID_GRIDSCAN_OUTER,
             "time": 1666604300.0310638,
             "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
             "exit_status": "success",
@@ -1595,9 +1561,19 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_run_gridscan_stop_document(self) -> RunStop:
+    def test_grid_detect_and_gridscan_stop_document(self) -> RunStop:
         return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "run_start": _UID_GRID_DETECT_AND_DO_GRIDSCAN,
+            "time": 1666604300.0310638,
+            "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
+            "exit_status": "success",
+            "reason": "",
+        }
+
+    @property
+    def test_do_fgs_stop_document(self) -> RunStop:
+        return {
+            "run_start": _UID_DO_FGS,
             "time": 1666604300.0310638,
             "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
             "exit_status": "success",
@@ -1606,31 +1582,9 @@ class _TestEventData(OavGridSnapshotTestEvents):
         }
 
     @property
-    def test_do_fgs_gridscan_stop_document(self) -> RunStop:
+    def test_grid_detect_and_gridscan_failed_stop_document(self) -> RunStop:
         return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-            "time": 1666604300.0310638,
-            "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
-            "exit_status": "success",
-            "reason": "",
-            "num_events": {"fake_ispyb_params": 1, "primary": 1},
-        }
-
-    @property
-    def test_failed_stop_document(self) -> RunStop:
-        return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-            "time": 1666604300.0310638,
-            "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
-            "exit_status": "fail",
-            "reason": "could not connect to devices",
-            "num_events": {"fake_ispyb_params": 1, "primary": 1},
-        }
-
-    @property
-    def test_run_gridscan_failed_stop_document(self) -> RunStop:
-        return {
-            "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+            "run_start": _UID_GRID_DETECT_AND_DO_GRIDSCAN,
             "time": 1666604300.0310638,
             "uid": "65b2bde5-5740-42d7-9047-e860e06fbe15",
             "exit_status": "fail",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,9 @@ from scanspec.specs import Line
 from mx_bluesky.common.external_interaction.callbacks.common.logging_callback import (
     VerbosePlanExecutionLoggingCallback,
 )
+from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
+    GridscanPlane,
+)
 from mx_bluesky.common.parameters.constants import (
     DocDescriptorNames,
     EnvironmentConstants,
@@ -279,7 +282,7 @@ def raw_params_from_file(filename, tmp_path):
         return loads
 
 
-def create_dummy_scan_spec(x_steps, y_steps, z_steps):
+def create_dummy_scan_spec():
     x_line = Line("sam_x", 0, 10, 10)
     y_line = Line("sam_y", 10, 20, 20)
     z_line = Line("sam_z", 30, 50, 30)
@@ -1161,6 +1164,16 @@ def pin_tip_edge_data():
     return tip_x_px, tip_y_px, top_edge_array, bottom_edge_array
 
 
+def thin_pin_edges():
+    return pin_tip_edge_data()
+
+
+def fat_pin_edges():
+    tip_x_px, tip_y_px, top_edge_array, bottom_edge_array = pin_tip_edge_data()
+    bottom_edge_array += 60
+    return tip_x_px, tip_y_px, top_edge_array, bottom_edge_array
+
+
 def find_a_pin(pin_tip_detection):
     def set_good_position():
         x, y, top_edge_array, bottom_edge_array = pin_tip_edge_data()
@@ -1451,6 +1464,7 @@ class _TestEventData(OavGridSnapshotTestEvents):
 
     @property
     def test_do_fgs_start_document(self) -> RunStart:
+        specs = create_dummy_scan_spec()
         return {  # type: ignore
             "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
             "time": 1666604299.6149616,
@@ -1459,7 +1473,10 @@ class _TestEventData(OavGridSnapshotTestEvents):
             "plan_type": "generator",
             "plan_name": PlanNameConstants.GRIDSCAN_AND_MOVE,
             "subplan_name": PlanNameConstants.DO_FGS,
-            "scan_points": create_dummy_scan_spec(10, 20, 30),
+            "omega_to_scan_spec": {
+                GridscanPlane.OMEGA_XY: specs[0],
+                GridscanPlane.OMEGA_XZ: specs[1],
+            },
         }
 
     @property

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientResponse
+from bluesky import RunEngine
 from dodal.beamlines import i03
 from dodal.devices.oav.oav_parameters import OAVConfigBeamCentre
 from ophyd_async.core import AsyncStatus
@@ -148,7 +149,7 @@ def next_oav_system_test_image():
 
 
 @pytest.fixture
-def oav_for_system_test(test_config_files, next_oav_system_test_image):
+def oav_for_system_test(RE: RunEngine, test_config_files, next_oav_system_test_image):
     parameters = OAVConfigBeamCentre(
         test_config_files["zoom_params_file"], test_config_files["display_config"]
     )

--- a/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/hyperion/external_interaction/test_ispyb_dev_connection.py
@@ -22,11 +22,10 @@ from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback
 )
 from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_mapping import (
     construct_comment_for_gridscan,
-    populate_xy_data_collection_info,
-    populate_xz_data_collection_info,
 )
 from mx_bluesky.common.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
+    DataCollectionInfo,
     Orientation,
     ScanDataInfo,
 )
@@ -115,8 +114,8 @@ def dummy_data_collection_group_info(dummy_params):
 
 @pytest.fixture
 def dummy_scan_data_info_for_begin_xy(dummy_params):
-    info = populate_xy_data_collection_info(
-        dummy_params.detector_params,
+    info = DataCollectionInfo(
+        data_collection_number=dummy_params.detector_params.run_number,
     )
     info = populate_remaining_data_collection_info(
         "MX-Bluesky: Xray centring 1 -", None, info, dummy_params
@@ -128,9 +127,11 @@ def dummy_scan_data_info_for_begin_xy(dummy_params):
 
 @pytest.fixture
 def dummy_scan_data_info_for_begin_xz(dummy_params):
-    info = populate_xz_data_collection_info(
-        dummy_params.detector_params,
+    run_number = dummy_params.detector_params.run_number + 1
+    info1 = DataCollectionInfo(
+        data_collection_number=run_number,
     )
+    info = info1
     info = populate_remaining_data_collection_info(
         "MX-Bluesky: Xray centring 2 -", None, info, dummy_params
     )
@@ -189,9 +190,11 @@ def scan_data_infos_for_update_3d(
     scan_xy_data_info_for_update,
     dummy_params: HyperionSpecifiedThreeDGridScan,
 ):
-    xz_data_collection_info = populate_xz_data_collection_info(
-        dummy_params.detector_params
+    run_number = dummy_params.detector_params.run_number + 1
+    info = DataCollectionInfo(
+        data_collection_number=run_number,
     )
+    xz_data_collection_info = info
 
     assert dummy_params is not None
     data_collection_grid_info = DataCollectionGridInfo(

--- a/tests/unit_tests/common/experiment_plans/inner_plans/test_do_fgs.py
+++ b/tests/unit_tests/common/experiment_plans/inner_plans/test_do_fgs.py
@@ -13,15 +13,21 @@ from dodal.devices.zocalo.zocalo_results import (
     ZOCALO_STAGE_GROUP,
 )
 from event_model.documents import Event, RunStart
+from numpy.testing import assert_equal
 from ophyd_async.core import init_devices
 from ophyd_async.testing import set_mock_value
 
 from mx_bluesky.common.experiment_plans.inner_plans.do_fgs import (
     kickoff_and_complete_gridscan,
 )
+from mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback import (
+    GridscanPlane,
+)
 from mx_bluesky.common.parameters.constants import (
     PlanNameConstants,
 )
+
+from .....conftest import create_dummy_scan_spec
 
 
 @pytest.fixture
@@ -62,8 +68,7 @@ def test_kickoff_and_complete_gridscan_correct_messages(
             fgs_device,
             detector,
             synchrotron,
-            scan_points=[],
-            scan_start_indices=[],
+            scan_points=create_dummy_scan_spec(),
             plan_during_collection=null_plan,
         )
     )
@@ -112,8 +117,7 @@ def test_kickoff_and_complete_gridscan_with_run_engine_correct_documents(
     class TestCallback(CallbackBase):
         def start(self, doc: RunStart):
             self.subplan_name = doc.get("subplan_name")
-            self.scan_points = doc.get("scan_points")
-            self.scan_start_indices = doc.get("scan_start_indices")
+            self.omega_to_scan_spec = doc.get("omega_to_scan_spec")
 
         def event(self, doc: Event):
             self.event_data = list(doc.get("data").keys())
@@ -131,40 +135,26 @@ def test_kickoff_and_complete_gridscan_with_run_engine_correct_documents(
 
     set_mock_value(fgs_device.status, 1)
 
+    expected_scan_points = create_dummy_scan_spec()
     with patch("mx_bluesky.common.experiment_plans.inner_plans.do_fgs.bps.complete"):
         RE(
             kickoff_and_complete_gridscan(
                 fgs_device,
                 detector,
                 synchrotron,
-                scan_points=[],
-                scan_start_indices=[],
+                scan_points=expected_scan_points,
             )
         )
 
     assert test_callback.subplan_name == PlanNameConstants.DO_FGS
-    assert test_callback.scan_points == []
-    assert test_callback.scan_start_indices == []
+    assert test_callback.omega_to_scan_spec
+    assert_equal(
+        test_callback.omega_to_scan_spec[GridscanPlane.OMEGA_XY],
+        expected_scan_points[0],
+    )
+    assert_equal(
+        test_callback.omega_to_scan_spec[GridscanPlane.OMEGA_XZ],
+        expected_scan_points[1],
+    )
     assert len(test_callback.event_data) == 1
     assert test_callback.event_data[0] == "eiger_odin_file_writer_id"
-
-
-@patch(
-    "mx_bluesky.common.experiment_plans.inner_plans.do_fgs.check_topup_and_wait_if_necessary"
-)
-def test_error_if_kickoff_and_complete_gridscan_parameters_wrong_lengths(
-    mock_check_topup, sim_run_engine: RunEngineSimulator, fgs_devices
-):
-    synchrotron = fgs_devices["synchrotron"]
-    detector = fgs_devices["detector"]
-    fgs_device = fgs_devices["grid_scan_device"]
-    with pytest.raises(AssertionError):
-        sim_run_engine.simulate_plan(
-            kickoff_and_complete_gridscan(
-                fgs_device,
-                detector,
-                synchrotron,
-                scan_points=[],
-                scan_start_indices=[0],
-            )
-        )

--- a/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
@@ -87,7 +87,9 @@ def RE_with_subs_snapshots_already_taken(RE_with_subs, TestEventData):
         sub for sub in subscriptions if isinstance(sub, GridscanISPyBCallback)
     ][0]
     ispyb_gridscan_callback.active = True
-    ispyb_gridscan_callback.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+    ispyb_gridscan_callback.start(
+        TestEventData.test_grid_detect_and_gridscan_start_document
+    )  # type: ignore
     ispyb_gridscan_callback.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
     ispyb_gridscan_callback.descriptor(
         TestEventData.test_descriptor_document_oav_snapshot

--- a/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
@@ -64,7 +64,6 @@ from tests.unit_tests.hyperion.experiment_plans.conftest import mock_zocalo_trig
 
 from ....conftest import TestData
 from ...conftest import (
-    create_gridscan_callbacks,
     modified_store_grid_scan_mock,
     run_generic_ispyb_handler_setup,
 )
@@ -79,6 +78,23 @@ class CompleteException(Exception):
 
 def mock_plan():
     yield from bps.null()
+
+
+@pytest.fixture
+def RE_with_subs_snapshots_already_taken(RE_with_subs, TestEventData):
+    RE, subscriptions = RE_with_subs
+    ispyb_gridscan_callback = [
+        sub for sub in subscriptions if isinstance(sub, GridscanISPyBCallback)
+    ][0]
+    ispyb_gridscan_callback.active = True
+    ispyb_gridscan_callback.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+    ispyb_gridscan_callback.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
+    ispyb_gridscan_callback.descriptor(
+        TestEventData.test_descriptor_document_oav_snapshot
+    )
+    ispyb_gridscan_callback.event(TestEventData.test_event_document_oav_snapshot_xy)
+    ispyb_gridscan_callback.event(TestEventData.test_event_document_oav_snapshot_xz)
+    return RE, subscriptions
 
 
 @patch(
@@ -209,7 +225,6 @@ class TestFlyscanXrayCentrePlan:
                     test_fgs_params.scan_points_first_grid,
                     test_fgs_params.scan_points_second_grid,
                 ],
-                test_fgs_params.scan_indices,
             )
 
         with pytest.raises(FailedStatus):
@@ -299,13 +314,13 @@ class TestFlyscanXrayCentrePlan:
         mock_abs_set,
         fake_fgs_composite: FlyScanEssentialDevices,
         test_fgs_params: SpecifiedThreeDGridScan,
-        RE_with_subs: ReWithSubs,
+        RE_with_subs_snapshots_already_taken: ReWithSubs,
         beamline_specific: BeamlineSpecificFGSFeatures,
     ):
         test_fgs_params.x_steps = 9
         test_fgs_params.y_steps = 10
         test_fgs_params.z_steps = 12
-        RE, (nexus_cb, ispyb_cb) = RE_with_subs
+        RE, (nexus_cb, ispyb_cb) = RE_with_subs_snapshots_already_taken
         # Put both mocks in a parent to easily capture order
         mock_parent = MagicMock()
         fake_fgs_composite.eiger.disarm_detector = mock_parent.disarm
@@ -335,7 +350,9 @@ class TestFlyscanXrayCentrePlan:
                 )
             )
 
-        mock_parent.assert_has_calls([call.disarm(), call.run_end(0), call.run_end(0)])
+        mock_parent.assert_has_calls(
+            [call.disarm(), call.run_end(100), call.run_end(200)]
+        )
 
     @patch(
         "mx_bluesky.common.experiment_plans.common_flyscan_xray_centre_plan.bps.wait",
@@ -431,27 +448,23 @@ class TestFlyscanXrayCentrePlan:
         autospec=True,
     )
     @patch(
-        "mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback.ZocaloTrigger",
-        autospec=True,
-    )
-    @patch(
         "mx_bluesky.common.experiment_plans.inner_plans.do_fgs.check_topup_and_wait_if_necessary",
         autospec=True,
     )
     def test_kickoff_and_complete_gridscan_triggers_zocalo(
         self,
         mock_topup,
-        mock_zocalo_trigger_class: MagicMock,
         mock_complete: MagicMock,
         mock_kickoff: MagicMock,
-        RE: RunEngine,
+        RE_with_subs_snapshots_already_taken,
         fake_fgs_composite: FlyScanEssentialDevices,
         dummy_rotation_data_collection_group_info,
         zebra_fast_grid_scan: ZebraFastGridScanThreeD,
     ):
         id_1, id_2 = 100, 200
 
-        _, ispyb_cb = create_gridscan_callbacks()
+        RE, subs = RE_with_subs_snapshots_already_taken
+        _, ispyb_cb = subs
         ispyb_cb.active = True
         ispyb_cb.ispyb = MagicMock()
         ispyb_cb.params = MagicMock()
@@ -473,8 +486,7 @@ class TestFlyscanXrayCentrePlan:
                 zebra_fast_grid_scan,
                 fake_fgs_composite.eiger,
                 fake_fgs_composite.synchrotron,
-                scan_points=create_dummy_scan_spec(x_steps, y_steps, z_steps),
-                scan_start_indices=[0, x_steps * y_steps],
+                scan_points=create_dummy_scan_spec(),
             )
         )
 

--- a/tests/unit_tests/common/external_interaction/callbacks/test_zocalo_handler.py
+++ b/tests/unit_tests/common/external_interaction/callbacks/test_zocalo_handler.py
@@ -15,6 +15,9 @@ from mx_bluesky.common.utils.exceptions import ISPyBDepositionNotMade
 from mx_bluesky.hyperion.external_interaction.callbacks.__main__ import (
     create_gridscan_callbacks,
 )
+from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback import (
+    generate_start_info_from_ordered_runs,
+)
 
 EXPECTED_RUN_START_MESSAGE = {"subplan_name": "test_plan_name", "uid": "my_uuid"}
 EXPECTED_RUN_END_MESSAGE = {"event": "end", "run_start": "my_uuid"}
@@ -22,7 +25,9 @@ EXPECTED_RUN_END_MESSAGE = {"event": "end", "run_start": "my_uuid"}
 
 class TestZocaloHandler:
     def _setup_handler(self):
-        zocalo_handler = ZocaloCallback("test_plan_name", "test_env")
+        zocalo_handler = ZocaloCallback(
+            "test_plan_name", "test_env", generate_start_info_from_ordered_runs
+        )
         return zocalo_handler
 
     def test_handler_doesnt_trigger_on_wrong_plan(self):
@@ -109,6 +114,9 @@ class TestZocaloHandler:
         ispyb_store.return_value.update_deposition.return_value = mock_ids
 
         ispyb_cb.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+        ispyb_cb.descriptor(TestEventData.test_descriptor_document_oav_snapshot)
+        ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xy)
+        ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xz)
         ispyb_cb.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
         ispyb_cb.start(TestEventData.test_do_fgs_start_document)  # type: ignore
         ispyb_cb.descriptor(TestEventData.test_descriptor_document_pre_data_collection)  # type: ignore
@@ -139,6 +147,71 @@ class TestZocaloHandler:
         assert zocalo_handler.zocalo_interactor.run_end.call_count == len(dc_ids)  # type: ignore
 
         zocalo_handler._reset_state.assert_called()
+
+    @patch(
+        "mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback.ZocaloTrigger",
+        autospec=True,
+    )
+    @patch(
+        "mx_bluesky.common.external_interaction.callbacks.xray_centre.nexus_callback.NexusWriter",
+    )
+    @patch(
+        "mx_bluesky.common.external_interaction.callbacks.xray_centre.ispyb_callback.StoreInIspyb",
+    )
+    def test_do_fgs_triggers_zocalo_calls_when_snapshots_in_reverse_order(
+        self,
+        ispyb_store: MagicMock,
+        nexus_writer: MagicMock,
+        zocalo_trigger,
+        TestEventData,
+    ):
+        dc_ids = (1, 2)
+        dcg_id = 4
+
+        mock_ids = IspybIds(data_collection_ids=dc_ids, data_collection_group_id=dcg_id)
+        ispyb_store.return_value.mock_add_spec(StoreInIspyb)
+
+        _, ispyb_cb = create_gridscan_callbacks()
+        ispyb_cb.active = True
+        assert isinstance(zocalo_handler := ispyb_cb.emit_cb, ZocaloCallback)
+        zocalo_handler._reset_state()
+        zocalo_handler._reset_state = MagicMock()
+
+        ispyb_store.return_value.begin_deposition.return_value = mock_ids
+        ispyb_store.return_value.update_deposition.return_value = mock_ids
+
+        ispyb_cb.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+        ispyb_cb.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
+        ispyb_cb.descriptor(TestEventData.test_descriptor_document_oav_snapshot)
+        ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xz)
+        ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xy)
+        ispyb_cb.start(TestEventData.test_do_fgs_start_document)  # type: ignore
+        ispyb_cb.descriptor(TestEventData.test_descriptor_document_pre_data_collection)  # type: ignore
+        ispyb_cb.event(TestEventData.test_event_document_pre_data_collection)
+        ispyb_cb.descriptor(TestEventData.test_descriptor_document_zocalo_hardware)
+        ispyb_cb.event(TestEventData.test_event_document_zocalo_hardware)
+        ispyb_cb.descriptor(
+            TestEventData.test_descriptor_document_during_data_collection  # type: ignore
+        )
+        ispyb_cb.event(TestEventData.test_event_document_during_data_collection)
+        assert zocalo_handler.zocalo_interactor is not None
+
+        expected_start_calls = [
+            call(ZocaloStartInfo(2, "test_path", 0, 200, 0)),
+            call(ZocaloStartInfo(1, "test_path", 200, 300, 1)),
+        ]
+
+        zocalo_handler.zocalo_interactor.run_start.assert_has_calls(  # type: ignore
+            expected_start_calls
+        )
+        assert zocalo_handler.zocalo_interactor.run_start.call_count == len(dc_ids)  # type: ignore
+
+        ispyb_cb.stop(TestEventData.test_stop_document)
+
+        zocalo_handler.zocalo_interactor.run_end.assert_has_calls(  # type: ignore
+            [call(dc_ids[1]), call(dc_ids[0])]
+        )
+        assert zocalo_handler.zocalo_interactor.run_end.call_count == len(dc_ids)  # type: ignore
 
     @patch(
         "mx_bluesky.common.external_interaction.callbacks.common.zocalo_callback.ZocaloTrigger",

--- a/tests/unit_tests/common/external_interaction/callbacks/test_zocalo_handler.py
+++ b/tests/unit_tests/common/external_interaction/callbacks/test_zocalo_handler.py
@@ -113,7 +113,7 @@ class TestZocaloHandler:
         ispyb_store.return_value.begin_deposition.return_value = mock_ids
         ispyb_store.return_value.update_deposition.return_value = mock_ids
 
-        ispyb_cb.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+        ispyb_cb.start(TestEventData.test_grid_detect_and_gridscan_start_document)  # type: ignore
         ispyb_cb.descriptor(TestEventData.test_descriptor_document_oav_snapshot)
         ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xy)
         ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xz)
@@ -139,7 +139,8 @@ class TestZocaloHandler:
         )
         assert zocalo_handler.zocalo_interactor.run_start.call_count == len(dc_ids)  # type: ignore
 
-        ispyb_cb.stop(TestEventData.test_stop_document)
+        ispyb_cb.stop(TestEventData.test_do_fgs_stop_document)
+        ispyb_cb.stop(TestEventData.test_gridscan_outer_stop_document)
 
         zocalo_handler.zocalo_interactor.run_end.assert_has_calls(  # type: ignore
             [call(x) for x in dc_ids]
@@ -180,7 +181,7 @@ class TestZocaloHandler:
         ispyb_store.return_value.begin_deposition.return_value = mock_ids
         ispyb_store.return_value.update_deposition.return_value = mock_ids
 
-        ispyb_cb.start(TestEventData.test_gridscan3d_start_document)  # type: ignore
+        ispyb_cb.start(TestEventData.test_grid_detect_and_gridscan_start_document)  # type: ignore
         ispyb_cb.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
         ispyb_cb.descriptor(TestEventData.test_descriptor_document_oav_snapshot)
         ispyb_cb.event(TestEventData.test_event_document_oav_snapshot_xz)
@@ -205,8 +206,8 @@ class TestZocaloHandler:
             expected_start_calls
         )
         assert zocalo_handler.zocalo_interactor.run_start.call_count == len(dc_ids)  # type: ignore
-
-        ispyb_cb.stop(TestEventData.test_stop_document)
+        ispyb_cb.stop(TestEventData.test_do_fgs_stop_document)
+        ispyb_cb.stop(TestEventData.test_gridscan_outer_stop_document)
 
         zocalo_handler.zocalo_interactor.run_end.assert_has_calls(  # type: ignore
             [call(dc_ids[1]), call(dc_ids[0])]

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_callback.py
@@ -75,7 +75,9 @@ class TestXrayCentreISPyBCallback:
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        callback.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # pyright: ignore
+        callback.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # pyright: ignore
         mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
         assert_upsert_call_with(
             mx_acq.upsert_data_collection_group.mock_calls[0],  # pyright: ignore
@@ -108,10 +110,12 @@ class TestXrayCentreISPyBCallback:
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        callback.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # pyright: ignore
+        callback.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # pyright: ignore
         mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
         callback.activity_gated_stop(
-            TestEventData.test_gridscan3d_stop_document_with_crystal_exception
+            TestEventData.test_grid_detect_and_gridscan_stop_document_with_crystal_exception
         )
         assert mx_acq.update_data_collection_append_comments.call_args_list[0] == (
             (
@@ -129,7 +133,9 @@ class TestXrayCentreISPyBCallback:
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        callback.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # pyright: ignore
+        callback.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # pyright: ignore
         mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
         mx_acq.upsert_data_collection_group.reset_mock()
         mx_acq.upsert_data_collection.reset_mock()
@@ -164,7 +170,9 @@ class TestXrayCentreISPyBCallback:
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        callback.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # pyright: ignore
+        callback.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # pyright: ignore
         mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
         callback.activity_gated_descriptor(
             TestEventData.test_descriptor_document_pre_data_collection
@@ -223,7 +231,9 @@ class TestXrayCentreISPyBCallback:
         callback = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        callback.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # pyright: ignore
+        callback.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # pyright: ignore
         mx_acq = mx_acquisition_from_conn(mock_ispyb_conn)
         mx_acq.upsert_data_collection_group.reset_mock()
         mx_acq.upsert_data_collection.reset_mock()
@@ -386,6 +396,32 @@ class TestXrayCentreISPyBCallback:
             )
 
         assert "No data collection group info" in str(e.value)
+
+    def test_ispyb_callback_clears_state_after_run_stop(
+        self, TestEventData, mock_ispyb_conn
+    ):
+        callback = GridscanISPyBCallback(
+            param_type=GridCommonWithHyperionDetectorParams
+        )
+        callback.active = True
+        callback.start(TestEventData.test_grid_detect_and_gridscan_start_document)  # type: ignore
+        callback.descriptor(TestEventData.test_descriptor_document_oav_snapshot)
+        callback.event(TestEventData.test_event_document_oav_snapshot_xy)
+        callback.event(TestEventData.test_event_document_oav_snapshot_xz)
+        callback.start(TestEventData.test_gridscan_outer_start_document)  # type: ignore
+        callback.start(TestEventData.test_do_fgs_start_document)  # type: ignore
+        callback.descriptor(TestEventData.test_descriptor_document_pre_data_collection)  # type: ignore
+        callback.event(TestEventData.test_event_document_pre_data_collection)
+        callback.descriptor(TestEventData.test_descriptor_document_zocalo_hardware)
+        callback.event(TestEventData.test_event_document_zocalo_hardware)
+        callback.descriptor(
+            TestEventData.test_descriptor_document_during_data_collection  # type: ignore
+        )
+        assert callback._grid_plane_to_id_map
+        callback.stop(TestEventData.test_do_fgs_stop_document)
+        callback.stop(TestEventData.test_gridscan_outer_stop_document)  # type: ignore
+        callback.stop(TestEventData.test_grid_detect_and_gridscan_stop_document)
+        assert not callback._grid_plane_to_id_map
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_handler.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_ispyb_handler.py
@@ -54,7 +54,9 @@ class TestXrayCentreIspybHandler:
         ispyb_handler = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        ispyb_handler.activity_gated_start(TestEventData.test_gridscan3d_start_document)
+        ispyb_handler.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )
         ispyb_handler.activity_gated_descriptor(
             TestEventData.test_descriptor_document_pre_data_collection
         )
@@ -68,7 +70,7 @@ class TestXrayCentreIspybHandler:
             TestEventData.test_event_document_during_data_collection  # pyright: ignore
         )
         ispyb_handler.activity_gated_stop(
-            TestEventData.test_run_gridscan_failed_stop_document
+            TestEventData.test_grid_detect_and_gridscan_failed_stop_document
         )
 
         ispyb_handler.ispyb.end_deposition.assert_called_once_with(  # type: ignore
@@ -87,7 +89,10 @@ class TestXrayCentreIspybHandler:
         ispyb_handler = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        ispyb_handler.activity_gated_start(TestEventData.test_gridscan3d_start_document)
+        ispyb_handler.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )
+        ispyb_handler.activity_gated_start(TestEventData.test_do_fgs_start_document)
         ispyb_handler.activity_gated_descriptor(
             TestEventData.test_descriptor_document_pre_data_collection
         )
@@ -100,10 +105,10 @@ class TestXrayCentreIspybHandler:
         ispyb_handler.activity_gated_event(
             TestEventData.test_event_document_during_data_collection
         )
+        ispyb_handler.activity_gated_stop(TestEventData.test_do_fgs_stop_document)
         ispyb_handler.activity_gated_stop(
-            TestEventData.test_do_fgs_gridscan_stop_document
+            TestEventData.test_grid_detect_and_gridscan_stop_document
         )
-
         ispyb_handler.ispyb.end_deposition.assert_called_once_with(  # type: ignore
             IspybIds(
                 data_collection_group_id=DCG_ID,
@@ -130,7 +135,9 @@ class TestXrayCentreIspybHandler:
         ispyb_handler = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        ispyb_handler.activity_gated_start(TestEventData.test_gridscan3d_start_document)
+        ispyb_handler.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )
         ispyb_handler.activity_gated_descriptor(
             TestEventData.test_descriptor_document_pre_data_collection
         )
@@ -164,7 +171,9 @@ class TestXrayCentreIspybHandler:
         ispyb_handler = GridscanISPyBCallback(
             param_type=GridCommonWithHyperionDetectorParams
         )
-        ispyb_handler.activity_gated_start(TestEventData.test_gridscan3d_start_document)
+        ispyb_handler.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )
         ispyb_handler.activity_gated_descriptor(
             TestEventData.test_descriptor_document_pre_data_collection
         )
@@ -178,7 +187,7 @@ class TestXrayCentreIspybHandler:
             TestEventData.test_event_document_during_data_collection
         )
         ispyb_handler.activity_gated_stop(
-            TestEventData.test_run_gridscan_failed_stop_document
+            TestEventData.test_grid_detect_and_gridscan_failed_stop_document
         )
 
         ISPYB_ZOCALO_CALLBACK_LOGGER.info("test")
@@ -196,11 +205,14 @@ class TestXrayCentreIspybHandler:
             param_type=GridCommonWithHyperionDetectorParams,
         )
 
-        ispyb_handler.activity_gated_start(TestEventData.test_gridscan3d_start_document)  # type:ignore
+        ispyb_handler.activity_gated_start(
+            TestEventData.test_grid_detect_and_gridscan_start_document
+        )  # type:ignore
 
         ispyb_handler.activity_gated_start(TestEventData.test_do_fgs_start_document)  # type:ignore
+        ispyb_handler.activity_gated_stop(TestEventData.test_do_fgs_stop_document)
         ispyb_handler.activity_gated_stop(
-            TestEventData.test_do_fgs_gridscan_stop_document
+            TestEventData.test_grid_detect_and_gridscan_stop_document
         )
 
         ispyb_handler.data_collection_group_info = (

--- a/tests/unit_tests/common/external_interaction/xray_centre/test_nexus_handler.py
+++ b/tests/unit_tests/common/external_interaction/xray_centre/test_nexus_handler.py
@@ -27,7 +27,7 @@ def test_writers_not_sDTypeLikeetup_on_plan_start_doc(
         param_type=HyperionSpecifiedThreeDGridScan
     )
     nexus_writer.assert_not_called()
-    nexus_handler.activity_gated_start(TestEventData.test_start_document)
+    nexus_handler.activity_gated_start(TestEventData.test_gridscan_outer_start_document)
     nexus_writer.assert_not_called()
 
 
@@ -83,7 +83,7 @@ def test_given_different_bit_depths_then_writers_created_wth_correct_VDS_size(
         param_type=HyperionSpecifiedThreeDGridScan
     )
 
-    nexus_handler.activity_gated_start(TestEventData.test_start_document)
+    nexus_handler.activity_gated_start(TestEventData.test_gridscan_outer_start_document)
     nexus_handler.activity_gated_descriptor(
         TestEventData.test_descriptor_document_during_data_collection
     )
@@ -114,7 +114,7 @@ def test_beam_and_attenuator_set_on_ispyb_transmission_event(
         param_type=HyperionSpecifiedThreeDGridScan
     )
 
-    nexus_handler.activity_gated_start(TestEventData.test_start_document)
+    nexus_handler.activity_gated_start(TestEventData.test_gridscan_outer_start_document)
     nexus_handler.activity_gated_descriptor(
         TestEventData.test_descriptor_document_during_data_collection
     )

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -52,6 +52,7 @@ from mx_bluesky.hyperion.external_interaction.callbacks.__main__ import (
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.ispyb_callback import (
     RotationISPyBCallback,
+    generate_start_info_from_ordered_runs,
 )
 from mx_bluesky.hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
@@ -804,7 +805,9 @@ def test_rotation_scan_correctly_triggers_zocalo_callback(
     fake_create_rotation_devices: RotationScanComposite,
     oav_parameters_for_rotation: OAVParameters,
 ):
-    mock_zocalo_callback = ZocaloCallback(CONST.PLAN.ROTATION_MAIN, "env")
+    mock_zocalo_callback = ZocaloCallback(
+        CONST.PLAN.ROTATION_MAIN, "env", generate_start_info_from_ordered_runs
+    )
     mock_ispyb_callback = RotationISPyBCallback(emit=mock_zocalo_callback)
     mock_store_in_ispyb.return_value.update_deposition.return_value = IspybIds(
         data_collection_ids=(0, 1)


### PR DESCRIPTION
Fixes #1290 



Link to dodal PR (if required): 
* DiamondLightSource/dodal#1576
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Gridscans should now work regardless of the order of grid detection / grid snapshot being taken
2. A side effect of this fix is that the ordering of the gridscan data collections will vary in synchweb, sometimes xy will be first, sometimes xz plane will be first
3. In most cases, xz will be first (lowest on screen), the exception that I can think of is if the sample is already loaded but a gridscan is needed again, and the previous rotation left the smargon in a different omega.

* System tests require a rebuild of the zocalo test image due to a bug in fake zocalo which didn't return the DataCollectionGroupId

### Checks for reviewer

- [ ] System tests pass
- [ ] Would the PR title make sense to a user on a set of release notes
