### PR TITLE
1756 nexus generates wrong omega multipin

### DIFF
--- a/src/mx_bluesky/common/parameters/rotation.py
+++ b/src/mx_bluesky/common/parameters/rotation.py
@@ -120,7 +120,8 @@ class SingleRotationScan(
             start=self.omega_start_deg,
             stop=(
                 self.omega_start_deg
-                + (self.scan_width_deg - self.rotation_increment_deg)
+                + self.rotation_direction.multiplier
+                * (self.scan_width_deg - self.rotation_increment_deg)
             ),
             num=self.num_images,
         )

--- a/tests/system_tests/hyperion/external_interaction/test_baton_handler_soak.py
+++ b/tests/system_tests/hyperion/external_interaction/test_baton_handler_soak.py
@@ -67,9 +67,6 @@ def patch_ensure_connected():
         yield p
 
 
-@pytest.mark.skip(
-    reason="Waiting for https://github.com/bluesky/ophyd-async/pull/1222 to make it into a stable release"
-)
 @pytest.mark.parametrize(
     "i, patch_setup_devices",
     [[i, True] for i in range(1, 101)],

--- a/tests/system_tests/hyperion/external_interaction/test_nexgen.py
+++ b/tests/system_tests/hyperion/external_interaction/test_nexgen.py
@@ -58,11 +58,14 @@ def test_params(tmp_path, config_client, request):
             "ins_8_5_expected_output.txt",
             RotationDirection.POSITIVE,
         ),
