### PR TITLE
Increase detector deadtime when setting up panda

### DIFF
--- a/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/hyperion_flyscan_xray_centre_plan.py
@@ -126,10 +126,9 @@ def _panda_triggering_setup(
         xrc_composite.panda_fast_grid_scan.run_up_distance_mm
     )
 
-    # Set the time between x steps pv
-    DEADTIME_S = 1e-6  # according to https://www.dectris.com/en/detectors/x-ray-detectors/eiger2/eiger2-for-synchrotrons/eiger2-x/
+    DETECTOR_DEADTIME_S = 1e-4  # This value was empirically found to be safer than the documented deadtime in the Eiger manual
 
-    time_between_x_steps_ms = (DEADTIME_S + parameters.exposure_time_s) * 1e3
+    time_between_x_steps_ms = (DETECTOR_DEADTIME_S + parameters.exposure_time_s) * 1e3
 
     smargon_speed_limit_mm_per_s = yield from bps.rd(
         xrc_composite.smargon.x.max_velocity


### PR DESCRIPTION
During PandA testing we found that the deadtime needed to be much higher than what is stated in the Eiger manual. At the old value, we got missing trigger-points on every time

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
