### PR TITLE
1770 fix dockerfile multiple pythons

### DIFF
--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -34,5 +34,5 @@ USER ubuntu
 RUN --mount=type=bind,from=work,source=/work,target=/tmp/work,rw --mount=type=tmpfs,target=/tmp/uvcache \
     cd /tmp/work && \
     . /app/.venv/bin/activate && \
-    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --active --cache-dir=/tmp/uvcache --locked && \
+    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --active --no-python-downloads --cache-dir=/tmp/uvcache --locked && \
     chmod -R 777 /app/.venv

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -33,4 +33,5 @@ USER ubuntu
 # in order for podman to bind mount the working directory
 RUN --mount=type=bind,from=work,source=/work,target=/tmp/work,rw --mount=type=tmpfs,target=/tmp/uvcache \
     cd /tmp/work && \
-    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --cache-dir=/tmp/uvcache --locked
+    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --cache-dir=/tmp/uvcache --locked && \
+    chmod -R 777 /app/.venv

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -33,5 +33,6 @@ USER ubuntu
 # in order for podman to bind mount the working directory
 RUN --mount=type=bind,from=work,source=/work,target=/tmp/work,rw --mount=type=tmpfs,target=/tmp/uvcache \
     cd /tmp/work && \
-    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --cache-dir=/tmp/uvcache --locked && \
+    . /app/.venv/bin/activate && \
+    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --active --cache-dir=/tmp/uvcache --locked && \
     chmod -R 777 /app/.venv

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -33,6 +33,5 @@ USER ubuntu
 # in order for podman to bind mount the working directory
 RUN --mount=type=bind,from=work,source=/work,target=/tmp/work,rw --mount=type=tmpfs,target=/tmp/uvcache \
     cd /tmp/work && \
-    . /app/.venv/bin/activate && \
-    UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --active --no-python-downloads --cache-dir=/tmp/uvcache --locked && \
+    UV_PYTHON=/app/.venv/bin/python UV_COMPILE_BYTECODE=0 UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --cache-dir=/tmp/uvcache --locked && \
     chmod -R 777 /app/.venv

--- a/Dockerfile.blueapi
+++ b/Dockerfile.blueapi
@@ -6,7 +6,7 @@
 # created in the scratch folder at runtime via the blueapi initContainer
 
 # An assumption is made here that at release time the latest blueapi is in effect
-FROM ghcr.io/diamondlightsource/blueapi:latest as base
+FROM ghcr.io/diamondlightsource/blueapi:latest AS base
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -17,13 +17,13 @@ RUN apt update -y && \
     apt upgrade -y && \
     apt install -y libgl1 libglib2.0-0
 
-FROM base as work
+FROM base AS work
 
 # Temporary work folder because uv sync needs to write to this even though
 # we don't need it in the build image
 COPY --chown=1000:1000 . /work
 
-FROM base as build
+FROM base AS build
 
 # User 1000 - same as owner of base image .venv files
 USER ubuntu

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 [[package]]
 name = "daq-config-server"
 version = "1.3.6"
-source = { git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=main#d1194e2fde834816daba5eb9ce3d9489208b3ac1" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -706,6 +706,10 @@ dependencies = [
     { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/74/56eddf2a44efd981cc5678e74fd777f37c045a7f9b71b01143ee8be45715/daq_config_server-1.3.6.tar.gz", hash = "sha256:ec25a69eca6fbeca309f04763d53728000e39d509a3f43353b76721985e34ee2", size = 232081, upload-time = "2026-06-10T13:30:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/0a/f225277d9b0133b6cd0e68f19d93af67db1fd76c9ccea9026563d53f2ffa/daq_config_server-1.3.6-py3-none-any.whl", hash = "sha256:948933c4d7f79ea609cff5774aeef3578ffda582d623e8d5bdf9aadf89df36b7", size = 33132, upload-time = "2026-06-10T13:30:52.176Z" },
 ]
 
 [[package]]
@@ -806,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.4.1.dev19+g47f3ca66d"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#47f3ca66d3ad0232f87486bf8881aa8a9336324a" }
+version = "2.5.1"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#641e0a47865c8c4c3c4413bc02f75f54a73cd334" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2681,7 +2685,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2695,9 +2699,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/a5/1811d2cb16ca2a0aa0830a119ae55cd8b3435acd821b68eebe430524502d/ophyd_async-0.19.1.tar.gz", hash = "sha256:a98f3514e159b3777b9eaf3b9417a2238c4fefc5c657a82cb043174c569acc37", size = 588480, upload-time = "2026-06-11T19:09:20.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/d9/bc09637a5caff453a205fa3c26474f497964618b72074413a6315d36725b/ophyd_async-0.19.2.tar.gz", hash = "sha256:138dcd5ac2ccc30194c9d74525aefb291b8a0be2ef3468a60e294f0fcea5495a", size = 588686, upload-time = "2026-06-16T15:31:31.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/a3/b4605ee05a6a3480ad57cf0ac15e381f99189b022362f0c08044c86227d7/ophyd_async-0.19.1-py3-none-any.whl", hash = "sha256:bb4cc6751aee46e53c588b493ce0a8905c94fbf4b5092af2f774019846af7c74", size = 228222, upload-time = "2026-06-11T19:09:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/90/36/96ac313cc51e147556e80d2388ca7c55672d13c06cb87353d8d607125284/ophyd_async-0.19.2-py3-none-any.whl", hash = "sha256:2cdd5ce876ce00246d043c581b1bb4074984822a879a330637a3188ace8e1f3e", size = 228241, upload-time = "2026-06-16T15:31:29.546Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Part 2 of fix for

* #1770

Link to dodal PR (if required): #N/A

This addresses

* scratch init was unable to read the .venv files
* scratch init was unable to resolve python because `uv sync` in the Dockerfile installed python 3.14 in `/home/ubuntu/.local/share/uv/python`, overwriting the already installed python 3.11