### PR TITLE
Revert "Make new parameter component for required sample id (#1210)"

### DIFF
--- a/src/mx_bluesky/common/parameters/components.py
+++ b/src/mx_bluesky/common/parameters/components.py
@@ -28,7 +28,6 @@ from mx_bluesky.common.parameters.constants import (
     DetectorParamConstants,
     GridscanParamConstants,
 )
-from mx_bluesky.common.utils.log import LOGGER
 
 PARAMETER_VERSION = Version.parse("5.3.0")
 
@@ -222,20 +221,6 @@ class SplitScan(BaseModel):
 
 
 class WithSample(BaseModel):
-    sample_id: int | None = (
-        None  # Long term, all sample should be in ispyb, see https://github.com/DiamondLightSource/mx-bluesky/issues/1337
-    )
-    sample_puck: int | None = None
-    sample_pin: int | None = None
-
-    @model_validator(mode="after")
-    def _warn_if_no_sample(self):
-        if not self.sample_id:
-            LOGGER.warning("No sample ID was provided")
-        return self
-
-
-class WithRequiredSample(BaseModel):
     sample_id: int
     sample_puck: int | None = None
     sample_pin: int | None = None

--- a/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/load_centre_collect_full_plan.py
@@ -59,6 +59,7 @@ def load_centre_collect_full(
      that satisfies the chosen selection function,
      move to that centre and do a collection with the specified parameters.
     """
+
     get_hyperion_config_client().refresh_cache()
 
     if not oav_params:

--- a/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/robot_load_and_change_energy.py
@@ -159,7 +159,6 @@ def robot_load_and_change_energy_plan(
 ):
     assert params.sample_puck is not None
     assert params.sample_pin is not None
-    assert params.sample_id is not None
 
     sample_location = SampleLocation(params.sample_puck, params.sample_pin)
 

--- a/src/mx_bluesky/hyperion/parameters/load_centre_collect.py
+++ b/src/mx_bluesky/hyperion/parameters/load_centre_collect.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, model_validator
 from mx_bluesky.common.parameters.components import (
     MxBlueskyParameters,
     WithCentreSelection,
-    WithRequiredSample,
+    WithSample,
     WithVisit,
 )
 from mx_bluesky.hyperion.parameters.robot_load import (
@@ -25,7 +25,7 @@ def construct_from_values(parent_context: dict, child_dict: dict, t: type[T]) ->
 class LoadCentreCollect(
     MxBlueskyParameters,
     WithVisit,
-    WithRequiredSample,
+    WithSample,
     WithCentreSelection,
 ):
     """Experiment parameters to perform the combined robot load,
@@ -51,7 +51,7 @@ class LoadCentreCollect(
 
         keys_from_outer_load_centre_collect = (
             MxBlueskyParameters.model_fields.keys()
-            | WithRequiredSample.model_fields.keys()
+            | WithSample.model_fields.keys()
             | WithVisit.model_fields.keys()
         )
         duplicated_robot_load_then_centre_keys = (

--- a/src/mx_bluesky/hyperion/parameters/robot_load.py
+++ b/src/mx_bluesky/hyperion/parameters/robot_load.py
@@ -3,7 +3,7 @@ from pydantic import Field
 from mx_bluesky.common.parameters.components import (
     MxBlueskyParameters,
     WithOptionalEnergyChange,
-    WithRequiredSample,
+    WithSample,
     WithSnapshot,
     WithVisit,
 )
@@ -17,11 +17,7 @@ from mx_bluesky.hyperion.parameters.gridscan import (
 
 
 class RobotLoadAndEnergyChange(
-    MxBlueskyParameters,
-    WithRequiredSample,
-    WithSnapshot,
-    WithOptionalEnergyChange,
-    WithVisit,
+    MxBlueskyParameters, WithSample, WithSnapshot, WithOptionalEnergyChange, WithVisit
 ):
     thawing_time: float = Field(default=HardwareConstants.THAWING_TIME)
 

--- a/tests/unit_tests/common/parameters/test_components.py
+++ b/tests/unit_tests/common/parameters/test_components.py
@@ -1,11 +1,10 @@
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
-from mx_bluesky.common.parameters.components import WithSample, WithSnapshot
+from mx_bluesky.common.parameters.components import WithSnapshot
 
 
 @pytest.mark.parametrize(
@@ -71,10 +70,3 @@ from mx_bluesky.common.parameters.components import WithSample, WithSnapshot
 def test_validate_with_snapshot_omegas_grid_snapshots(model, expectation):
     with expectation:
         WithSnapshot.model_validate(model)
-
-
-@patch("mx_bluesky.common.parameters.components.LOGGER.warning")
-def test_logger_warning_if_no_sample_id_provided(mock_warning: MagicMock):
-    empty_params = {}
-    WithSample(**empty_params)
-    mock_warning.assert_called_once()


### PR DESCRIPTION
This change didn't work: see https://github.com/DiamondLightSource/mx-bluesky/issues/1345#issuecomment-3385198530
