### PR TITLE
Support configuring the config server URL

### DIFF
--- a/docs/user/hyperion/advanced/advanced_configuration.rst
+++ b/docs/user/hyperion/advanced/advanced_configuration.rst
@@ -1,0 +1,18 @@
+Advanced Configuration
+======================
+
+Environment Variables
+---------------------
+
+Hyperion deployment is configurable by number of different environment variables:
+
+.. csv-table:: Environment variables
+    :widths: auto
+    :header: "Environment Variable", "Description"
+
+    "ISPYB_CONFIG_PATH", "Path to endpoint and credential configuration for ISPyB and ExpEye"
+    "LOG_DIR", "Path to the logging directory for file-based logging"
+    "DEBUG_LOG_DIR", "Path to the logging directory for the debug log"
+    "ZOCALO_CONFIG", "Path to the configuration YAML file for zocalo"
+    "BEAMLINE", "Defines the name of the beamline"
+    "CONFIG_SERVER_URL", "URL for the config server"

--- a/docs/user/hyperion/configuration.rst
+++ b/docs/user/hyperion/configuration.rst
@@ -57,3 +57,8 @@ ultimately it will be the source of all configuration and the remainder of the f
 moved over to it.
 
 .. _Config Server: https://github.com/DiamondLightSource/daq-config-server/
+
+
+See also `Advanced Configuration`_ for details of configuration performed at deployment time.
+
+.. _`Code Map`: advanced/advanced_configuration.rst

--- a/docs/user/hyperion/configuration.rst
+++ b/docs/user/hyperion/configuration.rst
@@ -56,9 +56,10 @@ Note that currently the rest of the configuration files are not read from the co
 ultimately it will be the source of all configuration and the remainder of the files in ``daq_configuration`` will be
 moved over to it.
 
-.. _Config Server: https://github.com/DiamondLightSource/daq-config-server/
+See `Config Server`_ for details of the config server and how it is configured and deployed.
 
+.. _Config Server: https://github.com/DiamondLightSource/daq-config-server/
 
 See also `Advanced Configuration`_ for details of configuration performed at deployment time.
 
-.. _`Code Map`: advanced/advanced_configuration.rst
+.. _`Advanced Configuration`: advanced/advanced_configuration.html

--- a/docs/user/hyperion/troubleshooting.rst
+++ b/docs/user/hyperion/troubleshooting.rst
@@ -40,7 +40,7 @@ following
 However on inspection the start log will not show any errors. Hyperion running can be verified as above `Verifying 
 that Hyperion is running`_
 
-.. _`Verifying that Hyperion is running`: advanced/install.rst
+.. _`Verifying that Hyperion is running`: advanced/install.html
 
 Smargon Motion
 ~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.16.0",
     "bluesky >= 1.14.6",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@fix_config_server_system_test_breakage",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.16.0",
     "bluesky >= 1.14.6",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@fix_config_server_system_test_breakage",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]
 
 

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -110,6 +110,8 @@ if [ -z "${BEAMLINE}" ]; then
     exit 1
 fi
 
+export CONFIG_SERVER_URL="https://${BEAMLINE}-daq-config.diamond.ac.uk"
+
 if [[ $STOP == 1 ]]; then
     if [ $IN_DEV == false ]; then
         check_user

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from abc import abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractContextManager
@@ -12,6 +13,8 @@ from bluesky.callbacks import CallbackBase
 from bluesky.callbacks.zmq import Proxy, RemoteDispatcher
 from bluesky_stomp.messaging import StompClient
 from bluesky_stomp.models import Broker
+from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.log import LOGGER as DODAL_LOGGER
 from dodal.log import set_up_all_logging_handlers
 
@@ -141,6 +144,15 @@ def setup_logging(dev_mode: bool):
     log_debug("nexgen logger added to nexus logger")
 
 
+def create_config_client() -> ConfigClient:
+    config_server_url = os.getenv("CONFIG_SERVER_URL")
+    if not config_server_url:
+        raise ValueError(
+            "CONFIG_SERVER_URL must be specified to run external callbacks."
+        )
+    return ConfigClient(config_server_url)
+
+
 def log_info(msg, *args, **kwargs):
     ISPYB_ZOCALO_CALLBACK_LOGGER.info(msg, *args, **kwargs)
     NEXUS_LOGGER.info(msg, *args, **kwargs)
@@ -157,6 +169,7 @@ class HyperionCallbackRunner:
     def __init__(self, callback_args: CallbackArgs) -> None:
         setup_logging(callback_args.dev_mode)
         log_info("Hyperion callback process started.")
+        set_config_client(create_config_client())
         set_alerting_service(LoggingAlertService(CONST.GRAYLOG_STREAM_ID))
 
         self.callbacks = setup_callbacks()

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -14,6 +14,7 @@ from bluesky.callbacks.zmq import Proxy, RemoteDispatcher
 from bluesky_stomp.messaging import StompClient
 from bluesky_stomp.models import Broker
 from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_parameters import CONFIG_SERVER_URL_ENV_VAR
 from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.log import LOGGER as DODAL_LOGGER
 from dodal.log import set_up_all_logging_handlers
@@ -145,10 +146,10 @@ def setup_logging(dev_mode: bool):
 
 
 def create_config_client() -> ConfigClient:
