### PR TITLE
1587 Fix use_roi_mode option in mx-bluesky

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server >= 1.3.0",
+    "daq-config-server @ git+https://github.com/DiamondLightSource/daq-config-server.git@mx-bluesky_1587_hyperion_should_honour_roi_mode",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.17a4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server >= 1.3.0",
+    "daq-config-server  @ git+https://github.com/DiamondLightSource/daq-config-server.git@mx-bluesky_1587_hyperion_should_honour_roi_mode",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.17a4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server @ git+https://github.com/DiamondLightSource/daq-config-server.git@mx-bluesky_1587_hyperion_should_honour_roi_mode",
+    "daq-config-server >= 1.3.7",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.17a4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server  @ git+https://github.com/DiamondLightSource/daq-config-server.git@mx-bluesky_1587_hyperion_should_honour_roi_mode",
+    "daq-config-server >= 1.3.0",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.17a4",

--- a/src/mx_bluesky/hyperion/blueapi/parameters.py
+++ b/src/mx_bluesky/hyperion/blueapi/parameters.py
@@ -46,6 +46,7 @@ class RobotLoadThenCentreParams(HyperionParam):
     pin_type: SingleSamplePinTypeParam | MultiSamplePinTypeParam = Field(
         discriminator="name", default=SingleSamplePinTypeParam()
     )
+    use_roi_mode: bool
 
 
 class SingleRotationScanParams(HyperionParam):

--- a/src/mx_bluesky/hyperion/external_interaction/agamemnon.py
+++ b/src/mx_bluesky/hyperion/external_interaction/agamemnon.py
@@ -25,6 +25,9 @@ from mx_bluesky.hyperion.blueapi.parameters import (
     PinTypeParam,
     SingleSamplePinTypeParam,
 )
+from mx_bluesky.hyperion.external_interaction.config_server import (
+    get_hyperion_feature_settings,
+)
 
 T = TypeVar("T", bound=WithVisit)
 MULTIPIN_PREFIX = "multipin"
