### PR TITLE
Fix jungfrau spurious test failures

### DIFF
--- a/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_plan_utils.py
+++ b/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_plan_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -44,6 +45,7 @@ async def test_fly_jungfrau(
         assert (yield from bps.rd(jungfrau._writer.file_path)) == f"{tmp_path}/00000"
 
     RE(_open_run_and_fly())
+    await asyncio.sleep(0)
     assert mock_stop.await_count == 2  # once when staging, once after run complete
 
 


### PR DESCRIPTION
This hopefully fixes test failures in `test_fly_jungfrau` as seen here

https://github.com/DiamondLightSource/mx-bluesky/actions/runs/18161240174/job/51693484886?pr=1282

It adds asyncio.sleep(0) to give scheduler time to register second await - I'm not 100% sure why this is necessary but suspect it is connected with the run engine being on a different thread to the main event loop.

### Instructions to reviewer on how to test:

1.Tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
