### PR TITLE
Derive x, y step sizes from box_size_um

### DIFF
--- a/src/mx_bluesky/beamlines/i02_1/i02_1_gridscan_plan.py
+++ b/src/mx_bluesky/beamlines/i02_1/i02_1_gridscan_plan.py
@@ -161,9 +161,7 @@ class ExternalGridScanParams(BaseModel):
     detector_distance_mm: float
     sample_id: int
 
-    # GDA branch needs to update for these params
-    x_step_size_um: PositiveFloat
-    y_step_sizes_um: list[PositiveFloat]
+    box_size_um: PositiveFloat
     omega_start_deg: int
 
 
@@ -195,8 +193,8 @@ def get_internal_params(
         z_starts_um=[params.z_start_um],
         x_steps=params.x_steps,
         y_steps=[params.y_steps],
-        x_step_size_um=params.x_step_size_um,
-        y_step_sizes_um=params.y_step_sizes_um,
+        x_step_size_um=params.box_size_um,
+        y_step_sizes_um=[params.box_size_um],
     )
     return fgs_params, grid_scan_params
 

--- a/src/mx_bluesky/beamlines/i02_1/parameters.py
+++ b/src/mx_bluesky/beamlines/i02_1/parameters.py
@@ -24,7 +24,5 @@ class I02_1FgsParams(DiffractionExperimentWithSample):  # noqa: N801
 
     # Overrides of default values in the superclass
     exposure_time_s: float = Field(default=GridscanParamConstants.EXPOSURE_TIME_S)
-    ispyb_experiment_type: IspybExperimentType = Field(
-        default=IspybExperimentType.GRIDSCAN_3D
-    )
+    ispyb_experiment_type: IspybExperimentType = Field(default=IspybExperimentType.SAD)
     selected_aperture: ApertureValue | None = Field(default=ApertureValue.SMALL)

--- a/tests/unit_tests/beamlines/i02_1/conftest.py
+++ b/tests/unit_tests/beamlines/i02_1/conftest.py
@@ -2,7 +2,10 @@ import pytest
 from dodal.beamlines import i02_1
 
 from mx_bluesky.beamlines.i02_1.parameters import I02_1FgsParams
-from mx_bluesky.common.parameters.components import get_param_version
+from mx_bluesky.common.parameters.components import (
+    IspybExperimentType,
+    get_param_version,
+)
 from mx_bluesky.common.parameters.gridscan import GridScanParams
 
 
@@ -22,6 +25,7 @@ def fgs_params_two_d(tmp_path) -> I02_1FgsParams:
         upper_left_x=0,
         upper_left_y=0,
         detector_distance_mm=100,
+        ispyb_experiment_type=IspybExperimentType.SAD,
     )
 
 
@@ -31,7 +35,8 @@ def grid_scan_params():
         x_start_um=0,
         y_starts_um=[0],
         z_starts_um=[0],
-        y_step_sizes_um=[10],
+        x_step_size_um=20,
+        y_step_sizes_um=[20],
         omega_starts_deg=[0],
         x_steps=5,
         y_steps=[3],

--- a/tests/unit_tests/beamlines/i02_1/test_i02_1_gridscan_plan.py
+++ b/tests/unit_tests/beamlines/i02_1/test_i02_1_gridscan_plan.py
@@ -66,8 +66,7 @@ def entry_params(tmp_path) -> ExternalGridScanParams:
         upper_left_y=2,
         detector_distance_mm=100,
         sample_id=0,
-        x_step_size_um=20,
-        y_step_sizes_um=[10],
+        box_size_um=20,
         omega_start_deg=10,
     )
 
@@ -157,9 +156,6 @@ def test_i02_1_flyscan_xray_centre_in_re(
     new=MagicMock(),
 )
 @patch(
-    "mx_bluesky.beamlines.i02_1.i02_1_gridscan_plan.get_internal_params",
-)
-@patch(
     "mx_bluesky.beamlines.i02_1.i02_1_gridscan_plan.construct_i02_1_specific_features",
 )
 @patch(
@@ -168,7 +164,6 @@ def test_i02_1_flyscan_xray_centre_in_re(
 def test_ispyb_activated_correct_params(
     mock_store_ispyb: MagicMock,
     mock_create_features: MagicMock,
-    mock_get_internal_params: MagicMock,
     run_engine: RunEngine,
     fgs_params_two_d: I02_1FgsParams,
     grid_scan_params: GridScanParams,
@@ -176,7 +171,6 @@ def test_ispyb_activated_correct_params(
     entry_params: ExternalGridScanParams,
 ):
     mock_ispyb = MagicMock()
-    mock_get_internal_params.return_value = fgs_params_two_d, grid_scan_params
 
     mock_store_ispyb.return_value = mock_ispyb
     expected_features = construct_i02_1_specific_features(
@@ -187,6 +181,7 @@ def test_ispyb_activated_correct_params(
     mock_create_features.return_value = expected_features
 
     run_engine(i02_1_gridscan_plan(entry_params, fgs_composite))
+
     expected_group_info = populate_data_collection_group(fgs_params_two_d)
     expected_group_info.comments = f"Diffraction grid scan of {grid_scan_params.x_steps} by {grid_scan_params.y_steps[0]}.Zocalo processing took 0.00 s."
     expected_detector_params = create_detector_params_for_grid_scan(fgs_params_two_d)


### PR DESCRIPTION
Part 3 of fix for
 *  #1765

Requires:
  * #1787 
  * #1786
  * DiamondLightSource/dodal#2112

The vmxm blueapi gridscan plan now accepts `box_size_um` and maps this to the gridscan x, y step sizes

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
