### PR TITLE
Replaced pmac strings with axes

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/web_gui_plans/oav_plans.py
+++ b/src/mx_bluesky/beamlines/i24/serial/web_gui_plans/oav_plans.py
@@ -17,26 +17,26 @@ class Direction(Enum):
     RIGHT = "right"
 
 
-def _move_direction(magnitude: int, direction: Direction, pmac):
-    y_move = "&2#6J:0"
-    x_move = "&2#5J:0"
+def _move_direction(magnitude: float, direction: Direction, pmac):
+    y_move = 0.0
+    x_move = 0.0
 
     match direction:
         case Direction.UP:
-            y_move = f"&2#6J:{-magnitude}"
+            y_move = magnitude
         case Direction.DOWN:
-            y_move = f"&2#6J:{magnitude}"
+            y_move = -magnitude
         case Direction.LEFT:
-            x_move = f"&2#5J:{-magnitude}"
+            x_move = -magnitude
         case Direction.RIGHT:
-            x_move = f"&2#5J:{magnitude}"
+            x_move = magnitude
 
-    yield from bps.abs_set(pmac.pmac_string, x_move, wait=True)
-    yield from bps.abs_set(pmac.pmac_string, y_move, wait=True)
+    yield from bps.abs_set(pmac.x, x_move, wait=True)
+    yield from bps.abs_set(pmac.y, y_move, wait=True)
 
 
 def move_block_on_arrow_click(direction: Direction, pmac: PMAC = inject("pmac")):
-    magnitude = 31750
+    magnitude = 3.1750
     yield from _move_direction(magnitude, direction, pmac)
 
 
@@ -45,9 +45,9 @@ def move_window_on_arrow_click(
 ):
     match size_of_move:
         case MoveSize.SMALL:
-            magnitude = 1250
+            magnitude = 0.1250
         case MoveSize.BIG:
-            magnitude = 3750
+            magnitude = 0.3750
 
     yield from _move_direction(magnitude, direction, pmac)
 
@@ -57,8 +57,8 @@ def move_nudge_on_arrow_click(
 ):
     match size_of_move:
         case MoveSize.SMALL:
-            magnitude = 10
+            magnitude = 0.0010
         case MoveSize.BIG:
-            magnitude = 60
+            magnitude = 0.0060
 
     yield from _move_direction(magnitude, direction, pmac)

--- a/tests/unit_tests/beamlines/i24/serial/web_gui/test_oav_plans.py
+++ b/tests/unit_tests/beamlines/i24/serial/web_gui/test_oav_plans.py
@@ -12,37 +12,40 @@ from mx_bluesky.beamlines.i24.serial.web_gui_plans.oav_plans import (
 
 
 @pytest.mark.parametrize(
-    "direction, expected_pmac_string",
+    "direction, expected_value",
     [
-        ("up", "&2#6J:-31750"),
-        ("left", "&2#5J:-31750"),
-        ("right", "&2#5J:31750"),
-        ("down", "&2#6J:31750"),
+        ("up", 3.1750),
+        ("left", -3.1750),
+        ("right", 3.1750),
+        ("down", -3.1750),
     ],
 )
-def test_move_block_on_arrow_click(direction, expected_pmac_string, pmac, run_engine):
+def test_move_block_on_arrow_click(direction, expected_value, pmac, run_engine):
     with patch(
         "mx_bluesky.beamlines.i24.serial.web_gui_plans.oav_plans.bps.abs_set",
     ) as mock_abs_set:
         run_engine(move_block_on_arrow_click(Direction(direction), pmac))
-        mock_abs_set.assert_any_call(pmac.pmac_string, expected_pmac_string, wait=True)
+        if direction in ["left", "right"]:
+            mock_abs_set.assert_any_call(pmac.x, expected_value, wait=True)
+        else:
+            mock_abs_set.assert_any_call(pmac.y, expected_value, wait=True)
 
 
 @pytest.mark.parametrize(
-    "direction, move_size, expected_pmac_string",
+    "direction, move_size, expected_value",
     [
-        ("up", "small", "&2#6J:-1250"),
-        ("up", "big", "&2#6J:-3750"),
-        ("left", "small", "&2#5J:-1250"),
-        ("left", "big", "&2#5J:-3750"),
-        ("right", "small", "&2#5J:1250"),
-        ("right", "big", "&2#5J:3750"),
-        ("down", "small", "&2#6J:1250"),
-        ("down", "big", "&2#6J:3750"),
+        ("up", "small", 0.1250),
+        ("up", "big", 0.3750),
+        ("left", "small", -0.1250),
+        ("left", "big", -0.3750),
+        ("right", "small", 0.1250),
+        ("right", "big", 0.3750),
+        ("down", "small", -0.1250),
+        ("down", "big", -0.3750),
     ],
 )
 def test_move_window_on_arrow_click(
-    direction, move_size, expected_pmac_string, pmac, run_engine
+    direction, move_size, expected_value, pmac, run_engine
 ):
     with patch(
         "mx_bluesky.beamlines.i24.serial.web_gui_plans.oav_plans.bps.abs_set",
@@ -50,24 +53,27 @@ def test_move_window_on_arrow_click(
         run_engine(
             move_window_on_arrow_click(Direction(direction), MoveSize(move_size), pmac)
         )
-        mock_abs_set.assert_any_call(pmac.pmac_string, expected_pmac_string, wait=True)
+        if direction in ["left", "right"]:
+            mock_abs_set.assert_any_call(pmac.x, expected_value, wait=True)
+        else:
+            mock_abs_set.assert_any_call(pmac.y, expected_value, wait=True)
 
 
 @pytest.mark.parametrize(
-    "direction, move_size, expected_pmac_string",
+    "direction, move_size, expected_value",
     [
-        ("up", "small", "&2#6J:-10"),
-        ("up", "big", "&2#6J:-60"),
-        ("left", "small", "&2#5J:-10"),
-        ("left", "big", "&2#5J:-60"),
-        ("right", "small", "&2#5J:10"),
-        ("right", "big", "&2#5J:60"),
-        ("down", "small", "&2#6J:10"),
-        ("down", "big", "&2#6J:60"),
+        ("up", "small", 0.0010),
+        ("up", "big", 0.0060),
+        ("left", "small", -0.0010),
+        ("left", "big", -0.0060),
+        ("right", "small", 0.0010),
+        ("right", "big", 0.0060),
+        ("down", "small", -0.0010),
+        ("down", "big", -0.0060),
     ],
 )
 def test_move_nudge_on_arrow_click(
-    direction, move_size, expected_pmac_string, pmac, run_engine
+    direction, move_size, expected_value, pmac, run_engine
 ):
     with patch(
         "mx_bluesky.beamlines.i24.serial.web_gui_plans.oav_plans.bps.abs_set",
@@ -75,4 +81,7 @@ def test_move_nudge_on_arrow_click(
         run_engine(
             move_nudge_on_arrow_click(Direction(direction), MoveSize(move_size), pmac)
         )
-        mock_abs_set.assert_any_call(pmac.pmac_string, expected_pmac_string, wait=True)
+        if direction in ["left", "right"]:
+            mock_abs_set.assert_any_call(pmac.x, expected_value, wait=True)
+        else:
+            mock_abs_set.assert_any_call(pmac.y, expected_value, wait=True)


### PR DESCRIPTION
Fixes #1476 

### Instructions to reviewer on how to test:

1. oav_plans no longer contain any pmac strings
2. test_oav_plans no longer contain any pmac strings
3. Tests still succeed

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
