### PR TITLE
Restore the global event loop after soak tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ setenv =
     ISPYB_CONFIG_PATH={toxinidir}/tests/test_data/ispyb-test-credentials.cfg
     ZOCALO_CONFIG={toxinidir}/tests/test_data/zocalo-test-configuration.yaml
 commands =
-    pytest -m system_test --timeout=60 tests/system_tests
+    pytest -m system_test --timeout=60 tests/system_tests {posargs}
 """
 
 [tool.ruff]


### PR DESCRIPTION
Fixes the system tests - the soak test caused following tests to get "bluesky event loop not running" due to inadvertently clobbering the bluesky event loop global, which is now no longer re-initialised because other tests share a session-scoped run engine.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. System tests pass - https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/jobs/289373

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