-    config_server_url = os.getenv("CONFIG_SERVER_URL")
+    config_server_url = os.getenv(CONFIG_SERVER_URL_ENV_VAR)
     if not config_server_url:
         raise ValueError(
-            "CONFIG_SERVER_URL must be specified to run external callbacks."
+            f"{CONFIG_SERVER_URL_ENV_VAR} must be specified to run external callbacks."
         )
     return ConfigClient(config_server_url)
 

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -48,7 +48,9 @@ def test_main_function(
     setup_callbacks: MagicMock,
     parse_callback_args: MagicMock,
     mock_run_watchdog: MagicMock,
+    monkeypatch,
 ):
+    monkeypatch.setenv("CONFIG_SERVER_URL", "http://127.0.0.1:8555")
     proxy_started = Event()
     dispatcher_started = Event()
     watchdog_started = Event()
@@ -178,7 +180,9 @@ def test_launch_with_stomp_launches_stomp_backend(
     mock_setup_callbacks: MagicMock,
     mock_client_cls: MagicMock,
     mock_dispatcher_cls: MagicMock,
+    monkeypatch,
 ):
+    monkeypatch.setenv("CONFIG_SERVER_URL", "http://127.0.0.1:8555")
     stomp_client = mock_client_cls.for_broker.return_value
     dispatcher = mock_dispatcher_cls.return_value
     stomp_client.is_connected.side_effect = [True, False]

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -33,7 +33,7 @@ from mx_bluesky.hyperion.parameters.constants import HyperionConstants
 )
 @patch("mx_bluesky.hyperion.external_interaction.callbacks.__main__.setup_callbacks")
 @patch("mx_bluesky.hyperion.external_interaction.callbacks.__main__.setup_logging")
-@patch("mx_bluesky.hyperion.external_interaction.callbcaks.__main__.set_config_client")
+@patch("mx_bluesky.hyperion.external_interaction.callbacks.__main__.set_config_client")
 @patch(
     "mx_bluesky.hyperion.external_interaction.callbacks.__main__.set_alerting_service"
 )

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -33,6 +33,7 @@ from mx_bluesky.hyperion.parameters.constants import HyperionConstants
 )
 @patch("mx_bluesky.hyperion.external_interaction.callbacks.__main__.setup_callbacks")
 @patch("mx_bluesky.hyperion.external_interaction.callbacks.__main__.setup_logging")
+@patch("mx_bluesky.hyperion.external_interaction.callbcaks.__main__.set_config_client")
 @patch(
     "mx_bluesky.hyperion.external_interaction.callbacks.__main__.set_alerting_service"
 )
@@ -42,6 +43,7 @@ def test_main_function(
     mock_proxy: MagicMock,
     mock_dispatcher: MagicMock,
     setup_alerting: MagicMock,
+    set_config_client: MagicMock,
     setup_logging: MagicMock,
     setup_callbacks: MagicMock,
     parse_callback_args: MagicMock,
@@ -60,10 +62,20 @@ def test_main_function(
     dispatcher_started.wait(0.5)
     mock_run_watchdog.wait(0.5)
     setup_logging.assert_called()
+    set_config_client.assert_called()
     setup_callbacks.assert_called()
     setup_alerting.assert_called_once()
     mock_run_watchdog.assert_called_once()
     assert isinstance(setup_alerting.mock_calls[0].args[0], LoggingAlertService)
+
+
+@patch(
+    "mx_bluesky.hyperion.external_interaction.callbacks.__main__.parse_callback_args",
+    MagicMock(return_value=CallbackArgs(True, HyperionConstants.SUPERVISOR_PORT)),
+)
+def test_no_config_server_url_raises_exception():
+    with pytest.raises(ValueError, match="CONFIG_SERVER_URL must be specified"):
+        main()
 
 
 def test_setup_callbacks():

--- a/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/unit_tests/hyperion/external_interaction/callbacks/test_external_callbacks.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 from bluesky.callbacks import CallbackBase
 from bluesky_stomp.models import Broker
+from dodal.common.beamlines.beamline_parameters import CONFIG_SERVER_URL_ENV_VAR
 from dodal.log import LOGGER as DODAL_LOGGER
 
 from mx_bluesky.common.external_interaction.alerting.log_based_service import (
@@ -50,7 +51,7 @@ def test_main_function(
     mock_run_watchdog: MagicMock,
     monkeypatch,
 ):
-    monkeypatch.setenv("CONFIG_SERVER_URL", "http://127.0.0.1:8555")
+    monkeypatch.setenv(CONFIG_SERVER_URL_ENV_VAR, "http://127.0.0.1:8555")
     proxy_started = Event()
     dispatcher_started = Event()
     watchdog_started = Event()
@@ -182,7 +183,7 @@ def test_launch_with_stomp_launches_stomp_backend(
     mock_dispatcher_cls: MagicMock,
     monkeypatch,
 ):
-    monkeypatch.setenv("CONFIG_SERVER_URL", "http://127.0.0.1:8555")
+    monkeypatch.setenv(CONFIG_SERVER_URL_ENV_VAR, "http://127.0.0.1:8555")
     stomp_client = mock_client_cls.for_broker.return_value
     dispatcher = mock_dispatcher_cls.return_value
     stomp_client.is_connected.side_effect = [True, False]

--- a/uv.lock
+++ b/uv.lock
@@ -807,8 +807,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.2.4.dev9+g4ba9de171"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#4ba9de17170657beb27e77ccb4a781cf311854b4" }
+version = "2.2.4.dev10+g0649293ed"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#0649293ed97538713ef77ab6e6f55fe984abd616" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
This enables the config server URL to be specified in the external callbacks, which allows system tests to be fixed.

Requires:

* DiamondLightSource/dodal#2008

Adds additional documentation for environment variables.
The external callbacks must now be launched with the CONFIG_SERVER_URL parameter specified in order to start


### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
