### PR TITLE
Remove module commands in favour of explict environment variables

### DIFF
--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -119,17 +119,15 @@ if [[ $START == 1 ]]; then
     if [ $IN_DEV == false ]; then
         check_user
         ISPYB_CONFIG_PATH="/dls_sw/dasc/mariadb/credentials/ispyb-hyperion-${BEAMLINE}.cfg"
+        ZOCALO_CONFIG=/dls_sw/apps/zocalo/live/configuration.yaml 
     else
         ISPYB_CONFIG_PATH="$RELATIVE_SCRIPT_DIR/tests/test_data/ispyb-test-credentials.cfg"
         ZOCALO_CONFIG="$RELATIVE_SCRIPT_DIR/tests/test_data/zocalo-test-configuration.yaml"
-        export ZOCALO_CONFIG
     fi
+    export ZOCALO_CONFIG
     export ISPYB_CONFIG_PATH
 
     kill_active_apps
-
-    module unload controls_dev
-    module load dials
 
     cd ${RELATIVE_SCRIPT_DIR}
 


### PR DESCRIPTION
Fixes #1426 

Post 9.33+, GDA no longer has many variables in its environment and these are not exported to the `run_hyperion.sh` script when it is spawned. Therefore the script no longer has access to the `module` command and consequently ZOCALO_CONFIG is never defined because `dials` is never loaded. 

### Instructions to reviewer on how to test:

1. Hyperion can still start with latest GDA master
2. Hyperion can still start with previous GDA master

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