@@ -152,7 +155,7 @@ def _populate_parameters_from_agamemnon(
     pin_type = _get_pin_type_from_agamemnon_collect_parameters(agamemnon_params)
     collections = agamemnon_params["collection"]
     visit_directory, file_name = path.split(agamemnon_params["prefix"])
-
+    use_roi_mode = get_hyperion_feature_settings().XRC_USE_ROI_MODE
     return [
         LoadCentreCollectParams.model_validate(
             {
@@ -174,6 +177,7 @@ def _populate_parameters_from_agamemnon(
                     "chi_start_deg": collection["chi"],
                     "transmission_frac": 1.0,
                     "exposure_time_s": GridscanParamConstants.EXPOSURE_TIME_S,
+                    "use_roi_mode": use_roi_mode,
                 },
                 "multi_rotation_scan": {
                     "comment": collection["comment"],

--- a/tests/test_data/parameter_json_files/external_load_centre_collect_params.json
+++ b/tests/test_data/parameter_json_files/external_load_centre_collect_params.json
@@ -14,7 +14,8 @@
       0,
       90
     ],
-    "chi_start_deg": 30
+    "chi_start_deg": 30,
+    "use_roi_mode": true
   },
   "multi_rotation_scan": {
     "comment": "Hyperion Rotation Scan - ",

--- a/tests/test_data/parameter_json_files/external_load_centre_collect_params_multipin.json
+++ b/tests/test_data/parameter_json_files/external_load_centre_collect_params_multipin.json
@@ -17,7 +17,8 @@
       "wells": 6,
       "tip_to_first_well_um": 60,
       "well_size_um": 80
-    }
+    },
+    "use_roi_mode": true
   },
   "multi_rotation_scan": {
     "comment": "Hyperion Rotation Scan - ",

--- a/tests/unit_tests/hyperion/blueapi_plans/test_parameters.py
+++ b/tests/unit_tests/hyperion/blueapi_plans/test_parameters.py
@@ -42,8 +42,8 @@ def test_map_external_to_internal_roi_mode(tmp_path, expected_roi_mode):
         "tests/test_data/parameter_json_files/external_load_centre_collect_params.json",
         tmp_path,
     )
-    external_params = LoadCentreCollectParams(**raw_params)
     raw_params["robot_load_then_centre"]["use_roi_mode"] = expected_roi_mode
+    external_params = LoadCentreCollectParams(**raw_params)
     actual_internal = load_centre_collect_to_internal(external_params)
     assert actual_internal.robot_load_then_centre.use_roi_mode == expected_roi_mode
 

--- a/tests/unit_tests/hyperion/blueapi_plans/test_parameters.py
+++ b/tests/unit_tests/hyperion/blueapi_plans/test_parameters.py
@@ -36,6 +36,18 @@ def test_map_external_to_internal_parameters(tmp_path):
     assert expected_internal == actual_internal
 
 
+@pytest.mark.parametrize("expected_roi_mode", [True, False])
+def test_map_external_to_internal_roi_mode(tmp_path, expected_roi_mode):
+    raw_params = raw_params_from_file(
+        "tests/test_data/parameter_json_files/external_load_centre_collect_params.json",
+        tmp_path,
+    )
+    external_params = LoadCentreCollectParams(**raw_params)
+    raw_params["robot_load_then_centre"]["use_roi_mode"] = expected_roi_mode
+    actual_internal = load_centre_collect_to_internal(external_params)
+    assert actual_internal.robot_load_then_centre.use_roi_mode == expected_roi_mode
+
+
 def test_map_external_to_internal_multisample_pin(tmp_path):
     raw_params = raw_params_from_file(
         "tests/test_data/parameter_json_files/external_load_centre_collect_params_multipin.json",

--- a/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
@@ -6,6 +6,11 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from daq_config_server import ConfigClient
+from daq_config_server.models.feature_settings.hyperion_feature_settings import (
+    HyperionFeatureSettings,
+)
+from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.devices.zebra.zebra import RotationDirection
 
 from mx_bluesky.hyperion._plan_runner_params import Wait
@@ -24,6 +29,11 @@ from mx_bluesky.hyperion.external_interaction.agamemnon import (
     _instruction_and_data,
     create_parameters_from_agamemnon,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_config_client():
+    set_config_client(ConfigClient("http://localhost"))
 
 
 def set_up_agamemnon_params(
@@ -233,13 +243,23 @@ def test_create_parameters_from_agamemnon_contains_expected_data(agamemnon_respo
 
 
 @pytest.mark.parametrize(
-    "agamemnon_response",
-    ["tests/test_data/agamemnon/example_native.json"],
-    indirect=True,
+    "agamemnon_response, expected_roi_mode",
+    [
+        ["tests/test_data/agamemnon/example_native.json", True],
+        ["tests/test_data/agamemnon/example_native.json", False],
+    ],
+    indirect=["agamemnon_response"],
+)
+@patch(
+    "mx_bluesky.hyperion.external_interaction.agamemnon.get_hyperion_feature_settings"
 )
 def test_create_parameters_from_agamemnon_contains_expected_robot_load_then_centre_data(
-    agamemnon_response,
+    mock_get_hyperion_feature_settings: MagicMock,
+    agamemnon_response: str,
+    expected_roi_mode: bool,
 ):
+    settings = HyperionFeatureSettings(XRC_USE_ROI_MODE=expected_roi_mode)
+    mock_get_hyperion_feature_settings.return_value = settings
     hyperion_params_list = create_parameters_from_agamemnon()
     load_centre_collect_list = [
         load_centre_collect_to_internal(p)
@@ -272,6 +292,7 @@ def test_create_parameters_from_agamemnon_contains_expected_robot_load_then_cent
         assert robot_load_params.snapshot_directory == PosixPath(
             "/dls/i03/data/2025/mx34598-77/auto/CBLBA/CBLBA-x00242/xraycentring/snapshots"
         )
+        assert robot_load_params.use_roi_mode == expected_roi_mode
 
 
 @patch("mx_bluesky.common.parameters.rotation.os", new=MagicMock())

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 [[package]]
 name = "daq-config-server"
 version = "1.3.6"
-source = { git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=main#d1194e2fde834816daba5eb9ce3d9489208b3ac1" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -706,6 +706,10 @@ dependencies = [
     { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/74/56eddf2a44efd981cc5678e74fd777f37c045a7f9b71b01143ee8be45715/daq_config_server-1.3.6.tar.gz", hash = "sha256:ec25a69eca6fbeca309f04763d53728000e39d509a3f43353b76721985e34ee2", size = 232081, upload-time = "2026-06-10T13:30:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/0a/f225277d9b0133b6cd0e68f19d93af67db1fd76c9ccea9026563d53f2ffa/daq_config_server-1.3.6-py3-none-any.whl", hash = "sha256:948933c4d7f79ea609cff5774aeef3578ffda582d623e8d5bdf9aadf89df36b7", size = 33132, upload-time = "2026-06-10T13:30:52.176Z" },
 ]
 
 [[package]]
@@ -806,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.4.1.dev19+g47f3ca66d"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#47f3ca66d3ad0232f87486bf8881aa8a9336324a" }
+version = "2.5.1"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#641e0a47865c8c4c3c4413bc02f75f54a73cd334" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2681,7 +2685,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2695,9 +2699,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/a5/1811d2cb16ca2a0aa0830a119ae55cd8b3435acd821b68eebe430524502d/ophyd_async-0.19.1.tar.gz", hash = "sha256:a98f3514e159b3777b9eaf3b9417a2238c4fefc5c657a82cb043174c569acc37", size = 588480, upload-time = "2026-06-11T19:09:20.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/d9/bc09637a5caff453a205fa3c26474f497964618b72074413a6315d36725b/ophyd_async-0.19.2.tar.gz", hash = "sha256:138dcd5ac2ccc30194c9d74525aefb291b8a0be2ef3468a60e294f0fcea5495a", size = 588686, upload-time = "2026-06-16T15:31:31.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/a3/b4605ee05a6a3480ad57cf0ac15e381f99189b022362f0c08044c86227d7/ophyd_async-0.19.1-py3-none-any.whl", hash = "sha256:bb4cc6751aee46e53c588b493ce0a8905c94fbf4b5092af2f774019846af7c74", size = 228222, upload-time = "2026-06-11T19:09:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/90/36/96ac313cc51e147556e80d2388ca7c55672d13c06cb87353d8d607125284/ophyd_async-0.19.2-py3-none-any.whl", hash = "sha256:2cdd5ce876ce00246d043c581b1bb4074984822a879a330637a3188ace8e1f3e", size = 228241, upload-time = "2026-06-16T15:31:29.546Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -692,8 +692,8 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.7.dev1+g06eaaa763"
-source = { git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=mx-bluesky_1587_hyperion_should_honour_roi_mode#06eaaa763f1f2596c6eebe56caefbaefd9bf4433" }
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -706,6 +706,10 @@ dependencies = [
     { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/93/c913c56425bf937c3c6b8733ac88bdb6b03a49dd10f068215473b511f12f/daq_config_server-1.3.7.tar.gz", hash = "sha256:6dc0c0613c88198eb16cd86c84c731de97090499ebcf39ccfe9be67dad84caae", size = 233043, upload-time = "2026-06-25T10:00:58.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/0b/0472e9ab51f04a5fd00d477edf8567bdf320a6f245bd6414b3f208f49684/daq_config_server-1.3.7-py3-none-any.whl", hash = "sha256:ecf11b770d059248d70b3418b75701842dce398d4945e26a8a16ac5049a845c5", size = 35113, upload-time = "2026-06-25T10:00:57.083Z" },
 ]
 
 [[package]]
@@ -806,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.1"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#641e0a47865c8c4c3c4413bc02f75f54a73cd334" }
+version = "2.5.2.dev3+g80b0c62df"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#80b0c62df96df9bbd5399d8d5c4a230e4d34ecad" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2115,7 +2119,7 @@ requires-dist = [
     { name = "bluesky-stomp", specifier = ">=0.2.0" },
     { name = "cachetools" },
     { name = "caproto" },
-    { name = "daq-config-server", git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=mx-bluesky_1587_hyperion_should_honour_roi_mode" },
+    { name = "daq-config-server", specifier = ">=1.3.7" },
     { name = "deepdiff" },
     { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=main" },
     { name = "fastapi", extras = ["all"] },

--- a/uv.lock
+++ b/uv.lock
@@ -692,8 +692,8 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.6"
-source = { registry = "https://pypi.org/simple" }
+version = "1.3.7.dev1+g06eaaa763"
+source = { git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=mx-bluesky_1587_hyperion_should_honour_roi_mode#06eaaa763f1f2596c6eebe56caefbaefd9bf4433" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -706,10 +706,6 @@ dependencies = [
     { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/74/56eddf2a44efd981cc5678e74fd777f37c045a7f9b71b01143ee8be45715/daq_config_server-1.3.6.tar.gz", hash = "sha256:ec25a69eca6fbeca309f04763d53728000e39d509a3f43353b76721985e34ee2", size = 232081, upload-time = "2026-06-10T13:30:53.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/0a/f225277d9b0133b6cd0e68f19d93af67db1fd76c9ccea9026563d53f2ffa/daq_config_server-1.3.6-py3-none-any.whl", hash = "sha256:948933c4d7f79ea609cff5774aeef3578ffda582d623e8d5bdf9aadf89df36b7", size = 33132, upload-time = "2026-06-10T13:30:52.176Z" },
 ]
 
 [[package]]
@@ -2119,7 +2115,7 @@ requires-dist = [
     { name = "bluesky-stomp", specifier = ">=0.2.0" },
     { name = "cachetools" },
     { name = "caproto" },
-    { name = "daq-config-server", specifier = ">=1.3.0" },
+    { name = "daq-config-server", git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=mx-bluesky_1587_hyperion_should_honour_roi_mode" },
     { name = "deepdiff" },
     { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=main" },
     { name = "fastapi", extras = ["all"] },


### PR DESCRIPTION
Fixes
* #1587 

Requires:
* DiamondLightSource/daq-config-server#193

Link to dodal PR (if required): #N/A


(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Hyperion honours the `gda.mx.hyperion.xrc.use_roi_mode` property in `domain.properties` for Xray centring. For rotations behaviour is unchanged and uses the full frame.

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
