### PR TITLE
fix: handle blueapi connection failure in supervisor (closes #1688)

### DIFF
--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -62,7 +62,14 @@ def main():
             client_config = _load_config_from_yaml(Path(args.client_config))
             supervisor_config = _load_config_from_yaml(Path(args.supervisor_config))
             context = BlueskyContext(configuration=supervisor_config)
-            plan_runner = SupervisorRunner(context, client_config, args.dev_mode)
+            try:
+                plan_runner = SupervisorRunner(context, client_config, args.dev_mode)
+            except ConnectionRefusedError:
+                LOGGER.exception("Failed to connect to blueapi, retrying...")
+                # Retry once after a short delay
+                from time import sleep
+                sleep(5)
+                plan_runner = SupervisorRunner(context, client_config, args.dev_mode)
             server_port = HyperionConstants.SUPERVISOR_PORT
     create_server_for_udc(plan_runner, server_port)
     _register_sigterm_handler(plan_runner)


### PR DESCRIPTION
## What
When Hyperion starts in supervisor mode but blueapi is not yet available, the `SupervisorRunner` constructor raises a `ConnectionRefusedError`. This exception propagates unhandled, causing the entire supervisor process to exit.

## Fix
Wrap the `SupervisorRunner` instantiation in a try/except block that catches `ConnectionRefusedError`, logs the error, waits briefly, and retries once. This prevents an abrupt exit and gives blueapi time to start.

Closes #1688