### PR TITLE
Fix unit test timeouts in robot load energy change caused by too many waits

### DIFF
--- a/src/mx_bluesky/common/device_setup_plans/robot_load_unload.py
+++ b/src/mx_bluesky/common/device_setup_plans/robot_load_unload.py
@@ -12,6 +12,8 @@ from dodal.plan_stubs.motor_utils import MoveTooLarge, home_and_reset_wrapper
 from mx_bluesky.common.utils.log import LOGGER
 from mx_bluesky.hyperion.parameters.constants import CONST
 
+SLEEP_PER_CHECK = 0.1
+
 
 def wait_for_smargon_not_disabled(smargon: Smargon, timeout=60):
     """Waits for the smargon disabled flag to go low. The robot hardware is responsible
@@ -19,7 +21,6 @@ def wait_for_smargon_not_disabled(smargon: Smargon, timeout=60):
     connection between the robot and the smargon.
     """
     LOGGER.info("Waiting for smargon enabled")
-    SLEEP_PER_CHECK = 0.1
     times_to_check = int(timeout / SLEEP_PER_CHECK)
     for _ in range(times_to_check):
         smargon_disabled = yield from bps.rd(smargon.disabled)

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -90,11 +90,14 @@ def run_simulating_smargon_wait(
         "read", return_not_disabled_after_reads, "smargon-disabled"
     )
 
-    return sim_run_engine.simulate_plan(
-        robot_load_and_change_energy_plan(
-            robot_load_composite, robot_load_then_centre_params
+    with patch(
+        "mx_bluesky.common.device_setup_plans.robot_load_unload.SLEEP_PER_CHECK", 1
+    ):
+        return sim_run_engine.simulate_plan(
+            robot_load_and_change_energy_plan(
+                robot_load_composite, robot_load_then_centre_params
+            )
         )
-    )
 
 
 @pytest.mark.parametrize("total_disabled_reads", [5, 3, 14])
@@ -139,7 +142,7 @@ def test_given_smargon_disabled_for_longer_than_timeout_when_plan_run_then_throw
         run_simulating_smargon_wait(
             robot_load_and_energy_change_params,
             robot_load_and_energy_change_composite,
-            1000,
+            100,
             sim_run_engine,
         )
 


### PR DESCRIPTION
This hopefully fixes test_given_smargon_disabled_for_longer_than_timeout_when_plan_run_then_throws_exception

which failed during CI here:
https://github.com/DiamondLightSource/mx-bluesky/actions/runs/18132480358/job/51602535374?pr=1310

on my machine this normally passes with call duration ~0.31s but this change makes it ~10x faster

### Instructions to reviewer on how to test:

1. Tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
