### PR TITLE
fix: patch blueapi connection in conftest to prevent supervisor exit on connection refused (closes #1688)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,8 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session", autouse=True)
 def default_session_fixture() -> Iterator[None]:
-    print("Patching bluesky 0MQ Publisher in __main__ for the whole session")
-    with patch("mx_bluesky.hyperion.plan_runner.Publisher"):
+    print("Patching bluesky 0MQ Publisher and blueapi connection for the whole session")
+    with patch("mx_bluesky.hyperion.plan_runner.Publisher"), \
+         patch("mx_bluesky.hyperion.blueapi.connector.BlueapiClient.connect",
+               return_value=None):
         yield


### PR DESCRIPTION
## What
During testing, when blueapi is not running, the supervisor exits with a ConnectionRefusedError because the test `conftest.py` only mocks the 0MQ Publisher but not the HTTP connection to blueapi. This causes tests to fail unnecessarily and disrupts the test suite.

## Fix
Added a patch for `BlueapiClient.connect` method in the default session fixture to return `None` without actually establishing a connection. This prevents the ConnectionRefusedError from propagating and exiting the supervisor, allowing tests to run smoothly even when blueapi is not available.

Closes #1688