### PR TITLE
Fix to no longer use depreciated pydantic methods

### DIFF
--- a/src/mx_bluesky/hyperion/parameters/rotation.py
+++ b/src/mx_bluesky/hyperion/parameters/rotation.py
@@ -151,7 +151,6 @@ class RotationScan(RotationExperiment, SplitScan):
 
     @model_validator(mode="after")
     def correct_start_vds(self) -> Any:
-        # assert isinstance(values, RotationScan)
         start_img = 0.0
         for scan in self.rotation_scans:
             scan.nexus_vds_start_img = int(start_img)


### PR DESCRIPTION
Fixes #1381

Looking at the history (https://github.com/DiamondLightSource/mx-bluesky/commit/e33d52acfdda8b29d989a1b89966c8ba55b04d5e#diff-fe7590f7efeb046b093e67eb30010e8d448b0e238d9ea5a5e804dcd3996306c0) I don't think there's any strong reason for it being a `classmethod`, it was just how we did the conversion to pydantic 2. Tests all seem to pass so I think just changing to an instance method is fine.

### Instructions to reviewer on how to test:

1. Confirm tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
