### PR TITLE
Update import for beam_centre device for i04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.uv]
 # Restrict lockfile to a sane subset of platforms
 environments = ["sys_platform == 'linux' and platform_machine == 'x86_64'"]
-constraint-dependencies = [
-    "starlette>=1.1.0"
-]
+constraint-dependencies = ["starlette>=1.1.0"]
 
 [project]
 name = "mx-bluesky"
@@ -59,7 +57,7 @@ dependencies = [
     "ophyd >= 1.10.5",
     "ophyd-async >= 0.17a4",
     "bluesky >= 1.14.6",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@684bc381d9ea5a924ed1ab4a444e71524765602f",
 ]
 
 

--- a/src/mx_bluesky/beamlines/i04/oav_centering_plans/oav_imaging.py
+++ b/src/mx_bluesky/beamlines/i04/oav_centering_plans/oav_imaging.py
@@ -7,9 +7,9 @@ from bluesky.utils import MsgGenerator
 from dodal.common import inject
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.beamlines.i04.beam_centre import CentreEllipseMethod
 from dodal.devices.beamlines.i04.max_pixel import MaxPixel
 from dodal.devices.mx_phase1.beamstop import Beamstop, BeamstopPositions
+from dodal.devices.oav.beam_centre.beam_centre import CentreEllipseMethod
 from dodal.devices.oav.oav_detector import OAV, ZoomControllerWithBeamCentres
 from dodal.devices.robot import BartRobot, PinMounted
 from dodal.devices.scintillator import InOut, Scintillator

--- a/tests/unit_tests/beamlines/i04/test_oav_imaging.py
+++ b/tests/unit_tests/beamlines/i04/test_oav_imaging.py
@@ -6,9 +6,9 @@ from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.beamlines.i04.beam_centre import CentreEllipseMethod
 from dodal.devices.beamlines.i04.max_pixel import MaxPixel
 from dodal.devices.mx_phase1.beamstop import Beamstop, BeamstopPositions
+from dodal.devices.oav.beam_centre.beam_centre import CentreEllipseMethod
 from dodal.devices.oav.oav_detector import OAV, ZoomControllerWithBeamCentres
 from dodal.devices.robot import BartRobot, PinMounted
 from dodal.devices.scintillator import InOut, Scintillator

--- a/uv.lock
+++ b/uv.lock
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.2.dev6+gb3d163a0a"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#b3d163a0ac223ca0876945a29bf7b33a2b7f82f7" }
+version = "2.5.2.dev22+g684bc381d"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=684bc381d9ea5a924ed1ab4a444e71524765602f#684bc381d9ea5a924ed1ab4a444e71524765602f" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2121,7 +2121,7 @@ requires-dist = [
     { name = "caproto" },
     { name = "daq-config-server", specifier = ">=1.3.7" },
     { name = "deepdiff" },
-    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=main" },
+    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal.git?rev=684bc381d9ea5a924ed1ab4a444e71524765602f" },
     { name = "fastapi", extras = ["all"] },
     { name = "flask-restful" },
     { name = "jupyterlab" },
@@ -2685,7 +2685,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.2"
+version = "0.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2699,9 +2699,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/d9/bc09637a5caff453a205fa3c26474f497964618b72074413a6315d36725b/ophyd_async-0.19.2.tar.gz", hash = "sha256:138dcd5ac2ccc30194c9d74525aefb291b8a0be2ef3468a60e294f0fcea5495a", size = 588686, upload-time = "2026-06-16T15:31:31.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/20/1241051befc05c21c958206611f9ed058d81b8e8f92e3acf9f9d6936f2fc/ophyd_async-0.19.3.tar.gz", hash = "sha256:9cb76a8a08794a26c619a0420012e7248542501d036f16f3314221869e989984", size = 595679, upload-time = "2026-06-29T15:21:37.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/36/96ac313cc51e147556e80d2388ca7c55672d13c06cb87353d8d607125284/ophyd_async-0.19.2-py3-none-any.whl", hash = "sha256:2cdd5ce876ce00246d043c581b1bb4074984822a879a330637a3188ace8e1f3e", size = 228241, upload-time = "2026-06-16T15:31:29.546Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/76ac5e485f6405fc0f1dbbd1c98b7c1137d4aa5c1e49ea9e69bbd8d22ae1/ophyd_async-0.19.3-py3-none-any.whl", hash = "sha256:ef6201edb52e5a54008d57cad1808626aa6493ba4a8fd015e08d14bcffbb697a", size = 232796, upload-time = "2026-06-29T15:21:36.46Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
[Dodal 1942](https://github.com/DiamondLightSource/dodal/pull/1942) will move the `CentreEllipseMethod` device to a more common location so other beamlines can use it. This PR updates the import to i04


### Instructions to reviewer on how to test:

1. Check all imports have been updated

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
