### PR TITLE
Use new base dcm devices

### DIFF
--- a/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
+++ b/src/mx_bluesky/beamlines/i04/experiment_plans/i04_grid_detect_then_xray_centre_plan.py
@@ -9,7 +9,7 @@ from dodal.common import inject
 from dodal.devices.aperturescatterguard import ApertureScatterguard, ApertureValue
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.common_dcm import BaseDCM
+from dodal.devices.common_dcm import DoubleCrystalMonochromator
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import (
@@ -97,7 +97,7 @@ def i04_grid_detect_then_xray_centre(
     attenuator: BinaryFilterAttenuator = inject("attenuator"),
     backlight: Backlight = inject("backlight"),
     beamstop: Beamstop = inject("beamstop"),
-    dcm: BaseDCM = inject("dcm"),
+    dcm: DoubleCrystalMonochromator = inject("dcm"),
     zebra_fast_grid_scan: ZebraFastGridScanThreeD = inject("zebra_fast_grid_scan"),
     flux: Flux = inject("flux"),
     oav: OAV = inject("oav"),

--- a/src/mx_bluesky/common/experiment_plans/inner_plans/read_hardware.py
+++ b/src/mx_bluesky/common/experiment_plans/inner_plans/read_hardware.py
@@ -4,7 +4,7 @@ import bluesky.plan_stubs as bps
 from bluesky.protocols import Readable
 from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
-from dodal.devices.common_dcm import BaseDCM
+from dodal.devices.common_dcm import DoubleCrystalMonochromator
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.flux import Flux
 from dodal.devices.s4_slit_gaps import S4SlitGaps
@@ -43,7 +43,7 @@ def standard_read_hardware_pre_collection(
     undulator: Undulator,
     synchrotron: Synchrotron,
     s4_slit_gaps: S4SlitGaps,
-    dcm: BaseDCM,
+    dcm: DoubleCrystalMonochromator,
     smargon: Smargon,
 ):
     LOGGER.info("Reading status of beamline for callbacks, pre collection.")
@@ -63,7 +63,7 @@ def standard_read_hardware_during_collection(
     aperture_scatterguard: ApertureScatterguard,
     attenuator: BinaryFilterAttenuator,
     flux: Flux,
-    dcm: BaseDCM,
+    dcm: DoubleCrystalMonochromator,
     detector: EigerDetector,
 ):
     signals_to_read_during_collection = [

--- a/src/mx_bluesky/common/parameters/device_composites.py
+++ b/src/mx_bluesky/common/parameters/device_composites.py
@@ -4,7 +4,7 @@ from dodal.devices.aperturescatterguard import (
 )
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.common_dcm import BaseDCM
+from dodal.devices.common_dcm import DoubleCrystalMonochromator
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import (
@@ -51,7 +51,7 @@ class GridDetectThenXRayCentreComposite(FlyScanEssentialDevices):
     attenuator: BinaryFilterAttenuator
     backlight: Backlight
     beamstop: Beamstop
-    dcm: BaseDCM
+    dcm: DoubleCrystalMonochromator
     detector_motion: DetectorMotion
     zebra_fast_grid_scan: ZebraFastGridScanThreeD
     flux: Flux

--- a/src/mx_bluesky/hyperion/parameters/device_composites.py
+++ b/src/mx_bluesky/hyperion/parameters/device_composites.py
@@ -6,7 +6,7 @@ from dodal.devices.aperturescatterguard import (
 )
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.common_dcm import BaseDCM
+from dodal.devices.common_dcm import DoubleCrystalMonochromatorWithDSpacing
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import (
     PandAFastGridScan,
@@ -37,7 +37,7 @@ class HyperionFlyScanXRayCentreComposite(FlyScanEssentialDevices):
 
     aperture_scatterguard: ApertureScatterguard
     attenuator: BinaryFilterAttenuator
-    dcm: BaseDCM
+    dcm: DoubleCrystalMonochromatorWithDSpacing
     eiger: EigerDetector
     flux: Flux
     s4_slit_gaps: S4SlitGaps

--- a/tests/unit_tests/beamlines/i04/test_i04_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/beamlines/i04/test_i04_grid_detect_then_xray_centre_plan.py
@@ -9,7 +9,7 @@ from bluesky.utils import MsgGenerator
 from dodal.devices.aperturescatterguard import ApertureScatterguard, ApertureValue
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.common_dcm import BaseDCM
+from dodal.devices.common_dcm import DoubleCrystalMonochromator
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import (
@@ -53,7 +53,7 @@ def i04_grid_detect_then_xrc_default_params(
     attenuator: BinaryFilterAttenuator,
     backlight: Backlight,
     beamstop_phase1: Beamstop,
-    dcm: BaseDCM,
+    dcm: DoubleCrystalMonochromator,
     zebra_fast_grid_scan: ZebraFastGridScanThreeD,
     flux: Flux,
     oav: OAV,


### PR DESCRIPTION
Matching mx-bluesky change to go with the DCM change in https://github.com/DiamondLightSource/dodal/pull/1601#event-20401701501

Typing for plans should show the minimal devices needed - eg if we need a DCM but don't need the d-spacing, don't type the plan to require a `DoubleCrystalMonochromatorWithDSpacing`.

As far as I can see, we only require d spacing for for set energy plan, which is currently only done in Hyperion. Non-hyperion plans are typed for more basic DCM devices.

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