-        (
+        pytest.param(
             "tests/test_data/nexus_files/rotation",
             "ins_8_5",
             "ins_8_5_expected_output.txt",
             RotationDirection.NEGATIVE,
+            marks=pytest.mark.skip(
+                reason="https://github.com/DiamondLightSource/mx-bluesky/issues/1794"
+            ),
         ),
         (
             "tests/test_data/nexus_files/rotation_unicode_metafile",

--- a/tests/system_tests/hyperion/external_interaction/test_nexgen.py
+++ b/tests/system_tests/hyperion/external_interaction/test_nexgen.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import bluesky.preprocessors as bpp
 import pytest
+from dodal.devices.zebra.zebra import RotationDirection
 
 from mx_bluesky.common.experiment_plans.inner_plans.read_hardware import (
     standard_read_hardware_during_collection,
@@ -28,7 +29,7 @@ DOCKER = environ.get("DOCKER", "docker")
 
 
 @pytest.fixture
-def test_params(tmp_path, config_client):
+def test_params(tmp_path, config_client, request):
     param_dict = raw_params_from_file(
         "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json",
         tmp_path,
@@ -41,23 +42,36 @@ def test_params(tmp_path, config_client):
     params.y_start_um = 0
     params.z_start_um = 0
     params.exposure_time_s = 0.004
+    params.rotation_direction = request.param
+    params.omega_start_deg = (
+        0 if params.rotation_direction == RotationDirection.POSITIVE else 360
+    )
     return params
 
 
 @pytest.mark.parametrize(
-    "test_data_directory, prefix, reference_file",
+    "test_data_directory, prefix, reference_file, test_params",
     [
         (
             "tests/test_data/nexus_files/rotation",
             "ins_8_5",
             "ins_8_5_expected_output.txt",
+            RotationDirection.POSITIVE,
+        ),
+        (
+            "tests/test_data/nexus_files/rotation",
+            "ins_8_5",
+            "ins_8_5_expected_output.txt",
+            RotationDirection.NEGATIVE,
         ),
         (
             "tests/test_data/nexus_files/rotation_unicode_metafile",
             "ins_8_5",
             "ins_8_5_expected_output.txt",
+            RotationDirection.POSITIVE,
         ),
     ],
+    indirect=["test_params"],
 )
 @patch(
     "mx_bluesky.common.external_interaction.nexus.nexus_utils.time.time",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -5,10 +5,7 @@
     "detector_distance_mm": 100.0,
     "demand_energy_ev": 100,
     "exposure_time_s": 0.1,
-    "omega_starts_deg": [
-        0,
-        90
-    ],
+    "omega_start_deg": 0.0,
     "file_name": "file_name",
     "scan_width_deg": 180.0,
     "rotation_axis": "omega",

--- a/tests/unit_tests/common/parameters/test_rotation.py
+++ b/tests/unit_tests/common/parameters/test_rotation.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mx_bluesky.common.parameters.rotation import SingleRotationScan
+
+from ...conftest import raw_params_from_file
+
+
+@pytest.mark.parametrize(
+    "omega_start_deg, rotation_direction, rotation_increment_deg, scan_width_deg, expected_omegas",
+    [
+        [0, "Positive", 0.25, 0.5, [0.0, 0.25]],
+        [0, "Negative", 0.25, 0.5, [0.0, -0.25]],
+    ],
+)
+def test_single_rotation_scan_scan_points(
+    omega_start_deg: float,
+    rotation_direction: str,
+    rotation_increment_deg: float,
+    scan_width_deg: float,
+    expected_omegas: list[float],
+    tmp_path: Path,
+):
+    params = raw_params_from_file(
+        "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json",
+        tmp_path,
+    )
+    params |= {
+        "omega_start_deg": omega_start_deg,
+        "rotation_direction": rotation_direction,
+        "rotation_increment_deg": rotation_increment_deg,
+        "scan_width_deg": scan_width_deg,
+    }
+    rotation_scan = SingleRotationScan(**params)
+    assert np.all(rotation_scan.scan_points["omega"] == np.array(expected_omegas))

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -1445,12 +1445,18 @@ def test_full_multi_rotation_plan_nexus_files_written_correctly(
             expected_omega_starts = np.linspace(
                 scan.omega_start_deg,
                 scan.omega_start_deg
-                + ((scan.num_images - 1) * multi_params.rotation_increment_deg),
+                + (
+                    (scan.num_images - 1)
+                    * multi_params.rotation_increment_deg
+                    * scan.rotation_direction.multiplier
+                ),
                 scan.num_images,
             )
             assert np.allclose(omega, expected_omega_starts)
             expected_omega_ends = (
-                expected_omega_starts + multi_params.rotation_increment_deg
+                expected_omega_starts
+                + multi_params.rotation_increment_deg
+                * scan.rotation_direction.multiplier
             )
             assert np.allclose(omega_end, expected_omega_ends)
             assert isinstance(

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -1442,17 +1442,18 @@ def test_full_multi_rotation_plan_nexus_files_written_correctly(
             )
             omega_end = omega_end[:]
             assert len(omega) == scan.num_images
+            omega_delta_deg = (
+                (scan.num_images - 1)  # length of the fence not the number of posts
+                * multi_params.rotation_increment_deg
+                * scan.rotation_direction.multiplier
+            )
             expected_omega_starts = np.linspace(
                 scan.omega_start_deg,
-                scan.omega_start_deg
-                + (
-                    (scan.num_images - 1)
-                    * multi_params.rotation_increment_deg
-                    * scan.rotation_direction.multiplier
-                ),
+                scan.omega_start_deg + omega_delta_deg,
                 scan.num_images,
             )
             assert np.allclose(omega, expected_omega_starts)
+            # ends are just the starts offset by a constant
             expected_omega_ends = (
                 expected_omega_starts
                 + multi_params.rotation_increment_deg

--- a/tests/unit_tests/hyperion/external_interaction/test_write_rotation_nexus.py
+++ b/tests/unit_tests/hyperion/external_interaction/test_write_rotation_nexus.py
@@ -9,6 +9,7 @@ import h5py
 import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
+from dodal.devices.zebra.zebra import RotationDirection
 from h5py import Dataset, ExternalLink, Group
 
 from mx_bluesky.common.experiment_plans.inner_plans.read_hardware import (
@@ -114,13 +115,18 @@ def apply_metafile_mapping(exceptions: dict, mapping: dict):
             exceptions[key] = mapping_value
 
 
+@pytest.mark.parametrize(
+    "direction", [RotationDirection.POSITIVE, RotationDirection.NEGATIVE]
+)
 @pytest.mark.timeout(2)
 def test_rotation_scan_nexus_output_compared_to_existing_full_compare(
     test_params: SingleRotationScan,
     tmpdir,
     fake_create_rotation_devices: RotationScanComposite,
     run_engine: RunEngine,
+    direction: RotationDirection,
 ):
+    test_params.rotation_direction = direction
     test_params.chi_start_deg = 0
     test_params.phi_start_deg = 0
     run_number = test_params.detector_params.run_number
@@ -195,14 +201,17 @@ def test_rotation_scan_nexus_output_compared_to_existing_full_compare(
             "sample": {
                 "beam": {"incident_wavelength": np.isclose},
                 "transformations": {
-                    "_missing": {"omega_end"},
-                    "_ignore": {"omega"},
-                    "omega_increment_set": 0.1,
-                    "omega_end": lambda a, b: np.all(np.isclose(a, b, atol=1e-03)),
+                    "omega_increment_set": 0.1 * direction.multiplier,
+                    "omega": lambda a, b: np.all(
+                        np.isclose(a, b[:] * direction.multiplier, atol=1e-03)
+                    ),
+                    "omega_end": lambda a, b: np.all(
+                        np.isclose(a, b[:] * direction.multiplier, atol=1e-03)
+                    ),
                 },
                 "sample_omega": {
                     "_ignore": {"omega_end", "omega"},
-                    "omega_increment_set": 0.1,
+                    "omega_increment_set": 0.1 * direction.multiplier,
                 },
                 "sample_x": {"sam_x": np.isclose},
                 "sample_y": {"sam_y": np.isclose},
@@ -226,9 +235,14 @@ def test_rotation_scan_nexus_output_compared_to_existing_full_compare(
         h5py.File(nexus_filename, "r") as hyperion_nexus,
     ):
         apply_metafile_mapping(exceptions, dectris_device_mapping(meta_filename))
-        _compare_actual_and_expected_nexus_output(
-            hyperion_nexus, example_nexus, exceptions
-        )
+        try:
+            _compare_actual_and_expected_nexus_output(
+                hyperion_nexus, example_nexus, exceptions
+            )
+        except Exception as e:
+            raise AssertionError(
+                f"Comparison failed between expected={example_nexus_path} and actual={nexus_filename}:"
+            ) from e
 
 
 @pytest.mark.timeout(2)
@@ -270,7 +284,8 @@ def test_rotation_scan_nexus_output_compared_to_existing_file(
         hyperion_omega: np.ndarray = np.array(
             hyperion_nexus["/entry/data/omega"][:]  # type: ignore
         )
-        example_omega: np.ndarray = example_nexus["/entry/data/omega"][:]  # type: ignore
+        # parameter file rotation direction is Negative
+        example_omega: np.ndarray = example_nexus["/entry/data/omega"][:] * -1  # type: ignore
         assert np.allclose(hyperion_omega, example_omega)
 
         assert isinstance(

--- a/uv.lock
+++ b/uv.lock
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.4.dev10+gf19cb4af3"
-source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#f19cb4af338e7abbf18ce26fe97d4f29bbfa40e1" }
+version = "2.5.5.dev1+gb4b38f1e0"
+source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#b4b38f1e0cf480faeb29d67695440c45a148f169" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
Fixes

* #1756 

Note: system tests are currently skipped (it is currently not certain whether changes to imginfo are required or whether the warnings will be fixed at some point in future), imginfo raises warnings due to it not liking decreasing omega.

The fix should now result in the `rotation_direction` parameter in the hyperion request being applied to the omega values in the generated nexus files instead of them always increasing.

(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Nexus files are generated with correct omega metadata in forwards and backwards directions
2. ~System tests pass (when above `imginfo` fix is applied)~

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
