### PR TITLE
Revert "Update BlueAPI version in Dockerfile"

### DIFF
--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -1,7 +1,7 @@
 # Before changing this BlueAPI version number, you should check that 
 # the BlueAPI pin in pyproject.toml is compatible, else the version will
 # be overridden
-FROM ghcr.io/diamondlightsource/blueapi:1.11.0
+FROM ghcr.io/diamondlightsource/blueapi:1.0.0-rc.2
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Reverts DiamondLightSource/mx-bluesky#1506 to fix the container build.

We originally thought that it might need to be moved forward due to a `uv` bug we were seeing when starting `BlueAPI`. However, this turned out to be an issue inside `BlueAPI` and _I think_ we don't need to update the container to fix it.

Note that we do need to update at some point but this is not trivial, see https://github.com/DiamondLightSource/mx-bluesky/issues/1516.