### PR TITLE
Remove flask from mx bluesky

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ dependencies = [
     "caproto",
     "fastapi[all]",
     "uvicorn",
-    # TODO remove flask
-    "flask-restful",
     "jupyterlab",
     "matplotlib",
     "nexgen >= 0.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "annotated_types",
     "caproto",
     "fastapi[all]",
+    "uvicorn",
+    # TODO remove flask
     "flask-restful",
     "jupyterlab",
     "matplotlib",

--- a/src/mx_bluesky/hyperion/plan_runner_api.py
+++ b/src/mx_bluesky/hyperion/plan_runner_api.py
@@ -1,10 +1,14 @@
+from typing import Annotated
+
 import uvicorn
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
 from mx_bluesky.common.utils.log import LOGGER
 from mx_bluesky.hyperion.plan_runner import PlanRunner
 
 app = FastAPI()
+
+_plan_runner: PlanRunner
 
 
 # Ignore this function for code coverage as there is no way to shut down
@@ -13,54 +17,29 @@ def create_server_for_udc(
     runner: PlanRunner, port: int
 ) -> uvicorn.Server:  # pragma: no cover
     # register resources with the app via instantiation
-    StatusResource(runner)
-    CallbackLiveness(runner)
+    global _plan_runner
+    _plan_runner = runner
 
     """Create a minimal API for Hyperion UDC mode"""
     config = uvicorn.Config("mx_bluesky.hyperion.plan_runner_api:app", port=port)
     server = uvicorn.Server(config)
     server.run()
-    # app = create_app_for_udc(runner)
-    #
-    # flask_thread = Thread(
-    #     target=app.run,
-    #     kwargs={"host": "0.0.0.0", "port": port},
-    #     daemon=True,
-    # )
-    # flask_thread.start()
+
     LOGGER.info(f"Hyperion now listening on {port}")
     return server
 
 
-# def create_app_for_udc(runner: PlanRunner):
-#     app = Flask(__name__)
-#     api = Api(app)
-#     api.add_resource(StatusResource, "/status", resource_class_args=[runner])
-#     api.add_resource(CallbackLiveness, "/callbackPing", resource_class_args=[runner])
-#     return app
+def plan_runner() -> PlanRunner:
+    return _plan_runner
 
 
-class StatusResource:
-    """Status endpoint, used by k8s healthcheck probe"""
-
-    def __init__(self, runner: PlanRunner):
-        super().__init__()
-        self._runner = runner
-
-    @app.get("/status")
-    async def get(self):
-        status = self._runner.current_status
-        return {"status": status.value}
+@app.get("/status")
+async def get_status(runner: Annotated[PlanRunner, Depends(plan_runner)]):
+    status = runner.current_status
+    return {"status": status.value}
 
 
-class CallbackLiveness:
-    """Called periodically by the external callbacks to indicate that they are still running"""
-
-    def __init__(self, runner: PlanRunner):
-        super().__init__()
-        self._runner = runner
-
-    @app.get("/callbackPing")
-    async def get(self):
-        LOGGER.debug("External callback ping received.")
-        self._runner.reset_callback_watchdog_timer()
+@app.get("/callbackPing")
+async def get_callback_ping(runner: Annotated[PlanRunner, Depends(plan_runner)]):
+    LOGGER.debug("External callback ping received.")
+    runner.reset_callback_watchdog_timer()

--- a/src/mx_bluesky/hyperion/plan_runner_api.py
+++ b/src/mx_bluesky/hyperion/plan_runner_api.py
@@ -1,55 +1,66 @@
-from threading import Thread
-
-from flask import Flask
-from flask_restful import Api, Resource
+import uvicorn
+from fastapi import FastAPI
 
 from mx_bluesky.common.utils.log import LOGGER
 from mx_bluesky.hyperion.plan_runner import PlanRunner
 
+app = FastAPI()
+
 
 # Ignore this function for code coverage as there is no way to shut down
 # a server once it is started.
-def create_server_for_udc(runner: PlanRunner, port: int) -> Thread:  # pragma: no cover
+def create_server_for_udc(
+    runner: PlanRunner, port: int
+) -> uvicorn.Server:  # pragma: no cover
+    # register resources with the app via instantiation
+    StatusResource(runner)
+    CallbackLiveness(runner)
+
     """Create a minimal API for Hyperion UDC mode"""
-    app = create_app_for_udc(runner)
-
-    flask_thread = Thread(
-        target=app.run,
-        kwargs={"host": "0.0.0.0", "port": port},
-        daemon=True,
-    )
-    flask_thread.start()
+    config = uvicorn.Config("mx_bluesky.hyperion.plan_runner_api:app", port=port)
+    server = uvicorn.Server(config)
+    server.run()
+    # app = create_app_for_udc(runner)
+    #
+    # flask_thread = Thread(
+    #     target=app.run,
+    #     kwargs={"host": "0.0.0.0", "port": port},
+    #     daemon=True,
+    # )
+    # flask_thread.start()
     LOGGER.info(f"Hyperion now listening on {port}")
-    return flask_thread
+    return server
 
 
-def create_app_for_udc(runner: PlanRunner):
-    app = Flask(__name__)
-    api = Api(app)
-    api.add_resource(StatusResource, "/status", resource_class_args=[runner])
-    api.add_resource(CallbackLiveness, "/callbackPing", resource_class_args=[runner])
-    return app
+# def create_app_for_udc(runner: PlanRunner):
+#     app = Flask(__name__)
+#     api = Api(app)
+#     api.add_resource(StatusResource, "/status", resource_class_args=[runner])
+#     api.add_resource(CallbackLiveness, "/callbackPing", resource_class_args=[runner])
+#     return app
 
 
-class StatusResource(Resource):
+class StatusResource:
     """Status endpoint, used by k8s healthcheck probe"""
 
     def __init__(self, runner: PlanRunner):
         super().__init__()
         self._runner = runner
 
-    def get(self):
+    @app.get("/status")
+    async def get(self):
         status = self._runner.current_status
         return {"status": status.value}
 
 
-class CallbackLiveness(Resource):
+class CallbackLiveness:
     """Called periodically by the external callbacks to indicate that they are still running"""
 
     def __init__(self, runner: PlanRunner):
         super().__init__()
         self._runner = runner
 
-    def get(self):
+    @app.get("/callbackPing")
+    async def get(self):
         LOGGER.debug("External callback ping received.")
         self._runner.reset_callback_watchdog_timer()

--- a/tests/unit_tests/hyperion/test_plan_runner_api.py
+++ b/tests/unit_tests/hyperion/test_plan_runner_api.py
@@ -1,42 +1,41 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
-from flask.testing import FlaskClient
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from mx_bluesky.common.parameters.constants import Status
 from mx_bluesky.hyperion.in_process_runner import InProcessRunner
-from mx_bluesky.hyperion.plan_runner_api import (
-    create_app_for_udc,
-)
+from mx_bluesky.hyperion.plan_runner_api import app
 
 
 @pytest.fixture()
 def mock_runner():
-    return MagicMock(spec=InProcessRunner)
+    runner = MagicMock(spec=InProcessRunner)
+    with patch("mx_bluesky.hyperion.plan_runner_api._plan_runner", runner, create=True):
+        yield runner
 
 
 @pytest.fixture()
 def app_under_test(mock_runner):
-    app = create_app_for_udc(mock_runner)
     yield app
 
 
 @pytest.fixture()
-def client(app_under_test: Flask) -> FlaskClient:
-    return app_under_test.test_client()
+def client(app_under_test: FastAPI) -> TestClient:
+    return TestClient(app_under_test)
 
 
 def test_plan_runner_api_fetch_status(app_under_test, client, mock_runner):
     mock_runner.current_status = Status.BUSY
     response = client.get("/status")
     assert response.status_code == 200
-    assert response.content_type == "application/json"
-    assert response.json["status"] == Status.BUSY.value
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.json()["status"] == Status.BUSY.value
 
 
 def test_plan_runner_api_callback_liveness(app_under_test, client, mock_runner):
     response = client.get("/callbackPing")
     mock_runner.reset_callback_watchdog_timer.assert_called_once()
     assert response.status_code == 200
-    assert response.content_type == "application/json"
+    assert response.headers["Content-Type"] == "application/json"

--- a/uv.lock
+++ b/uv.lock
@@ -108,15 +108,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aniso8601"
-version = "10.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/52179c4e3f1978d3d9a285f98c706642522750ef343e9738286130423730/aniso8601-10.0.1.tar.gz", hash = "sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845", size = 47190, upload-time = "2025-04-18T17:29:42.995Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/75/e0e10dc7ed1408c28e03a6cb2d7a407f99320eb953f229d008a7a6d05546/aniso8601-10.0.1-py2.py3-none-any.whl", hash = "sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e", size = 52848, upload-time = "2025-04-18T17:29:41.492Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -336,15 +327,6 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-
-[[package]]
-name = "blinker"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -1029,38 +1011,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
-]
-
-[[package]]
-name = "flask"
-version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "blinker", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "itsdangerous", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jinja2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "markupsafe", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "werkzeug", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
-]
-
-[[package]]
-name = "flask-restful"
-version = "0.3.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aniso8601", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flask", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pytz", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "six", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/ce/a0a133db616ea47f78a41e15c4c68b9f08cab3df31eb960f61899200a119/Flask-RESTful-0.3.10.tar.gz", hash = "sha256:fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37", size = 110453, upload-time = "2023-05-21T03:58:55.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/7b/f0b45f0df7d2978e5ae51804bb5939b7897b2ace24306009da0cc34d8d1f/Flask_RESTful-0.3.10-py2.py3-none-any.whl", hash = "sha256:1cf93c535172f112e080b0d4503a8d15f93a48c88bdd36dd87269bdaf405051b", size = 26217, upload-time = "2023-05-21T03:58:54.004Z" },
 ]
 
 [[package]]
@@ -2059,7 +2009,6 @@ dependencies = [
     { name = "deepdiff", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "dls-dodal", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", extra = ["all"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flask-restful", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "jupyterlab", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "matplotlib", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "mysql-connector-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2078,6 +2027,7 @@ dependencies = [
     { name = "scanspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "semver", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -2123,7 +2073,6 @@ requires-dist = [
     { name = "deepdiff" },
     { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=main" },
     { name = "fastapi", extras = ["all"] },
-    { name = "flask-restful" },
     { name = "jupyterlab" },
     { name = "matplotlib" },
     { name = "mysql-connector-python", specifier = "==9.5.0" },
@@ -2142,6 +2091,7 @@ requires-dist = [
     { name = "scanspec" },
     { name = "scipy" },
     { name = "semver" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata.requires-dev]
@@ -3416,15 +3366,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2026.1.post1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4521,18 +4462,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
     { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "werkzeug"
-version = "3.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This removes the dependency on `flask` from mx-bluesky in favour of uvicorn / fastAPI, which are already indirect dependencies via `blueapi`.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Tests pass

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
