### PR TITLE
Fixup graylog unit test config to avoid timeouts

### DIFF
--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -88,6 +88,12 @@ def test_params(tmp_path):
     )
 
 
+@pytest.fixture(autouse=True)
+def patch_remote_graylog_endpoint():
+    with patch("dodal.log.get_graylog_configuration", return_value=("localhost", 5555)):
+        yield None
+
+
 class MockRunEngine:
     def __init__(self, test_name):
         self.RE_takes_time = True


### PR DESCRIPTION
Patches the graylog config for some tests where `main()` is invoked without the usual dev-mode switch; in these cases the graylog logging config points to the production graylog and on systems where this is not available, this can sometimes cause the tests to time out.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
