### PR TITLE
1998 fix smargon combined moves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.16.0",
     "bluesky >= 1.14.6",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@1998_serialize_omega_combined_move",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.16.0",
     "bluesky >= 1.14.6",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@1998_serialize_omega_combined_move",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]
 
 

--- a/src/mx_bluesky/common/device_setup_plans/manipulate_sample.py
+++ b/src/mx_bluesky/common/device_setup_plans/manipulate_sample.py
@@ -93,20 +93,17 @@ def move_x_y_z(
         yield from bps.wait(group)
 
 
-def move_phi_chi_omega(
+def move_phi_chi(
     smargon: Smargon,
     phi: float | None = None,
     chi: float | None = None,
-    omega: float | None = None,
     wait=False,
     group="move_phi_chi_omega",
 ):
-    """Move the x, y, and z axes of the given smargon to the specified position. All
+    """Move the phi, chi of the given smargon to the specified position. All
     axes are optional."""
 
-    LOGGER.info(f"Moving smargon to phi, chi, omega: {(phi, chi, omega)}")
-    yield from bps.abs_set(
-        smargon, CombinedMove(phi=phi, chi=chi, omega=omega), group=group
-    )
+    LOGGER.info(f"Moving smargon to phi, chi: {(phi, chi)}")
+    yield from bps.abs_set(smargon, CombinedMove(phi=phi, chi=chi), group=group)
     if wait:
         yield from bps.wait(group)

--- a/src/mx_bluesky/common/device_setup_plans/robot_load_unload.py
+++ b/src/mx_bluesky/common/device_setup_plans/robot_load_unload.py
@@ -63,7 +63,8 @@ def prepare_for_robot_load(
 
     yield from bps.mv(smargon.stub_offsets, StubPosition.RESET_TO_ROBOT_LOAD)
 
-    yield from bps.mv(smargon, CombinedMove(x=0, y=0, z=0, chi=0, phi=0, omega=0))
+    yield from bps.mv(smargon.wrapped_omega.phase, 0)
+    yield from bps.mv(smargon, CombinedMove(x=0, y=0, z=0, chi=0, phi=0))
 
     yield from bps.wait("prepare_robot_load")
 

--- a/src/mx_bluesky/hyperion/experiment_plans/pin_centre_then_gridscan_plan.py
+++ b/src/mx_bluesky/hyperion/experiment_plans/pin_centre_then_gridscan_plan.py
@@ -5,7 +5,7 @@ import json
 from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.oav.oav_parameters import OAVParameters
 
-from mx_bluesky.common.device_setup_plans.manipulate_sample import move_phi_chi_omega
+from mx_bluesky.common.device_setup_plans.manipulate_sample import move_phi_chi
 from mx_bluesky.common.experiment_plans.common_grid_detect_then_xray_centre_plan import (
     detect_grid_and_do_gridscan,
 )
@@ -74,7 +74,7 @@ def pin_centre_then_gridscan_plan(
             composite.gonio, composite.backlight, composite.aperture_scatterguard
         )
 
-        yield from move_phi_chi_omega(
+        yield from move_phi_chi(
             composite.gonio,
             parameters.phi_start_deg,
             parameters.chi_start_deg,

--- a/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
+++ b/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
@@ -93,7 +93,7 @@ async def test_when_robot_unload_called_then_sample_area_prepared_before_load(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj.name == "gonio"
-        and msg.args[0] == CombinedMove(x=0, y=0, z=0, omega=0, chi=0, phi=0),
+        and msg.args[0] == CombinedMove(x=0, y=0, z=0, chi=0, phi=0),
     )
 
     assert_message_and_return_remaining(

--- a/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
+++ b/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
@@ -89,14 +89,27 @@ async def test_when_robot_unload_called_then_sample_area_prepared_before_load(
         and msg.args[0] == ApertureValue.OUT_OF_BEAM,
     )
 
-    assert_message_and_return_remaining(
+    msgs = assert_message_and_return_remaining(
+        msgs,
+        lambda msg: msg.command == "set"
+        and msg.obj is smargon.wrapped_omega.phase
+        and msg.args[0] == 0,
+    )
+
+    msgs = assert_message_and_return_remaining(
+        msgs,
+        lambda msg: msg.command == "wait"
+        and msg.kwargs["group"] == msgs[0].kwargs["group"],
+    )
+
+    msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj.name == "gonio"
         and msg.args[0] == CombinedMove(x=0, y=0, z=0, chi=0, phi=0),
     )
 
-    assert_message_and_return_remaining(
+    msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj is robot

--- a/tests/unit_tests/hyperion/device_setup_plans/test_manipulate_sample.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_manipulate_sample.py
@@ -7,7 +7,7 @@ from ophyd_async.core import get_mock_put
 
 from mx_bluesky.common.device_setup_plans.manipulate_sample import (
     move_aperture_if_required,
-    move_phi_chi_omega,
+    move_phi_chi,
     move_x_y_z,
 )
 
@@ -76,12 +76,12 @@ def test_move_phi_chi_omega_no_wait(
     smargon: Smargon,
     sim_run_engine: RunEngineSimulator,
 ):
-    msgs = sim_run_engine.simulate_plan(move_phi_chi_omega(smargon, 10.0, 5.0, None))
+    msgs = sim_run_engine.simulate_plan(move_phi_chi(smargon, 10.0, 5.0))
     msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj.name == smargon.name
-        and msg.args[0] == CombinedMove(phi=10.0, chi=5.0, omega=None),
+        and msg.args[0] == CombinedMove(phi=10.0, chi=5.0),
     )
     assert len(msgs) == 1
 
@@ -90,14 +90,12 @@ def test_move_phi_chi_omega_wait(
     smargon: Smargon,
     sim_run_engine: RunEngineSimulator,
 ):
-    msgs = sim_run_engine.simulate_plan(
-        move_phi_chi_omega(smargon, 10.0, 5.0, None, wait=True)
-    )
+    msgs = sim_run_engine.simulate_plan(move_phi_chi(smargon, 10.0, 5.0, wait=True))
     msgs = assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj.name == smargon.name
-        and msg.args[0] == CombinedMove(phi=10.0, chi=5.0, omega=None),
+        and msg.args[0] == CombinedMove(phi=10.0, chi=5.0),
     )
     group = msgs[0].kwargs["group"]
     assert_message_and_return_remaining(

--- a/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -283,7 +283,7 @@ def test_pin_centre_then_gridscan_plan_goes_to_the_starting_chi_and_phi(
         msgs,
         lambda msg: msg.command == "set"
         and msg.obj.name == "gonio"
-        and msg.args[0] == CombinedMove(phi=expected_phi, chi=expected_chi, omega=None)
+        and msg.args[0] == CombinedMove(phi=expected_phi, chi=expected_chi)
         and msg.kwargs["group"] == CONST.WAIT.READY_FOR_OAV,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -802,8 +802,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.2.3.dev14+g729a8b2d8"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#729a8b2d8730963455c268cb38d91bfcaa9e50be" }
+version = "2.2.4.dev3+geb7d0e631"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=1998_serialize_omega_combined_move#eb7d0e631a1a5a78ffe9fdad8c8729452baf0279" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2109,7 +2109,7 @@ requires-dist = [
     { name = "caproto" },
     { name = "daq-config-server", specifier = ">=1.3.0" },
     { name = "deepdiff" },
-    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=main" },
+    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=1998_serialize_omega_combined_move" },
     { name = "fastapi", extras = ["all"] },
     { name = "flask-restful" },
     { name = "jupyterlab" },

--- a/uv.lock
+++ b/uv.lock
@@ -807,8 +807,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.3.1.dev4+gdd687cce0"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#dd687cce03e1a18ba9a0698d7ebc1e8f6b460ad9" }
+version = "2.3.1.dev8+gca163b99a"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#ca163b99a719b006e844067e724bf8c103615b83" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
Fixes
* DiamondLightSource/dodal#1998

Requires:
* #1640

Link to dodal PR (if required): 
* DiamondLightSource/dodal#1999
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

This removes omega from `CombinedMove` because a) omega moves cannot be reliably parallelised with other axes and b) following mod-360 changes, we wish to apply a phase angle and not an absolute angle which is inconsistent with the other axes in `CombinedMove`
Instead, when we perform a combined move, the plan explicitly moves the omega axis beforehand

### Instructions to reviewer on how to test:

1. Tests pass
2. Functionality as described

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
