### PR TITLE
Update ophyd async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "daq-config-server>=v1.0.0-rc.2",
     "blueapi >= 1.5.0",
     "ophyd >= 1.10.5",
-    "ophyd-async >= 0.10.0a2",
+    "ophyd-async >= 0.13.4",
     "bluesky >= 1.14.6",
     "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]


### PR DESCRIPTION
Tests were failing with `ophyd-async` version `0.13.2` so I've pinned to `>= 0.13.4`

### Instructions to reviewer on how to test:

1. Check tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
