### PR TITLE
Add skip for CI pre-commit for uv lock file update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/_tox.yml
     with:
       tox: pre-commit,type-checking
-      skip_hooks: local-install-dodal,type-checking
+      skip_hooks: local-install-dodal,type-checking,uv-sync
 
   test:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,6 @@ commands = [
         ], extend = true },
     ],
 ]
-# Skip the uv.lock update when pre-commit is run in CI
-set-env = { SKIP = "uv-sync" }
 
 [tool.tox.env.type-checking]
 description = "Run pyright"


### PR DESCRIPTION
This makes the uv.lock update step skipped in CI which should make it easier to merge, now that renovate should be submitting PRs for uv lockfile changes we shouldn't need to update the lockfile except when we have a dependency on the very latest dodal.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1.Tests pass
2. UV lockfile not checked in CI

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
