### PR TITLE
Update Dockerfile.blueapi to generate the .venv correctly

### DIFF
--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -1,7 +1,7 @@
 # Before changing this BlueAPI version number, you should check that 
 # the BlueAPI pin in pyproject.toml is compatible, else the version will
 # be overridden
-FROM ghcr.io/diamondlightsource/blueapi:latest
+FROM ghcr.io/diamondlightsource/blueapi:latest as base
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,13 +12,20 @@ RUN apt update -y && \
     apt upgrade -y && \
     apt install -y libgl1 libglib2.0-0
 
-RUN uv pip install --no-cache-dir --no-compile mx-bluesky
+FROM base as work
 
-# Create and set permissions for uv venv, root cache
-# and user cache. Allows Blueapi's setup-scratch
-# to change dependencies without permission errors
-RUN mkdir -p /app/.venv /root/.cache/uv /home/app/.cache/uv \
-    && chmod -R 777 /app/.venv /root/.cache/uv /home/app/.cache/uv
+# Temporary work folder because uv sync needs to write to this even though
+# we don't need it in the build image
+COPY --chown=1000:1000 . /work
 
+FROM base as build
 
+# User 1000 - same as owner of base image .venv files
 USER ubuntu
+
+# If running this build locally in podman, and this fails here you may need to run
+# chcon -Rt container_file_t .
+# in order for podman to bind mount the working directory
+RUN --mount=type=bind,from=work,source=/work,target=/tmp/work,rw --mount=type=tmpfs,target=/tmp/uvcache \
+    cd /tmp/work && \
+    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --cache-dir=/tmp/uvcache --locked

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -1,6 +1,11 @@
-# Before changing this BlueAPI version number, you should check that 
-# the BlueAPI pin in pyproject.toml is compatible, else the version will
-# be overridden
+# Generate a customised version of the stock BlueAPI container image
+# The image updates the virtual environment in /app/.venv with the correct versions of
+# mx-bluesky dependencies as determined from the uv.lock file
+#
+# The image does not contain the mx-bluesky or dodal workspaces; these are
+# created in the scratch folder at runtime via the blueapi initContainer
+
+# An assumption is made here that at release time the latest blueapi is in effect
 FROM ghcr.io/diamondlightsource/blueapi:latest as base
 USER root
 

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -5,7 +5,6 @@ from sys import argv
 
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.core import BlueskyContext
-
 from daq_config_server import ConfigClient
 from dodal.common.beamlines.beamline_utils import set_config_client
 
@@ -31,6 +30,7 @@ from mx_bluesky.hyperion.supervisor import SupervisorRunner
 from mx_bluesky.hyperion.utils.context import setup_context
 
 DEFAULT_CONFIG_SERVER_ENDPOINT = "https://i03-daq-config.diamond.ac.uk"
+
 
 def initialise_globals(args: HyperionArgs):
     """Do all early main low-level application initialisation."""

--- a/uv.lock
+++ b/uv.lock
@@ -806,8 +806,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.4.1.dev18+ge4c528ddd"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#e4c528ddd7a81a347bc589dd873a549944b63b63" }
+version = "2.4.1.dev19+g47f3ca66d"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#47f3ca66d3ad0232f87486bf8881aa8a9336324a" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
* Update Dockerfile.blueapi to generate the .venv for the current build instead of downloading a previous version of mx-bluesky

Fixes 
* #1770

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. mx-bluesky-blueapi image is built with the correct dependencies as defined in the mx-bluesky uv.lock file

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
