### PR TITLE
Fix linter breakage caused by latest pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ dev = [
     "plantweb",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
-    "pyright",
+    # Pin to previous pyright until https://github.com/microsoft/pyright/issues/11060 is fixed
+    "pyright==1.1.406", 
     "pytest-asyncio",
     "pytest-cov",
     "pytest-random-order",


### PR DESCRIPTION
Fixes linter breakage caused by
https://github.com/microsoft/pyright/issues/11060

Pins dodal to 1.1.406

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1.Tests pass
2. Linting passes