### PR TITLE
Remove mysql connector pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "matplotlib",
     "cachetools",
     "bluesky-stomp >= 0.2.0",
-    "mysql-connector-python == 9.5.0", # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
+    "mysql-connector-python",
 
     #
     # These dependencies may be issued as pre-release versions and should have a pin constraint


### PR DESCRIPTION
Pin says it needs a release of https://github.com/DiamondLightSource/ispyb-api/pull/244, which is now done so removing

Link to dodal PR (if required):  https://github.com/DiamondLightSource/dodal/pull/1938

### Instructions to reviewer on how to test:

1. Confirm tests still pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
