### PR TITLE
Ophyd async reserved name fix, daq-config-server update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795
-    "ophyd-async == 0.19.3",
+    "ophyd-async == 0.19.4",
     "bluesky >= 1.14.6",
     "dls-dodal >= 2.5.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795
-    "ophyd-async == 0.19.4",
+    "ophyd-async == 0.20.1",
     "bluesky >= 1.14.6",
     "dls-dodal >= 2.5.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,12 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server >= 1.3.7",
+    "daq-config-server >= 1.5.1",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
-    # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795
-    "ophyd-async == 0.20.1",
+    "ophyd-async >= 0.20.1",
     "bluesky >= 1.14.6",
-    "dls-dodal >= 2.5.3",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal@main",
 ]
 
 

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -5,7 +5,7 @@ from sys import argv
 
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.core import BlueskyContext
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.common.beamlines.beamline_utils import set_config_client
 
 from mx_bluesky.common.external_interaction import alerting
@@ -50,7 +50,7 @@ def initialise_globals(args: HyperionArgs):
 
 def initialise_config_server():
     config_client_url = os.getenv("CONFIG_SERVER_URL", DEFAULT_CONFIG_SERVER_ENDPOINT)
-    client = ConfigClient(config_client_url)
+    client = ConfigClient.from_url(config_client_url)
     set_config_client(client)
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -14,7 +14,7 @@ from bluesky.callbacks import CallbackBase
 from bluesky.callbacks.zmq import Proxy, RemoteDispatcher
 from bluesky_stomp.messaging import StompClient
 from bluesky_stomp.models import Broker
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.common.beamlines.beamline_parameters import CONFIG_SERVER_URL_ENV_VAR
 from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.log import LOGGER as DODAL_LOGGER
@@ -159,7 +159,7 @@ def create_config_client() -> ConfigClient:
         raise ValueError(
             f"{CONFIG_SERVER_URL_ENV_VAR} must be specified to run external callbacks."
         )
-    return ConfigClient(config_server_url)
+    return ConfigClient.from_url(config_server_url)
 
 
 def log_info(msg, *args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ from ophyd_async.core import (
     completed_status,
     get_mock_put,
     init_devices,
+    set_mock_attr,
     set_mock_value,
 )
 from ophyd_async.epics.core import epics_signal_rw
@@ -366,9 +367,13 @@ def test_three_d_grid_params(tmp_path, patch_beamline_env_variable):
 @pytest.fixture
 def eiger():
     eiger = i03.eiger.build(mock=True)
-    eiger.stage = MagicMock(side_effect=lambda: completed_status())
-    eiger.do_arm.set = MagicMock(side_effect=lambda _: completed_status())
-    eiger.unstage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(eiger, "stage", MagicMock(side_effect=lambda: completed_status()))  # type: ignore
+    set_mock_attr(
+        eiger.do_arm,  # type: ignore
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
+    set_mock_attr(eiger, "unstage", MagicMock(side_effect=lambda: completed_status()))  # type: ignore
     return eiger
 
 
@@ -475,7 +480,9 @@ def ophyd_pin_tip_detection():
 def transfocator():
     with init_devices(mock=True):
         transfocator = Transfocator("", "")
-    transfocator.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(
+        transfocator, "set", MagicMock(side_effect=lambda _: completed_status())
+    )
     return transfocator
 
 
@@ -491,7 +498,7 @@ def robot():
             set_mock_value(robot.current_puck, val.puck)
             set_mock_value(robot.sample_id, await robot.next_sample_id.get_value())
 
-    robot.set = MagicMock(side_effect=fake_load)
+    set_mock_attr(robot, "set", MagicMock(side_effect=fake_load))
     return robot
 
 
@@ -516,7 +523,7 @@ def attenuator():
     async def fake_attenuator_set(val):
         set_mock_value(attenuator.actual_transmission, val)
 
-    attenuator.set = MagicMock(side_effect=fake_attenuator_set)
+    set_mock_attr(attenuator, "set", MagicMock(side_effect=fake_attenuator_set))
 
     yield attenuator
 
@@ -549,7 +556,7 @@ def xbpm_feedback(
     baton: Baton,  # Ensure baton is cached with mock configuration
 ):
     xbpm = i03.xbpm_feedback.build(connect_immediately=True, mock=True)
-    xbpm.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(xbpm, "trigger", MagicMock(side_effect=lambda: completed_status()))
     yield xbpm
 
 
@@ -597,9 +604,9 @@ def lower_gonio(
 def mirror_voltages():
     voltages = i03.mirror_voltages.build(connect_immediately=True, mock=True)
     for vc in voltages.vertical_voltages.values():
-        vc.set = MagicMock(side_effect=lambda _: completed_status())
+        set_mock_attr(vc, "set", MagicMock(side_effect=lambda _: completed_status()))
     for vc in voltages.horizontal_voltages.values():
-        vc.set = MagicMock(side_effect=lambda _: completed_status())
+        set_mock_attr(vc, "set", MagicMock(side_effect=lambda _: completed_status()))
     yield voltages
 
 
@@ -734,8 +741,8 @@ def fake_create_devices(
 ):
     mock_omega_sets = MagicMock(side_effect=lambda _: completed_status())
 
-    smargon.omega.velocity.set = mock_omega_sets
-    smargon.omega.set = mock_omega_sets
+    set_mock_attr(smargon.omega.velocity, "set", mock_omega_sets)
+    set_mock_attr(smargon.omega, "set", mock_omega_sets)
 
     devices = {
         "beamstop": beamstop_phase1,
@@ -752,8 +759,8 @@ def fake_create_devices(
 @pytest.fixture
 def zocalo():
     zoc = i03.zocalo.build(connect_immediately=True, mock=True)
-    zoc.stage = MagicMock(side_effect=lambda: completed_status())
-    zoc.unstage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(zoc, "stage", MagicMock(side_effect=lambda: completed_status()))
+    set_mock_attr(zoc, "unstage", MagicMock(side_effect=lambda: completed_status()))
     return zoc
 
 
@@ -768,7 +775,7 @@ async def enum_attenuator() -> EnumFilterAttenuator:
     async def fake_attenuator_set(val):
         set_mock_value(attenuator.actual_transmission, val)
 
-    attenuator.set = MagicMock(side_effect=fake_attenuator_set)
+    set_mock_attr(attenuator, "set", MagicMock(side_effect=fake_attenuator_set))
     return attenuator
 
 
@@ -839,8 +846,8 @@ async def async_status_done():
 
 
 def mock_gridscan_kickoff_complete(gridscan: FastGridScanCommon):
-    gridscan.kickoff = MagicMock(return_value=async_status_done)
-    gridscan.complete = MagicMock(return_value=async_status_done)
+    set_mock_attr(gridscan, "kickoff", MagicMock(return_value=async_status_done))
+    set_mock_attr(gridscan, "complete", MagicMock(return_value=async_status_done))
 
 
 @pytest.fixture
@@ -858,8 +865,8 @@ def panda_fast_grid_scan():
         set_mock_value(scan.status, 0)
         return completed_status()
 
-    with patch.object(scan, "complete", side_effect=mock_complete):
-        yield scan
+    set_mock_attr(scan, "complete", MagicMock(side_effect=mock_complete))
+    return scan
 
 
 @pytest.fixture
@@ -902,7 +909,11 @@ async def hyperion_flyscan_xrc_composite(
         beamsize=beamsize,
     )
 
-    fake_composite.eiger.stage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        fake_composite.eiger,  # type: ignore
+        "stage",
+        MagicMock(side_effect=lambda: completed_status()),
+    )
     # unstage should be mocked on a per-test basis because several rely on unstage
     fake_composite.eiger.set_detector_parameters(hyperion_fgs_params.detector_params)
     fake_composite.eiger.stop_odin_when_all_frames_collected = MagicMock()
@@ -921,8 +932,10 @@ async def hyperion_flyscan_xrc_composite(
     async def mock_complete(result):
         await fake_composite.zocalo._put_results([result], {"dcid": 0, "dcgid": 0})
 
-    fake_composite.zocalo.trigger = MagicMock(
-        side_effect=partial(mock_complete, test_result)
+    set_mock_attr(
+        fake_composite.zocalo,
+        "trigger",
+        MagicMock(side_effect=partial(mock_complete, test_result)),
     )  # type: ignore
     fake_composite.zocalo.timeout_s = 3
     set_mock_value(fake_composite.gonio.x.max_velocity, 10)
@@ -1107,12 +1120,10 @@ def pin_tip_detection_with_found_pin(ophyd_pin_tip_detection: PinTipDetection):
         set_mock_value(ophyd_pin_tip_detection.triggered_top_edge, top_edge_array)  # type: ignore
         set_mock_value(ophyd_pin_tip_detection.triggered_bottom_edge, bottom_edge_array)  # type: ignore
 
-    with patch.object(
-        ophyd_pin_tip_detection,
-        "trigger",
-        side_effect=set_good_position,
-    ):
-        yield ophyd_pin_tip_detection
+    set_mock_attr(
+        ophyd_pin_tip_detection, "trigger", MagicMock(side_effect=set_good_position)
+    )
+    return ophyd_pin_tip_detection
 
 
 # Prevent pytest from catching exceptions when debugging in vscode so that break on

--- a/tests/system_tests/common/daq_config_server/test_daq_config_server.py
+++ b/tests/system_tests/common/daq_config_server/test_daq_config_server.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.feature_settings.hyperion_feature_settings import (
     HyperionFeatureSettings,
 )

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -39,6 +39,7 @@ from dodal.devices.zebra.zebra_controlled_shutter import MXZebraShutter
 from ophyd_async.core import (
     AsyncStatus,
     completed_status,
+    set_mock_attr,
     set_mock_value,
 )
 from PIL import Image
@@ -245,11 +246,15 @@ def oav_for_system_test(
         with Image.open(next_oav_system_test_image()) as image:
             await self.post_processing(image)
 
-    oav.snapshot.trigger = MagicMock(
-        side_effect=partial(trigger_with_test_image, oav.snapshot)
+    set_mock_attr(
+        oav.snapshot,
+        "trigger",
+        MagicMock(side_effect=partial(trigger_with_test_image, oav.snapshot)),
     )
-    oav.grid_snapshot.trigger = MagicMock(
-        side_effect=partial(trigger_with_test_image, oav.grid_snapshot)
+    set_mock_attr(
+        oav.grid_snapshot,
+        "trigger",
+        MagicMock(side_effect=partial(trigger_with_test_image, oav.grid_snapshot)),
     )
 
     empty_response = AsyncMock(spec=ClientResponse)
@@ -365,7 +370,7 @@ def system_tests_rotation_devices(
     beamsize: BeamsizeBase,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
-    undulator.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(undulator, "set", MagicMock(side_effect=lambda _: completed_status()))
     return RotationScanComposite(
         attenuator=attenuator,
         backlight=backlight,

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientResponse
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.beamlines import i03
 from dodal.common.beamlines.beamline_utils import clear_config_client
 from dodal.devices.aperturescatterguard import (

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -42,6 +42,7 @@ from ophyd_async.core import (
     AsyncStatus,
     callback_on_mock_put,
     completed_status,
+    set_mock_attr,
     set_mock_value,
 )
 from sqlalchemy import create_engine
@@ -376,20 +377,26 @@ def fgs_composite_for_fake_zocalo(
     set_mock_value(
         hyperion_flyscan_xrc_composite.aperture_scatterguard.aperture.z.user_setpoint, 2
     )
-    hyperion_flyscan_xrc_composite.eiger.unstage = MagicMock(
-        side_effect=lambda: completed_status()
-    )  # type: ignore
-    hyperion_flyscan_xrc_composite.gonio.stub_offsets.set = MagicMock(
-        side_effect=lambda _: completed_status()
-    )  # type: ignore
+    set_mock_attr(
+        hyperion_flyscan_xrc_composite.eiger,  # type: ignore
+        "unstage",
+        MagicMock(side_effect=lambda: completed_status()),
+    )
+    set_mock_attr(
+        hyperion_flyscan_xrc_composite.gonio.stub_offsets,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
     callback_on_mock_put(
         hyperion_flyscan_xrc_composite.zebra_fast_grid_scan.run_cmd,
         lambda *args, **kwargs: set_mock_value(
             hyperion_flyscan_xrc_composite.zebra_fast_grid_scan.status, 1
         ),
     )
-    hyperion_flyscan_xrc_composite.zebra_fast_grid_scan.complete = MagicMock(
-        side_effect=lambda: completed_status()
+    set_mock_attr(
+        hyperion_flyscan_xrc_composite.zebra_fast_grid_scan,
+        "complete",
+        MagicMock(side_effect=lambda: completed_status()),
     )
     hyperion_flyscan_xrc_composite.zocalo = zocalo_for_fake_zocalo
     return hyperion_flyscan_xrc_composite
@@ -452,8 +459,10 @@ def composite_for_rotation_scan(
     beamsize: BeamsizeBase,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
-    oav_for_system_test.zoom_controller.level.describe = AsyncMock(
-        return_value={"level": {"choices": ["1.0x", "5.0x", "7.5x"]}}
+    set_mock_attr(
+        oav_for_system_test.zoom_controller.level,
+        "describe",
+        AsyncMock(return_value={"level": {"choices": ["1.0x", "5.0x", "7.5x"]}}),
     )
 
     fake_create_rotation_devices = RotationScanComposite(

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -17,7 +17,12 @@ from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.synchrotron import SynchrotronMode
 from ispyb.sqlalchemy import BLSample
-from ophyd_async.core import AsyncStatus, completed_status, set_mock_value
+from ophyd_async.core import (
+    AsyncStatus,
+    completed_status,
+    set_mock_attr,
+    set_mock_value,
+)
 
 from mx_bluesky.common.experiment_plans.common_grid_detect_then_xray_centre_plan import (
     detect_grid_and_do_gridscan,
@@ -557,8 +562,10 @@ def test_load_centre_collect_updates_bl_sample_status_robot_load_fail(
     run_engine.subscribe(robot_load_cb)
     run_engine.subscribe(sample_handling_cb)
 
-    load_centre_collect_composite.robot.set = MagicMock(
-        side_effect=TimeoutError("Simulated timeout")
+    set_mock_attr(
+        load_centre_collect_composite.robot,
+        "set",
+        MagicMock(side_effect=TimeoutError("Simulated timeout")),
     )
     with pytest.raises(TimeoutError, match="Simulated timeout"):
         run_engine(

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.devices.beamsize.beamsize import BeamsizeBase
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection

--- a/tests/unit_tests/beamlines/aithre_lasershaping/test_robot_load.py
+++ b/tests/unit_tests/beamlines/aithre_lasershaping/test_robot_load.py
@@ -6,7 +6,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
-from ophyd_async.core import set_mock_value
+from ophyd_async.core import set_mock_attr, set_mock_value
 
 from mx_bluesky.beamlines.aithre_lasershaping.experiment_plans.robot_load_plan import (
     RobotLoadComposite,
@@ -123,11 +123,11 @@ async def test_when_take_snapshots_called_then_filename_and_directory_set_and_de
 
     mock_datetime.now.return_value.strftime.return_value = "TIME"
 
-    oav.snapshot.trigger = MagicMock(side_effect=oav.snapshot.trigger)
+    set_mock_attr(oav.snapshot, "trigger", MagicMock(side_effect=oav.snapshot.trigger))
 
     run_engine(_take_robot_snapshots(oav, Path(test_directory)))
 
-    oav.snapshot.trigger.assert_called_once()
+    oav.snapshot.trigger.assert_called_once()  # type: ignore
     assert await oav.snapshot.filename.get_value() == "TIME_oav-snapshot_after_load"
     assert await oav.snapshot.directory.get_value() == test_directory
 

--- a/tests/unit_tests/beamlines/i04/test_oav_imaging.py
+++ b/tests/unit_tests/beamlines/i04/test_oav_imaging.py
@@ -23,6 +23,7 @@ from ophyd_async.core import (
     completed_status,
     get_mock_put,
     init_devices,
+    set_mock_attr,
     set_mock_value,
 )
 
@@ -319,7 +320,7 @@ async def max_pixel() -> MaxPixel:
     async with init_devices(mock=True):
         max_pixel = MaxPixel("TEST: MAX_PIXEL", "max_pixel")
 
-    max_pixel.trigger = MagicMock(return_value=completed_status())
+    set_mock_attr(max_pixel, "trigger", MagicMock(return_value=completed_status()))
     return max_pixel
 
 
@@ -378,7 +379,7 @@ def test_given_transmission_change_always_high_then_raises_stop_iteration(
     async def fake_attenuator_set(val):
         set_mock_value(attenuator.actual_transmission, val + 0.2)
 
-    attenuator.set = MagicMock(side_effect=fake_attenuator_set)
+    set_mock_attr(attenuator, "set", MagicMock(side_effect=fake_attenuator_set))
 
     with pytest.raises(RuntimeError) as e:
         run_engine(
@@ -655,7 +656,7 @@ async def centre_ellipse() -> CentreEllipseMethod:
     async with init_devices(mock=True):
         centre_ellipse = CentreEllipseMethod("", name="centre_ellipse")
 
-    centre_ellipse.trigger = MagicMock(return_value=completed_status())
+    set_mock_attr(centre_ellipse, "trigger", MagicMock(return_value=completed_status()))
     return centre_ellipse
 
 

--- a/tests/unit_tests/beamlines/i04/test_thawing.py
+++ b/tests/unit_tests/beamlines/i04/test_thawing.py
@@ -18,6 +18,7 @@ from ophyd_async.core import (
     completed_status,
     get_mock_put,
     init_devices,
+    set_mock_attr,
     set_mock_value,
 )
 
@@ -81,9 +82,9 @@ def thawer() -> Thawer:
 @patch("dodal.devices.beamlines.i04.murko_results.StrictRedis")
 async def murko_results(mock_strict_redis: MagicMock) -> MurkoResultsDevice:
     murko_results = MurkoResultsDevice(name="murko_results")
-    murko_results.trigger = MagicMock(side_effect=completed_status)
-    murko_results.stage = MagicMock(side_effect=completed_status)
-    murko_results.unstage = MagicMock(side_effect=completed_status)
+    set_mock_attr(murko_results, "trigger", MagicMock(side_effect=completed_status))
+    set_mock_attr(murko_results, "stage", MagicMock(side_effect=completed_status))
+    set_mock_attr(murko_results, "unstage", MagicMock(side_effect=completed_status))
     return murko_results
 
 
@@ -100,8 +101,8 @@ async def oav_forwarder(oav_full_screen: OAV, oav_roi: OAV) -> OAVToRedisForward
         )
     set_mock_value(oav_forwarder.uuid, "test")
 
-    oav_forwarder.kickoff = MagicMock(side_effect=completed_status)
-    oav_forwarder.complete = MagicMock(side_effect=completed_status)
+    set_mock_attr(oav_forwarder, "kickoff", MagicMock(side_effect=completed_status))
+    set_mock_attr(oav_forwarder, "complete", MagicMock(side_effect=completed_status))
     return oav_forwarder
 
 
@@ -113,9 +114,9 @@ def robot() -> BartRobot:
 def _do_thaw_and_confirm_cleanup(
     move_mock: MagicMock, smargon: Smargon, thawer: Thawer, do_thaw_func
 ):
-    smargon.omega.set = move_mock
+    set_mock_attr(smargon.omega, "set", move_mock)
     set_mock_value(smargon.omega.velocity, initial_velocity := 10)
-    smargon.omega.set = move_mock
+    set_mock_attr(smargon.omega, "set", move_mock)
     do_thaw_func()
     last_thawer_call = get_mock_put(thawer._control).call_args_list[-1]
     assert last_thawer_call == call(OnOff.OFF)
@@ -486,7 +487,7 @@ def test_thaw_and_murko_centre_will_centre_based_on_murko_results_after_both_rot
         return completed_status()
 
     mock_trigger = MagicMock()
-    murko_results.trigger = mock_trigger
+    set_mock_attr(murko_results, "trigger", mock_trigger)
 
     def side_effect():
         return fake_trigger(mock_trigger.call_count)

--- a/tests/unit_tests/beamlines/i04/test_thawing.py
+++ b/tests/unit_tests/beamlines/i04/test_thawing.py
@@ -6,8 +6,9 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import assert_message_and_return_remaining
 from bluesky.utils import MsgGenerator
-from daq_config_server import ConfigClient
+from daq_config_server.testing import PathToMockDataDict
 from dodal.beamlines import i04
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.beamlines.i04.murko_results import MurkoResultsDevice
 from dodal.devices.oav.oav_detector import OAV, OAVBeamCentrePV, OAVConfig
 from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder, Source
@@ -39,8 +40,10 @@ class MyError(Exception):
 
 
 @pytest.fixture
-async def oav_full_screen(test_config_files: ConfigFilesForTests) -> OAV:
-    oav_config = OAVConfig(test_config_files["zoom_params_file"], ConfigClient(""))
+async def oav_full_screen(
+    mock_daq_config: PathToMockDataDict, test_config_files: ConfigFilesForTests
+) -> OAV:
+    oav_config = OAVConfig(test_config_files["zoom_params_file"], get_config_client())
     async with init_devices(mock=True, connect=True):
         oav = OAVBeamCentrePV(
             "", config=oav_config, name="oav_full_screen", mjpeg_prefix="XTAL"
@@ -52,8 +55,10 @@ async def oav_full_screen(test_config_files: ConfigFilesForTests) -> OAV:
 
 
 @pytest.fixture
-async def oav_roi(test_config_files: ConfigFilesForTests) -> OAV:
-    oav_config = OAVConfig(test_config_files["zoom_params_file"], ConfigClient(""))
+async def oav_roi(
+    mock_daq_config: PathToMockDataDict, test_config_files: ConfigFilesForTests
+) -> OAV:
+    oav_config = OAVConfig(test_config_files["zoom_params_file"], get_config_client())
     async with init_devices(mock=True, connect=True):
         oav = OAVBeamCentrePV("", config=oav_config, name="oav")
     set_mock_value(oav.zoom_controller.level, "5.0x")

--- a/tests/unit_tests/beamlines/i24/jungfrau_commissioning/experiment_plans/test_do_darks.py
+++ b/tests/unit_tests/beamlines/i24/jungfrau_commissioning/experiment_plans/test_do_darks.py
@@ -10,7 +10,7 @@ from bluesky.simulators import RunEngineSimulator, assert_message_and_return_rem
 from dodal.devices.beamlines.i24.commissioning_jungfrau import (
     CommissioningJungfrauDetector,
 )
-from ophyd_async.core import completed_status
+from ophyd_async.core import completed_status, set_mock_attr
 from ophyd_async.fastcs.jungfrau import (
     AcquisitionType,
     GainMode,
@@ -120,14 +120,16 @@ async def test_pedestals_unstage_and_wait_on_exception(
     jungfrau: CommissioningJungfrauDetector,
     run_engine: RunEngine,
 ):
-    jungfrau.prepare = MagicMock(side_effect=FakeError)
-    jungfrau.unstage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(jungfrau, "prepare", MagicMock(side_effect=FakeError))
+    set_mock_attr(
+        jungfrau, "unstage", MagicMock(side_effect=lambda: completed_status())
+    )
 
     with pytest.raises(FakeError):
         run_engine(do_pedestal_darks(0.001, 2, 2, jungfrau=jungfrau))
 
-    assert jungfrau.unstage.call_count == 1
-    assert [c == call(jungfrau, wait=True) for c in jungfrau.unstage.call_args_list]
+    assert jungfrau.unstage.call_count == 1  # type: ignore
+    assert [c == call(jungfrau, wait=True) for c in jungfrau.unstage.call_args_list]  # type: ignore
 
 
 @patch(
@@ -154,9 +156,11 @@ def test_do_darks_stops_if_exception_after_stage(
     run_engine: RunEngine, jungfrau: CommissioningJungfrauDetector
 ):
     mock_stop = AsyncMock()
-    jungfrau.detector.acquisition_stop.trigger = mock_stop
-    jungfrau.complete = MagicMock(
-        side_effect=FailedStatus("Simulated completion exception")
+    set_mock_attr(jungfrau.detector.acquisition_stop, "trigger", mock_stop)
+    set_mock_attr(
+        jungfrau,
+        "complete",
+        MagicMock(side_effect=FailedStatus("Simulated completion exception")),
     )
 
     with pytest.raises(FailedStatus):
@@ -172,13 +176,15 @@ def test_do_darks_stops_if_exception_after_stage(
 def test_do_non_pedestal_darks_unstages_jf_on_exception(
     run_engine: RunEngine, jungfrau: CommissioningJungfrauDetector
 ):
-    jungfrau.stage = MagicMock(side_effect=lambda: completed_status())
-    jungfrau.unstage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(jungfrau, "stage", MagicMock(side_effect=lambda: completed_status()))
+    set_mock_attr(
+        jungfrau, "unstage", MagicMock(side_effect=lambda: completed_status())
+    )
     with pytest.raises(FakeError):
         run_engine(do_non_pedestal_darks(GainMode.DYNAMIC, jungfrau=jungfrau))
 
-    assert jungfrau.unstage.call_count == 1
-    assert [c == call(jungfrau, wait=True) for c in jungfrau.unstage.call_args_list]
+    assert jungfrau.unstage.call_count == 1  # type: ignore
+    assert [c == call(jungfrau, wait=True) for c in jungfrau.unstage.call_args_list]  # type: ignore
 
 
 @patch(
@@ -191,11 +197,13 @@ def test_do_non_pedestal_darks_triggers_correct_plans(
 ):
     gain_mode = GainMode.FORCE_SWITCH_G1
     parent_mock = MagicMock()
-    jungfrau.unstage = MagicMock(side_effect=lambda: completed_status())
-    jungfrau.stage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        jungfrau, "unstage", MagicMock(side_effect=lambda: completed_status())
+    )
+    set_mock_attr(jungfrau, "stage", MagicMock(side_effect=lambda: completed_status()))
     parent_mock.attach_mock(mock_fly_jf, "mock_fly_jf")
-    parent_mock.attach_mock(jungfrau.unstage, "jungfrau_unstage")
-    parent_mock.attach_mock(jungfrau.stage, "jungfrau_stage")
+    parent_mock.attach_mock(jungfrau.unstage, "jungfrau_unstage")  # type: ignore
+    parent_mock.attach_mock(jungfrau.stage, "jungfrau_stage")  # type: ignore
     expected_trigger_info = create_jungfrau_internal_triggering_info(1000, 0.001)
     run_engine(do_non_pedestal_darks(gain_mode=gain_mode, jungfrau=jungfrau))
 

--- a/tests/unit_tests/beamlines/i24/jungfrau_commissioning/plan_stubs/test_plan_utils.py
+++ b/tests/unit_tests/beamlines/i24/jungfrau_commissioning/plan_stubs/test_plan_utils.py
@@ -12,6 +12,7 @@ from dodal.devices.beamlines.i24.commissioning_jungfrau import (
 from ophyd_async.core import (
     TriggerInfo,
     completed_status,
+    set_mock_attr,
     set_mock_value,
 )
 from ophyd_async.fastcs.jungfrau import GainMode
@@ -27,7 +28,7 @@ async def test_fly_jungfrau(
 ):
     set_mock_value(jungfrau.writer.frame_counter, 10)
     mock_stop = AsyncMock()
-    jungfrau.detector.acquisition_stop.trigger = mock_stop
+    set_mock_attr(jungfrau.detector.acquisition_stop, "trigger", mock_stop)
 
     filename = "test"
 
@@ -62,18 +63,24 @@ async def test_fly_jungfrau_does_read_plan_after_prepare(
     run_engine: RunEngine, jungfrau: CommissioningJungfrauDetector
 ):
     mock_stop = AsyncMock()
-    jungfrau.detector.acquisition_stop.trigger = mock_stop
+    set_mock_attr(jungfrau.detector.acquisition_stop, "trigger", mock_stop)
 
     read_hardware = MagicMock()
 
     filename = "test"
-    jungfrau.prepare = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(
+        jungfrau, "prepare", MagicMock(side_effect=lambda _: completed_status())
+    )
 
     parent_mock = MagicMock()
-    parent_mock.attach_mock(jungfrau.prepare, "jungfrau_prepare")
+    parent_mock.attach_mock(jungfrau.prepare, "jungfrau_prepare")  # type: ignore
     parent_mock.attach_mock(read_hardware, "read_hardware")
-    jungfrau.kickoff = MagicMock(side_effect=lambda: completed_status())
-    jungfrau.complete = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        jungfrau, "kickoff", MagicMock(side_effect=lambda: completed_status())
+    )
+    set_mock_attr(
+        jungfrau, "complete", MagicMock(side_effect=lambda: completed_status())
+    )
     test_trigger_info = TriggerInfo(livetime=1e-3, collections_per_event=5)
 
     @run_decorator(md={"detector_file_template": filename})

--- a/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_do_darks.py
+++ b/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_do_darks.py
@@ -8,7 +8,7 @@ from bluesky.run_engine import RunEngine
 from dodal.devices.beamlines.i24.commissioning_jungfrau import (
     CommissioningJungfrauDetector,
 )
-from ophyd_async.core import completed_status
+from ophyd_async.core import completed_status, set_mock_attr
 from ophyd_async.fastcs.jungfrau import (
     AcquisitionType,
     GainMode,
@@ -105,12 +105,14 @@ class FakeError(Exception): ...
 async def test_jungfrau_unstage_on_error(
     jungfrau: CommissioningJungfrauDetector, run_engine: RunEngine
 ):
-    jungfrau.stage = MagicMock(side_effect=FakeError)
-    jungfrau.unstage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(jungfrau, "stage", MagicMock(side_effect=FakeError))
+    set_mock_attr(
+        jungfrau, "unstage", MagicMock(side_effect=lambda: completed_status())
+    )
 
     def test_plan():
         yield from do_pedestal_darks(0.001, 2, 2, jungfrau=jungfrau)
 
     with pytest.raises(FakeError):
         run_engine(test_plan())
-    assert jungfrau.unstage.call_count == 1
+    assert jungfrau.unstage.call_count == 1  # type: ignore

--- a/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_rotation_scan.py
+++ b/tests/unit_tests/beamlines/i24/jungfrau_commissioning/test_rotation_scan.py
@@ -8,7 +8,7 @@ from dodal.devices.beamlines.i24.aperture import AperturePositions
 from dodal.devices.beamlines.i24.beamstop import BeamstopPositions
 from dodal.devices.beamlines.i24.dual_backlight import BacklightPositions
 from dodal.devices.hutch_shutter import ShutterState
-from ophyd_async.core import completed_status, set_mock_value
+from ophyd_async.core import completed_status, set_mock_attr, set_mock_value
 
 from mx_bluesky.beamlines.i24.jungfrau_commissioning.experiment_plans.rotation_scan_plan import (
     DEFAULT_DETECTOR_DISTANCE_MM,
@@ -83,7 +83,7 @@ async def test_rotation_scan_plan_in_re(
     )
     # Test correct functions are called, but don't test bluesky messages
     mock_zebra_arm = MagicMock(side_effect=lambda _: completed_status())
-    rotation_composite.zebra.pc.arm.set = mock_zebra_arm
+    set_mock_attr(rotation_composite.zebra.pc.arm, "set", mock_zebra_arm)
     params = get_good_single_rotation_params(tmp_path)
     mock_calc_motion_profile.return_value = calculate_motion_profile(params, 1, 1)
     run_engine(single_rotation_plan(rotation_composite, params))
@@ -254,8 +254,10 @@ def test_cleanup_plan(
     rotation_composite: RotationScanComposite,
     run_engine: RunEngine,
 ):
-    rotation_composite.jungfrau.unstage = MagicMock(
-        side_effect=lambda: completed_status()
+    set_mock_attr(
+        rotation_composite.jungfrau,
+        "unstage",
+        MagicMock(side_effect=lambda: completed_status()),
     )
     run_engine(
         _cleanup_plan(
@@ -265,4 +267,4 @@ def test_cleanup_plan(
         )
     )
     mock_tidy_zebra.assert_called_once()
-    rotation_composite.jungfrau.unstage.assert_called_once()
+    rotation_composite.jungfrau.unstage.assert_called_once()  # type: ignore

--- a/tests/unit_tests/beamlines/i24/serial/extruder/test_extruder_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/extruder/test_extruder_collect.py
@@ -5,7 +5,7 @@ import pytest
 from dodal.beamlines.i24 import I24_ZEBRA_MAPPING
 from dodal.devices.zebra.zebra import ArmDemand, Zebra
 from ophyd.sim import NullStatus
-from ophyd_async.core import get_mock_put, init_devices, set_mock_value
+from ophyd_async.core import get_mock_put, init_devices, set_mock_attr, set_mock_value
 
 from mx_bluesky.beamlines.i24.serial.extruder.i24ssx_extruder_collect_py3v2 import (
     collection_complete_plan,
@@ -36,7 +36,7 @@ def zebra():
         set_mock_value(i24_zebra.pc.arm.armed, demand.value)
         return NullStatus()
 
-    i24_zebra.pc.arm.set = MagicMock(side_effect=mock_side)
+    set_mock_attr(i24_zebra.pc.arm, "set", MagicMock(side_effect=mock_side))
     return i24_zebra
 
 

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
@@ -11,6 +11,7 @@ from ophyd_async.core import (
     callback_on_mock_put,
     completed_status,
     get_mock_put,
+    set_mock_attr,
     set_mock_value,
 )
 
@@ -295,10 +296,14 @@ def test_finish_i24(
 def test_run_aborted_plan(
     mock_log: MagicMock, fake_dcid: MagicMock, pmac: PMAC, run_engine
 ):
-    pmac.abort_program.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        pmac.abort_program,  # type: ignore
+        "trigger",
+        MagicMock(side_effect=lambda: completed_status()),
+    )
     run_engine(run_aborted_plan(pmac, fake_dcid, Exception("Test Exception")))
 
-    pmac.abort_program.trigger.assert_called_once()
+    pmac.abort_program.trigger.assert_called_once()  # type: ignore
     fake_dcid.collection_complete.assert_called_once_with(ANY, aborted=True)
     assert "Test Exception" in mock_log.warning.mock_calls[0].args[0]
 
@@ -345,8 +350,12 @@ async def test_tidy_up_after_collection_plan(
 
 
 async def test_kick_off_and_complete_collection(pmac, dummy_params_with_pp, run_engine):
-    pmac.run_program.kickoff = MagicMock(side_effect=lambda: completed_status())
-    pmac.run_program.complete = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        pmac.run_program, "kickoff", MagicMock(side_effect=lambda: completed_status())
+    )
+    set_mock_attr(
+        pmac.run_program, "complete", MagicMock(side_effect=lambda: completed_status())
+    )
 
     async def go_high_then_low():
         set_mock_value(pmac.scanstatus, 1)

--- a/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
+++ b/tests/unit_tests/common/device_setup_plans/test_robot_load_unload.py
@@ -9,7 +9,12 @@ from dodal.devices.aperturescatterguard import ApertureScatterguard, ApertureVal
 from dodal.devices.motors import XYZStage
 from dodal.devices.robot import SAMPLE_LOCATION_EMPTY, BartRobot
 from dodal.devices.smargon import CombinedMove, Smargon, StubPosition
-from ophyd_async.core import completed_status, get_mock_put, set_mock_value
+from ophyd_async.core import (
+    completed_status,
+    get_mock_put,
+    set_mock_attr,
+    set_mock_value,
+)
 
 from mx_bluesky.common.device_setup_plans.robot_load_unload import (
     prepare_for_robot_load,
@@ -52,7 +57,9 @@ async def test_when_prepare_for_robot_load_called_then_moves_as_expected(
     smargon: Smargon,
     run_engine: RunEngine,
 ):
-    smargon.stub_offsets.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(
+        smargon.stub_offsets, "set", MagicMock(side_effect=lambda _: completed_status())
+    )
     get_mock_put(aperture_scatterguard.selected_aperture).reset_mock()
 
     set_mock_value(smargon.x.user_setpoint, 10)
@@ -258,7 +265,7 @@ def test_when_unload_plan_fails_then_error_deposited_in_ispyb(
     callback = RobotLoadISPyBCallback()
     callback.expeye = (mock_expeye := MagicMock())
     run_engine.subscribe(callback)
-    loaded_robot.set = MagicMock(side_effect=TestError("Bad Error"))
+    set_mock_attr(loaded_robot, "set", MagicMock(side_effect=TestError("Bad Error")))
 
     action_id = 1098
     mock_expeye.start_robot_action.return_value = action_id

--- a/tests/unit_tests/common/device_setup_plans/test_xbpm_feedback.py
+++ b/tests/unit_tests/common/device_setup_plans/test_xbpm_feedback.py
@@ -11,7 +11,12 @@ from dodal.devices.xbpm_feedback import Pause, XBPMFeedback
 from dodal.plans.preprocessors.verify_undulator_gap import (
     verify_undulator_gap_before_run_decorator,
 )
-from ophyd_async.core import AsyncStatus, completed_status, set_mock_value
+from ophyd_async.core import (
+    AsyncStatus,
+    completed_status,
+    set_mock_attr,
+    set_mock_value,
+)
 
 from mx_bluesky.common.device_setup_plans.xbpm_feedback import (
     unpause_xbpm_feedback_and_set_transmission_to_1,
@@ -26,8 +31,10 @@ from tests.conftest import XBPMAndTransmissionWrapperComposite
 def composite(
     xbpm_and_transmission_wrapper_composite: XBPMAndTransmissionWrapperComposite,
 ) -> XBPMAndTransmissionWrapperComposite:
-    xbpm_and_transmission_wrapper_composite.undulator.set = MagicMock(
-        side_effect=lambda _: completed_status()
+    set_mock_attr(
+        xbpm_and_transmission_wrapper_composite.undulator,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
     )
 
     return xbpm_and_transmission_wrapper_composite
@@ -37,8 +44,10 @@ async def test_xbpm_decorator_with_undulator_check_decorators(
     run_engine, composite: XBPMAndTransmissionWrapperComposite
 ):
     energy_in_kev = 11.3
-    composite.dcm.energy_in_keV.user_readback.read = MagicMock(
-        return_value={"value": {"value": energy_in_kev}}
+    set_mock_attr(
+        composite.dcm.energy_in_keV.user_readback,
+        "read",
+        MagicMock(return_value={"value": {"value": energy_in_kev}}),
     )
 
     @pause_xbpm_feedback_during_collection_at_desired_transmission_decorator(
@@ -59,7 +68,7 @@ async def test_xbpm_decorator_with_undulator_check_decorators(
     # Assert XBPM is stable
     composite.xbpm_feedback.trigger.assert_called_once()
     # Assert DCM energy is read after XBPM is stable
-    composite.dcm.energy_in_keV.user_readback.read.assert_called_once()
+    composite.dcm.energy_in_keV.user_readback.read.assert_called_once()  # type: ignore
     # Assert Undulator is finally set
     composite.undulator.set.assert_called_once()
     # Assert energy passed to the Undulator is the same as read from the DCM
@@ -102,8 +111,10 @@ async def test_given_xbpm_checks_fail_when_plan_run_with_decorator_then_plan_not
         mock()
         yield from bps.null()
 
-    composite.xbpm_feedback.trigger = MagicMock(
-        side_effect=lambda: completed_status(Exception())
+    set_mock_attr(
+        composite.xbpm_feedback,
+        "trigger",
+        MagicMock(side_effect=lambda: completed_status(Exception())),
     )
 
     with pytest.raises(FailedStatus):
@@ -146,7 +157,7 @@ def test_unpause_feedback_and_set_transmission_to_1_times_out_if_timeout_specifi
     async def wait_for_1_s():
         await asyncio.sleep(1)
 
-    xbpm_feedback.trigger = MagicMock(side_effect=wait_for_1_s)
+    set_mock_attr(xbpm_feedback, "trigger", MagicMock(side_effect=wait_for_1_s))
     with pytest.raises(TimeoutError):
         run_engine(
             unpause_xbpm_feedback_and_set_transmission_to_1(

--- a/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_flyscan_xray_centre_plan.py
@@ -22,7 +22,7 @@ from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zocalo import ZocaloStartInfo
 from ophyd.sim import NullStatus
 from ophyd.status import Status
-from ophyd_async.core import completed_status, set_mock_value
+from ophyd_async.core import completed_status, set_mock_attr, set_mock_value
 
 from mx_bluesky.common.experiment_plans.common_flyscan_xray_centre_plan import (
     BeamlineSpecificFGSFeatures,
@@ -127,21 +127,22 @@ class TestFlyscanXrayCentrePlan:
         )
         run_engine.subscribe(ispyb_callback)
 
-        error = None
-        with patch.object(fake_fgs_composite.gonio.omega, "set") as mock_set:
-            error = AssertionError("Test Exception")
-            mock_set.side_effect = FailedStatus(error)
-            with pytest.raises(FailedStatus):
-                run_engine(
-                    ispyb_activation_wrapper(
-                        common_flyscan_xray_centre(
-                            fake_fgs_composite,
-                            test_three_d_grid_params,
-                            beamline_specific,
-                        ),
+        set_mock_attr(
+            fake_fgs_composite.gonio.omega,
+            "set",
+            MagicMock(side_effect=FailedStatus(AssertionError("Test Exception"))),
+        )
+        with pytest.raises(FailedStatus):
+            run_engine(
+                ispyb_activation_wrapper(
+                    common_flyscan_xray_centre(
+                        fake_fgs_composite,
                         test_three_d_grid_params,
+                        beamline_specific,
                     ),
-                )
+                    test_three_d_grid_params,
+                ),
+            )
 
         ispyb_callback.ispyb.end_deposition.assert_called_once_with(  # type: ignore
             IspybIds(data_collection_group_id=0, data_collection_ids=(0, 0)),
@@ -212,12 +213,16 @@ class TestFlyscanXrayCentrePlan:
         test_three_d_grid_params: SpecifiedThreeDGridScan,
         fake_fgs_composite: FlyScanEssentialDevices,
     ):
-        fake_fgs_composite.eiger.unstage = MagicMock(
-            side_effect=lambda: completed_status()
+        set_mock_attr(
+            fake_fgs_composite.eiger,  # type: ignore
+            "unstage",
+            MagicMock(side_effect=lambda: completed_status()),
         )
         fgs = i03.zebra_fast_grid_scan.build(connect_immediately=True, mock=True)
         fgs.KICKOFF_TIMEOUT = 0.1
-        fgs.complete = MagicMock(side_effect=lambda: completed_status())
+        set_mock_attr(
+            fgs, "complete", MagicMock(side_effect=lambda: completed_status())
+        )
         set_mock_value(fgs.motion_program.running, 1)
 
         def test_plan():
@@ -343,8 +348,10 @@ class TestFlyscanXrayCentrePlan:
             return_value=True
         )
         fake_fgs_composite.eiger.odin.file_writer.num_captured.sim_put(1200)  # type: ignore
-        fake_fgs_composite.eiger.stage = MagicMock(
-            return_value=Status(None, None, 0, True, True)
+        set_mock_attr(
+            fake_fgs_composite.eiger,  # type: ignore
+            "stage",
+            MagicMock(return_value=Status(None, None, 0, True, True)),
         )
 
         with patch(
@@ -392,14 +399,18 @@ class TestFlyscanXrayCentrePlan:
         run_engine: RunEngine,
         beamline_specific: BeamlineSpecificFGSFeatures,
     ):
-        fake_fgs_composite.eiger.unstage = MagicMock(side_effect=completed_status)
+        set_mock_attr(
+            fake_fgs_composite.eiger,  # type: ignore
+            "unstage",
+            MagicMock(side_effect=completed_status),
+        )
         run_engine(
             run_gridscan(
                 fake_fgs_composite, test_three_d_grid_params, beamline_specific
             )
         )
         fake_fgs_composite.eiger.stage.assert_called_once()  # type: ignore
-        fake_fgs_composite.eiger.unstage.assert_called_once()
+        fake_fgs_composite.eiger.unstage.assert_called_once()  # type: ignore
 
     @patch(
         "mx_bluesky.common.experiment_plans.common_flyscan_xray_centre_plan.bps.kickoff",
@@ -436,8 +447,10 @@ class TestFlyscanXrayCentrePlan:
 
         mock_complete.side_effect = CompleteError()
 
-        fake_fgs_composite.eiger.stage = MagicMock(
-            return_value=Status(None, None, 0, True, True)
+        set_mock_attr(
+            fake_fgs_composite.eiger,  # type: ignore
+            "stage",
+            MagicMock(return_value=Status(None, None, 0, True, True)),
         )
 
         fake_fgs_composite.eiger.filewriters_finished = NullStatus()
@@ -493,7 +506,11 @@ class TestFlyscanXrayCentrePlan:
         assert isinstance(ispyb_cb.emit_cb, ZocaloCallback)
 
         mock_zocalo_trigger = ispyb_cb.emit_cb.zocalo_interactor
-        fake_fgs_composite.eiger.unstage = MagicMock(side_effect=completed_status)
+        set_mock_attr(
+            fake_fgs_composite.eiger,  # type: ignore
+            "unstage",
+            MagicMock(side_effect=completed_status),
+        )
         fake_fgs_composite.eiger.odin.file_writer.id.sim_put("test/filename")  # type: ignore
 
         x_steps, y_steps, z_steps = 10, 20, 30

--- a/tests/unit_tests/common/experiment_plans/test_common_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_grid_detect_then_xray_centre_plan.py
@@ -6,7 +6,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from bluesky.utils import Msg
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import ApertureValue
 from dodal.devices.backlight import InOut
 from dodal.devices.mx_phase1.beamstop import BeamstopPositions
@@ -170,7 +170,7 @@ def _do_detect_grid_and_gridscan_then_wait_for_backlight(
         composite,
         parameters=test_full_grid_scan_params,
         oav_params=OAVParameters(
-            ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+            get_config_client(), "xrayCentring", test_config_files["oav_config_json"]
         ),
         xrc_params_type=HyperionSpecifiedThreeDGridScan,
         construct_beamline_specific=construct_beamline_specific_xrc_features,
@@ -193,7 +193,7 @@ def test_when_full_grid_scan_run_then_parameters_sent_to_fgs_as_expected(
     construct_beamline_specific: ConstructBeamlineSpecificFeatures,
 ):
     oav_params = OAVParameters(
-        ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+        get_config_client(), "xrayCentring", test_config_files["oav_config_json"]
     )
 
     run_engine(
@@ -263,7 +263,9 @@ def test_detect_grid_and_do_gridscan_does_not_activate_ispyb_callback(
             grid_detect_xrc_devices,
             test_full_grid_scan_params,
             OAVParameters(
-                ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+                get_config_client(),
+                "xrayCentring",
+                test_config_files["oav_config_json"],
             ),
             xrc_params_type=HyperionSpecifiedThreeDGridScan,
             construct_beamline_specific=construct_beamline_specific,

--- a/tests/unit_tests/common/experiment_plans/test_grid_detection_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_grid_detection_plan.py
@@ -8,8 +8,8 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from bluesky.utils import Msg
-from daq_config_server import ConfigClient
 from dodal.beamlines import i03
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAVConfigBeamCentre
 from dodal.devices.oav.oav_parameters import OAVParameters
@@ -61,7 +61,7 @@ def fake_devices(
     params = OAVConfigBeamCentre(
         test_config_files["zoom_params_file"],
         test_config_files["display_config"],
-        ConfigClient(""),
+        get_config_client(),
     )
     oav = i03.oav.build(connect_immediately=True, mock=True, params=params)
     set_mock_value(oav.zoom_controller.level, "5.0x")
@@ -116,7 +116,7 @@ def test_grid_detection_plan_runs_and_triggers_snapshots(
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, image_save = fake_devices
 
@@ -148,7 +148,7 @@ async def test_grid_detection_plan_gives_warning_error_if_tip_not_found(
     )
 
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
 
     with pytest.raises(WarningError) as excinfo:
@@ -165,7 +165,7 @@ async def test_given_when_grid_detect_then_start_position_as_expected(
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     box_size_um = 0.2
     composite, _ = fake_devices
@@ -211,7 +211,7 @@ async def test_when_grid_detection_plan_run_then_ispyb_callback_gets_correct_val
     dummy_rotation_data_collection_group_info,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
     cb = GridDetectAndScanISPyBCallback(param_type=GenericGrid)
@@ -277,7 +277,7 @@ def test_when_grid_detection_plan_run_then_grid_detection_callback_gets_correct_
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
     box_size_um = 20
@@ -315,7 +315,7 @@ def test_when_grid_detection_plan_run_with_different_omega_order_then_grid_detec
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
 
@@ -397,7 +397,7 @@ async def test_when_detected_grid_has_odd_y_steps_then_add_a_y_step_and_shift_gr
 ):
     composite, _ = fake_devices
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     box_size_um = 20
     microns_per_pixel_y = await composite.oav.microns_per_pixel_y.get_value()

--- a/tests/unit_tests/common/experiment_plans/test_oav_snapshot_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_oav_snapshot_plan.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pydantic
 import pytest
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.areadetector.plugins.cam import ColorMode
 from dodal.devices.backlight import Backlight
@@ -75,7 +75,8 @@ def test_oav_snapshot_plan_issues_rotations_and_generates_events(
             oav_snapshot_composite,
             oav_snapshot_params,
             OAVParameters(
-                ConfigClient(""), oav_config_json=test_config_files["oav_config_json"]
+                get_config_client(),
+                oav_config_json=test_config_files["oav_config_json"],
             ),
         )
     )

--- a/tests/unit_tests/common/experiment_plans/test_pin_tip_centring.py
+++ b/tests/unit_tests/common/experiment_plans/test_pin_tip_centring.py
@@ -12,7 +12,12 @@ from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.oav.pin_image_recognition.utils import SampleLocation
 from dodal.devices.oav.utils import PinNotFoundError
 from dodal.devices.smargon import Smargon
-from ophyd_async.core import completed_status, get_mock_put, set_mock_value
+from ophyd_async.core import (
+    completed_status,
+    get_mock_put,
+    set_mock_attr,
+    set_mock_value,
+)
 from ophyd_async.epics.motor import MotorLimitsError
 
 from mx_bluesky.common.device_setup_plans.gonio import (
@@ -65,11 +70,13 @@ async def test_given_the_pin_tip_is_already_in_view_when_get_tip_into_view_then_
 ):
     set_mock_value(mock_pin_tip.triggered_tip, np.array([100, 200]))
 
-    mock_pin_tip.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        mock_pin_tip, "trigger", MagicMock(side_effect=lambda: completed_status())
+    )
 
     result = run_engine(move_pin_into_view(mock_pin_tip, smargon_with_limits))
 
-    mock_pin_tip.trigger.assert_called_once()
+    mock_pin_tip.trigger.assert_called_once()  # type: ignore
     assert await smargon_with_limits.x.user_setpoint.get_value() == 0
     assert isinstance(result, RunEngineResult)
     assert result.plan_result == (100, 200)

--- a/tests/unit_tests/common/external_interaction/callbacks/common/test_snapshot_callback.py
+++ b/tests/unit_tests/common/external_interaction/callbacks/common/test_snapshot_callback.py
@@ -12,7 +12,7 @@ from bluesky.run_engine import RunEngine
 from dodal.devices.areadetector.plugins.mjpg import MJPG
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.smargon import Smargon
-from ophyd_async.core import AsyncStatus, set_mock_value
+from ophyd_async.core import AsyncStatus, set_mock_attr, set_mock_value
 from PIL import Image
 
 from mx_bluesky.common.parameters.components import WithSnapshot
@@ -53,9 +53,15 @@ def oav_with_snapshots(oav: OAV, next_snapshot):
             # don't do full post-processing to save on slow PIL image save calls
             await mjpg._save_image(image)
 
-    oav.snapshot.trigger = MagicMock(side_effect=partial(fake_trigger, oav.snapshot))
-    oav.grid_snapshot.trigger = MagicMock(
-        side_effect=partial(fake_trigger, oav.grid_snapshot)
+    set_mock_attr(
+        oav.snapshot,
+        "trigger",
+        MagicMock(side_effect=partial(fake_trigger, oav.snapshot)),
+    )
+    set_mock_attr(
+        oav.grid_snapshot,
+        "trigger",
+        MagicMock(side_effect=partial(fake_trigger, oav.grid_snapshot)),
     )
     yield oav
 

--- a/tests/unit_tests/common/preprocessors/test_preprocessors.py
+++ b/tests/unit_tests/common/preprocessors/test_preprocessors.py
@@ -6,7 +6,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import assert_message_and_return_remaining
 from bluesky.utils import IllegalMessageSequence
-from ophyd_async.core import completed_status
+from ophyd_async.core import completed_status, set_mock_attr
 
 from mx_bluesky.common.parameters.constants import (
     PlanNameConstants,
@@ -93,8 +93,10 @@ def test_trigger_xbpm_preprocessor_wraps_one_run_only_if_no_run_specified(
     xbpm_and_transmission_wrapper_composite: XBPMAndTransmissionWrapperComposite,
     run_engine: RunEngine,
 ):
-    xbpm_and_transmission_wrapper_composite.attenuator.set = MagicMock(
-        side_effect=lambda _: completed_status()
+    set_mock_attr(
+        xbpm_and_transmission_wrapper_composite.attenuator,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
     )
     mock_set_transmission = xbpm_and_transmission_wrapper_composite.attenuator.set
 
@@ -103,7 +105,7 @@ def test_trigger_xbpm_preprocessor_wraps_one_run_only_if_no_run_specified(
     )
     @bpp.run_decorator()
     def first_plan():
-        mock_set_transmission.assert_called_once()
+        mock_set_transmission.assert_called_once()  # type: ignore
         yield from second_plan()
 
     @bpp.set_run_key_decorator(PlanNameConstants.GRID_DETECT_AND_DO_GRIDSCAN)
@@ -112,7 +114,7 @@ def test_trigger_xbpm_preprocessor_wraps_one_run_only_if_no_run_specified(
         yield from bps.null()
 
     run_engine(first_plan())
-    mock_set_transmission.assert_called_once()
+    mock_set_transmission.assert_called_once()  # type: ignore
 
 
 def assert_open_run_then_pause_xbpm_then_close_run_then_unpause(msgs):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -62,6 +62,7 @@ from ophyd_async.core import (
     PathProvider,
     completed_status,
     init_devices,
+    set_mock_attr,
     set_mock_value,
 )
 from ophyd_async.fastcs.panda import HDFPanda
@@ -304,7 +305,9 @@ def mock_zocalo_trigger(zocalo: ZocaloResults, result):
     async def mock_complete(results):
         await zocalo._put_results(results, {"dcid": 0, "dcgid": 0})
 
-    zocalo.trigger = MagicMock(side_effect=partial(mock_complete, result))
+    set_mock_attr(
+        zocalo, "trigger", MagicMock(side_effect=partial(mock_complete, result))
+    )
 
 
 def modified_store_grid_scan_mock(*args, dcids=(0, 0), dcgid=0, **kwargs):
@@ -395,7 +398,11 @@ async def fake_fgs_composite(
         synchrotron=synchrotron,
     )
 
-    fake_composite.eiger.stage = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        fake_composite.eiger,  # type: ignore
+        "stage",
+        MagicMock(side_effect=lambda: completed_status()),
+    )
     # unstage should be mocked on a per-test basis because several rely on unstage
     fake_composite.eiger.set_detector_parameters(
         test_three_d_grid_params.detector_params
@@ -417,7 +424,9 @@ async def fake_fgs_composite(
     async def mock_complete(result):
         await zocalo._put_results([result], {"dcid": 0, "dcgid": 0})
 
-    zocalo.trigger = MagicMock(side_effect=partial(mock_complete, test_result))  # type: ignore
+    set_mock_attr(
+        zocalo, "trigger", MagicMock(side_effect=partial(mock_complete, test_result))
+    )  # type: ignore
     zocalo.timeout_s = 3
     set_mock_value(fake_composite.gonio.x.max_velocity, 10)
 
@@ -671,8 +680,12 @@ def oav(test_config_files):
     set_mock_value(oav.grid_snapshot.x_size, 1024)
     set_mock_value(oav.grid_snapshot.y_size, 768)
 
-    oav.snapshot.trigger = MagicMock(side_effect=lambda: completed_status())
-    oav.grid_snapshot.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(
+        oav.snapshot, "trigger", MagicMock(side_effect=lambda: completed_status())
+    )
+    set_mock_attr(
+        oav.grid_snapshot, "trigger", MagicMock(side_effect=lambda: completed_status())
+    )
     yield oav
 
 
@@ -700,7 +713,7 @@ def fake_create_rotation_devices(
     sim_run_engine: RunEngineSimulator,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
-    undulator.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(undulator, "set", MagicMock(side_effect=lambda _: completed_status()))
     sim_run_engine.add_handler(
         "read",
         lambda msg: {

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -13,8 +13,10 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
+from daq_config_server.testing import MockServerResponse, PathToMockDataDict
 from dodal.beamlines import i03
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import (
     ApertureScatterguard,
     ApertureValue,
@@ -109,8 +111,6 @@ from mx_bluesky.hyperion.parameters.device_composites import (
 )
 from tests.conftest import TEST_BEAMLINE_PARAMETERS, raw_params_from_file
 from tests.test_data.oav import TEST_DISPLAY_CONFIG, TEST_OAV_ZOOM_LEVELS
-
-pytest_plugins = ["dodal.testing.fixtures.config_server"]
 
 i03.DAQ_CONFIGURATION_PATH = "tests/test_data/test_daq_configuration"
 
@@ -230,6 +230,22 @@ def create_gridscan_callbacks() -> tuple[
             ),
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_daq_config() -> Generator[PathToMockDataDict, None, None]:
+    mutable_dict = {}
+    mock_config_server = ConfigClient(MockServerResponse(mutable_dict))
+    with (
+        patch(
+            "dodal.common.beamlines.beamline_utils.CONFIG_CLIENT", mock_config_server
+        ),
+        patch(
+            "daq_config_server.client.ConfigClient.from_url",
+            return_value=mock_config_server,
+        ),
+    ):
+        yield mutable_dict
 
 
 @pytest.fixture(autouse=True)
@@ -661,18 +677,20 @@ def patch_config_paths(monkeypatch):
 
 
 @pytest.fixture
-def oav_parameters_for_rotation(test_config_files) -> OAVParameters:
-    return OAVParameters(
-        ConfigClient(""), oav_config_json=test_config_files["oav_config_json"]
-    )
+def oav_parameters_for_rotation(
+    mock_daq_config: PathToMockDataDict, test_config_files
+) -> OAVParameters:
+    oav_config_path = test_config_files["oav_config_json"]
+    # mock_daq_config[oav_config_path] = json.loads(oav_config_path)
+    return OAVParameters(get_config_client(), oav_config_json=oav_config_path)
 
 
 @pytest.fixture
-def oav(test_config_files):
+def oav(mock_daq_config: PathToMockDataDict, test_config_files):
     parameters = OAVConfigBeamCentre(
         test_config_files["zoom_params_file"],
         test_config_files["display_config"],
-        ConfigClient(""),
+        get_config_client(),
     )
     oav = i03.oav.build(mock=True, connect_immediately=True, params=parameters)
 

--- a/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
@@ -8,6 +8,7 @@ from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from ophyd.status import Status
+from ophyd_async.core import set_mock_attr
 from ophyd_async.sim import SimMotor
 
 from mx_bluesky.common.device_setup_plans.setup_oav import (
@@ -32,7 +33,7 @@ def test_when_set_up_oav_then_only_waits_on_oav_to_finish(
     """This test will hang if pre_centring_setup_oav waits too generally as my_waiting_device
     never finishes moving"""
     my_waiting_device = SimMotor(name="")
-    my_waiting_device.set = MagicMock(return_value=Status())
+    set_mock_attr(my_waiting_device, "set", MagicMock(return_value=Status()))
 
     def my_plan():
         yield from bps.abs_set(my_waiting_device, 10, wait=False)

--- a/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -20,7 +20,7 @@ from tests.conftest import ConfigFilesForTests
 @pytest.fixture
 def mock_parameters(test_config_files: ConfigFilesForTests):
     return OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
 
 

--- a/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from bluesky import plan_stubs as bps
 from dodal.beamlines import i03
-from ophyd_async.core import get_mock_put
+from ophyd_async.core import get_mock_put, set_mock_attr
 
 from mx_bluesky.common.device_setup_plans.utils import (
     start_preparing_data_collection_then_do_plan,
@@ -54,7 +54,7 @@ def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_retu
     beamstop_phase1, mock_eiger, null_plan, run_engine
 ):
     detector_motion = MagicMock()
-    detector_motion.z.set = MagicMock(side_effect=MyTestError())
+    set_mock_attr(detector_motion.z, "set", MagicMock(side_effect=MyTestError()))
 
     with pytest.raises(MyTestError):
         run_engine(
@@ -71,7 +71,7 @@ def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_retu
 def test_given_detector_move_fails_then_eiger_disarmed_and_correct_exception_returned(
     beamstop_phase1, mock_eiger, detector_motion, null_plan, run_engine
 ):
-    detector_motion.shutter.set = MagicMock(side_effect=MyTestError)
+    set_mock_attr(detector_motion.shutter, "set", MagicMock(side_effect=MyTestError))
 
     with pytest.raises(MyTestError):
         run_engine(

--- a/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_utils.py
@@ -54,7 +54,7 @@ def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_retu
     beamstop_phase1, mock_eiger, null_plan, run_engine
 ):
     detector_motion = MagicMock()
-    set_mock_attr(detector_motion.z, "set", MagicMock(side_effect=MyTestError()))
+    set_mock_attr(detector_motion.z, "set", MagicMock(side_effect=MyTestError))
 
     with pytest.raises(MyTestError):
         run_engine(

--- a/tests/unit_tests/hyperion/experiment_plans/conftest.py
+++ b/tests/unit_tests/hyperion/experiment_plans/conftest.py
@@ -8,7 +8,12 @@ from bluesky.utils import Msg
 from dodal.devices.beamsize.beamsize import BeamsizeBase
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zocalo import ZocaloResults
-from ophyd_async.core import AsyncStatus, completed_status, set_mock_value
+from ophyd_async.core import (
+    AsyncStatus,
+    completed_status,
+    set_mock_attr,
+    set_mock_value,
+)
 
 from mx_bluesky.common.experiment_plans.common_flyscan_xray_centre_plan import (
     BeamlineSpecificFGSFeatures,
@@ -92,7 +97,9 @@ def mock_zocalo_trigger(zocalo: ZocaloResults, result):
     async def mock_complete(results):
         await zocalo._put_results(results, {"dcid": 0, "dcgid": 0})
 
-    zocalo.trigger = MagicMock(side_effect=partial(mock_complete, result))
+    set_mock_attr(
+        zocalo, "trigger", MagicMock(side_effect=partial(mock_complete, result))
+    )
 
 
 def modified_store_grid_scan_mock(*args, dcids=(0, 0), dcgid=0, **kwargs):
@@ -179,8 +186,14 @@ def robot_load_composite(
     beamsize: BeamsizeBase,
 ) -> RobotLoadThenCentreComposite:
     set_mock_value(dcm.energy_in_keV.user_readback, 11.105)
-    smargon.stub_offsets.set = MagicMock(side_effect=lambda _: completed_status())
-    aperture_scatterguard.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(
+        smargon.stub_offsets, "set", MagicMock(side_effect=lambda _: completed_status())
+    )
+    set_mock_attr(
+        aperture_scatterguard,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
     set_mock_value(smargon.omega.max_velocity, 131)
     return RobotLoadThenCentreComposite(
         xbpm_feedback=xbpm_feedback,
@@ -248,11 +261,15 @@ def robot_load_and_energy_change_composite(
         aperture_scatterguard,
         backlight,
     )
-    composite.gonio.stub_offsets.set = MagicMock(
-        side_effect=lambda _: completed_status()
+    set_mock_attr(
+        composite.gonio.stub_offsets,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
     )
-    composite.aperture_scatterguard.set = MagicMock(
-        side_effect=lambda _: completed_status()
+    set_mock_attr(
+        composite.aperture_scatterguard,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
     )
     set_mock_value(composite.dcm.energy_in_keV.user_readback, 11.105)
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_load_centre_collect_full_plan.py
@@ -16,7 +16,7 @@ from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zebra.zebra import RotationDirection
-from ophyd_async.core import completed_status, set_mock_value
+from ophyd_async.core import completed_status, set_mock_attr, set_mock_value
 from pydantic import ValidationError
 
 from mx_bluesky.common.parameters.gridscan import SpecifiedThreeDGridScan
@@ -123,7 +123,11 @@ def composite(
 
     composite = LoadCentreCollectComposite(baton=baton, **(rlaec_args | rotation_args))
     composite.pin_tip_detection = pin_tip_detection_with_found_pin
-    composite.undulator_dcm.set = MagicMock(side_effect=lambda _: completed_status())
+    set_mock_attr(
+        composite.undulator_dcm,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
     minaxis = Location(setpoint=-2, readback=-2)
     maxaxis = Location(setpoint=2, readback=2)
     tip_x_px, tip_y_px, top_edge_array, bottom_edge_array = pin_tip_edge_data()
@@ -151,8 +155,10 @@ def composite(
         composite.pin_tip_detection.triggered_bottom_edge, bottom_edge_array
     )
     zoom_levels_list = ["1.0x", "3.0x", "5.0x", "7.5x", "10.0x"]
-    composite.oav.zoom_controller.level.describe = AsyncMock(
-        return_value={"level": {"choices": zoom_levels_list}}
+    set_mock_attr(
+        composite.oav.zoom_controller.level,
+        "describe",
+        AsyncMock(return_value={"level": {"choices": zoom_levels_list}}),
     )
     set_mock_value(composite.oav.zoom_controller.level, "1.0x")
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_optimise_attenuation_plan.py
@@ -6,7 +6,12 @@ import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
-from ophyd_async.core import AsyncStatus, completed_status, set_mock_value
+from ophyd_async.core import (
+    AsyncStatus,
+    completed_status,
+    set_mock_attr,
+    set_mock_value,
+)
 
 from mx_bluesky.common.utils.log import LOGGER
 from mx_bluesky.hyperion.experiment_plans import optimise_attenuation_plan
@@ -49,19 +54,18 @@ async def fake_composite(attenuator) -> OptimizeAttenuationComposite:
 
 @pytest.fixture
 def fake_composite_mocked_sets(fake_composite: OptimizeAttenuationComposite):
-    with (
-        patch.object(
-            fake_composite.xspress3mini,
-            "stage",
-            MagicMock(side_effect=lambda: completed_status()),
-        ),
-        patch.object(
-            fake_composite.sample_shutter,
-            "set",
-            MagicMock(side_effect=lambda _: completed_status()),
-        ),
-    ):
-        yield fake_composite
+    set_mock_attr(
+        fake_composite.xspress3mini,
+        "stage",
+        MagicMock(side_effect=lambda: completed_status()),
+    )
+    set_mock_attr(
+        fake_composite.sample_shutter,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
+
+    return fake_composite
 
 
 def test_is_deadtime_optimised_returns_true_once_direction_is_flipped_and_deadtime_goes_back_above_threshold():
@@ -307,7 +311,7 @@ def test_total_counts_gets_within_target(
         )
         return AsyncStatus(asyncio.sleep(0))
 
-    fake_composite_mocked_sets.attenuator.set = update_data
+    set_mock_attr(fake_composite_mocked_sets.attenuator, "set", update_data)
     iteration = 0
 
     run_engine(
@@ -350,9 +354,15 @@ def test_optimisation_attenuation_plan_runs_correct_functions(
     run_engine: RunEngine,
     fake_composite: OptimizeAttenuationComposite,
 ):
-    fake_composite.attenuator.set = MagicMock(side_effect=lambda _: completed_status())
-    fake_composite.xspress3mini.acquire_time.set = MagicMock(
-        side_effect=lambda _: completed_status()
+    set_mock_attr(
+        fake_composite.attenuator,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
+    )
+    set_mock_attr(
+        fake_composite.xspress3mini.acquire_time,
+        "set",
+        MagicMock(side_effect=lambda _: completed_status()),
     )
 
     run_engine(
@@ -368,6 +378,6 @@ def test_optimisation_attenuation_plan_runs_correct_functions(
     else:
         mock_total_counts_optimisation.assert_not_called()
         mock_deadtime_optimisation.assert_called_once()
-    fake_composite.attenuator.set.assert_called_once()
+    fake_composite.attenuator.set.assert_called_once()  # type: ignore
     mock_check_parameters.assert_called_once()
-    fake_composite.xspress3mini.acquire_time.set.assert_called_once()
+    fake_composite.xspress3mini.acquire_time.set.assert_called_once()  # type: ignore

--- a/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_robot_load_and_change_energy.py
@@ -10,7 +10,7 @@ from dodal.devices.backlight import InOut
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.thawer import OnOff
 from dodal.devices.webcam import Webcam
-from ophyd_async.core import completed_status, set_mock_value
+from ophyd_async.core import completed_status, set_mock_attr, set_mock_value
 
 from mx_bluesky.hyperion.experiment_plans.robot_load_and_change_energy import (
     RobotLoadAndEnergyChangeComposite,
@@ -120,7 +120,7 @@ def test_given_ispyb_callback_attached_when_robot_load_then_centre_plan_called_t
         "test_oav_snapshot",
     )
     set_mock_value(webcam.last_saved_path, "test_webcam_snapshot")
-    webcam.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(webcam, "trigger", MagicMock(side_effect=lambda: completed_status()))
     set_mock_value(robot.barcode, "BARCODE")
 
     run_engine.subscribe(RobotLoadISPyBCallback())
@@ -160,16 +160,16 @@ async def test_when_take_snapshots_called_then_filename_and_directory_set_and_de
 
     mock_datetime.now.return_value.strftime.return_value = "TIME"
 
-    oav.snapshot.trigger = MagicMock(side_effect=oav.snapshot.trigger)
-    webcam.trigger = MagicMock(side_effect=lambda: completed_status())
+    set_mock_attr(oav.snapshot, "trigger", MagicMock(side_effect=oav.snapshot.trigger))
+    set_mock_attr(webcam, "trigger", MagicMock(side_effect=lambda: completed_status()))
 
     run_engine(take_robot_snapshots(oav, webcam, Path(test_directory)))
 
-    oav.snapshot.trigger.assert_called_once()
+    oav.snapshot.trigger.assert_called_once()  # type: ignore
     assert await oav.snapshot.filename.get_value() == "TIME_oav-snapshot_after_load"
     assert await oav.snapshot.directory.get_value() == test_directory
 
-    webcam.trigger.assert_called_once()
+    webcam.trigger.assert_called_once()  # type: ignore
     assert (await webcam.filename.get_value()) == "TIME_webcam_after_load"
     assert (await webcam.directory.get_value()) == test_directory
 

--- a/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/hyperion/experiment_plans/test_rotation_scan_plan.py
@@ -26,7 +26,7 @@ from dodal.devices.thawer import OnOff
 from dodal.devices.xbpm_feedback import Pause
 from dodal.devices.zebra.zebra import RotationDirection, Zebra
 from dodal.devices.zebra.zebra_controlled_shutter import ZebraShutterControl
-from ophyd_async.core import get_mock_put, set_mock_value
+from ophyd_async.core import get_mock_put, set_mock_attr, set_mock_value
 
 from mx_bluesky.common.experiment_plans.oav_snapshot_plan import (
     OAV_SNAPSHOT_GROUP,
@@ -385,25 +385,25 @@ def test_cleanup_happens(
         side_effect=MyTestError("Experiment fails because this is a test")
     )
 
-    with patch.object(fake_create_rotation_devices.gonio.omega, "set", failing_set):
-        # check main subplan part fails
-        params = next(test_rotation_params.single_rotation_scans)
-        with pytest.raises(MyTestError):
-            run_engine(
-                rotation_scan_plan(fake_create_rotation_devices, params, motion_values)
+    set_mock_attr(fake_create_rotation_devices.gonio.omega, "set", failing_set)
+    # check main subplan part fails
+    params = next(test_rotation_params.single_rotation_scans)
+    with pytest.raises(MyTestError):
+        run_engine(
+            rotation_scan_plan(fake_create_rotation_devices, params, motion_values)
+        )
+    cleanup_plan.assert_not_called()
+    # check that failure is handled in composite plan
+    with pytest.raises(FailedStatus) as exc:
+        run_engine(
+            rotation_scan_internal(
+                fake_create_rotation_devices,
+                test_rotation_params,
+                oav_parameters_for_rotation,
             )
-        cleanup_plan.assert_not_called()
-        # check that failure is handled in composite plan
-        with pytest.raises(FailedStatus) as exc:
-            run_engine(
-                rotation_scan_internal(
-                    fake_create_rotation_devices,
-                    test_rotation_params,
-                    oav_parameters_for_rotation,
-                )
-            )
-        assert "Experiment fails because this is a test" in str(exc.value)
-        cleanup_plan.assert_called_once()
+        )
+    assert "Experiment fails because this is a test" in str(exc.value)
+    cleanup_plan.assert_called_once()
 
 
 def test_rotation_plan_reads_hardware(

--- a/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
@@ -6,11 +6,9 @@ from typing import cast
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-from daq_config_server import ConfigClient
 from daq_config_server.models.feature_settings.hyperion_feature_settings import (
     HyperionFeatureSettings,
 )
-from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.devices.zebra.zebra import RotationDirection
 from requests import ConnectionError, HTTPError, Response, Timeout
 
@@ -31,11 +29,6 @@ from mx_bluesky.hyperion.external_interaction.agamemnon import (
     create_parameters_from_agamemnon,
 )
 from mx_bluesky.hyperion.plan_runner import PlanError
-
-
-@pytest.fixture(autouse=True)
-def mock_config_client():
-    set_config_client(ConfigClient("http://localhost"))
 
 
 def set_up_agamemnon_params(

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -274,7 +274,7 @@ def test_sending_main_process_sigterm_in_udc_mode_performs_clean_prompt_shutdown
     main()
 
 
-@patch("mx_bluesky.hyperion.__main__.ConfigClient")
+@patch("mx_bluesky.hyperion.__main__.ConfigClient.from_url")
 @patch("mx_bluesky.hyperion.__main__.set_config_client")
 @patch(
     "sys.argv",
@@ -291,7 +291,7 @@ def test_sending_main_process_sigterm_in_udc_mode_performs_clean_prompt_shutdown
 )
 def test_supervisor_start_reads_config_client_url(
     mock_set_config_client: MagicMock,
-    mock_config_client_cls: MagicMock,
+    mock_from_url: MagicMock,
     mock_supervisor_mode: MagicMock,
     monkeypatch,
 ):
@@ -300,5 +300,5 @@ def test_supervisor_start_reads_config_client_url(
 
     main()
 
-    mock_config_client_cls.assert_called_once_with(test_url)
-    mock_set_config_client.assert_called_once_with(mock_config_client_cls.return_value)
+    mock_from_url.assert_called_once_with(test_url)
+    mock_set_config_client.assert_called_once_with(mock_from_url.return_value)

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ requires-dist = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "ophyd", specifier = ">=1.10.5" },
-    { name = "ophyd-async", specifier = "==0.19.3" },
+    { name = "ophyd-async", specifier = "==0.19.4" },
     { name = "pydantic" },
     { name = "pydantic-extra-types", specifier = ">=2.10.1" },
     { name = "pyepics" },
@@ -2689,7 +2689,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.3"
+version = "0.19.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2703,9 +2703,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/20/1241051befc05c21c958206611f9ed058d81b8e8f92e3acf9f9d6936f2fc/ophyd_async-0.19.3.tar.gz", hash = "sha256:9cb76a8a08794a26c619a0420012e7248542501d036f16f3314221869e989984", size = 595679, upload-time = "2026-06-29T15:21:37.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/07/22e05906c87e8cc1eb32b6753a09ad84bb382c723f332f5010f777bcf4d2/ophyd_async-0.19.4.tar.gz", hash = "sha256:f484c02487c6bcd82307db7caea42fe922cf66979680a3e6e11a1d9622e700ba", size = 643368, upload-time = "2026-07-15T15:30:01.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/2c/76ac5e485f6405fc0f1dbbd1c98b7c1137d4aa5c1e49ea9e69bbd8d22ae1/ophyd_async-0.19.3-py3-none-any.whl", hash = "sha256:ef6201edb52e5a54008d57cad1808626aa6493ba4a8fd015e08d14bcffbb697a", size = 232796, upload-time = "2026-06-29T15:21:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/27/00fd0ce52333ffdc4527e3bb3b33b3170dfb851faa9214cbdd9566bdd3f4/ophyd_async-0.19.4-py3-none-any.whl", hash = "sha256:c161709f0fa18cd5c993a630aba8f40fb35213f8e600583f1f414d0b6ce17ecd", size = 253459, upload-time = "2026-07-15T15:30:00.058Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.4.dev7+g36e3b03da"
-source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#36e3b03da324c3a567d0720e86fc86a6f67eb87d" }
+version = "2.5.4.dev8+g9c419b297"
+source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#9c419b29768b3852bf384881772989fcaea16186" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.7"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -707,9 +707,9 @@ dependencies = [
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/93/c913c56425bf937c3c6b8733ac88bdb6b03a49dd10f068215473b511f12f/daq_config_server-1.3.7.tar.gz", hash = "sha256:6dc0c0613c88198eb16cd86c84c731de97090499ebcf39ccfe9be67dad84caae", size = 233043, upload-time = "2026-06-25T10:00:58.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a2/2fc42d3231be454be244c1dd19a1e36204fe68957b275fc37775efffc9ba/daq_config_server-1.5.1.tar.gz", hash = "sha256:e7dbcd335a1ec06faa777bc0f03039c90aa067b3b71df599cb59ae7cf5fac368", size = 236115, upload-time = "2026-07-28T14:03:52.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0b/0472e9ab51f04a5fd00d477edf8567bdf320a6f245bd6414b3f208f49684/daq_config_server-1.3.7-py3-none-any.whl", hash = "sha256:ecf11b770d059248d70b3418b75701842dce398d4945e26a8a16ac5049a845c5", size = 35113, upload-time = "2026-06-25T10:00:57.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/7a8d2a4d7c35f1e384e58c559b44fa41d90878b67e1c9689831fe2a1d125/daq_config_server-1.5.1-py3-none-any.whl", hash = "sha256:3076083c3a9a007f635562654d834c8528997316e1764b4cbd46cb324e3904be", size = 35620, upload-time = "2026-07-28T14:03:51.285Z" },
 ]
 
 [[package]]
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.3"
-source = { registry = "https://pypi.org/simple" }
+version = "2.5.4.dev7+g36e3b03da"
+source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#36e3b03da324c3a567d0720e86fc86a6f67eb87d" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -833,10 +833,6 @@ dependencies = [
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scanspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "zocalo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/3c/36b192e29e1f26298f6fd1ec0f7d9c74fa12e45355fa0f404fdcc505f6ce/dls_dodal-2.5.3.tar.gz", hash = "sha256:32c6af01222c80a7c558b376f417e2c6d3bfd4ba03d6f8fb0114a7630e987afb", size = 1720734, upload-time = "2026-07-21T10:45:44.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/3d/fc1ad68dabdcb669ed3b273966d2a423ff8675db7386600e85643a6ad610/dls_dodal-2.5.3-py3-none-any.whl", hash = "sha256:dd1de29502be760ad679c6c7d991fb785cb3d38317334d22f79caf225398c95a", size = 437446, upload-time = "2026-07-21T10:45:42.565Z" },
 ]
 
 [[package]]
@@ -2123,9 +2119,9 @@ requires-dist = [
     { name = "bluesky-stomp", specifier = ">=0.2.0" },
     { name = "cachetools" },
     { name = "caproto" },
-    { name = "daq-config-server", specifier = ">=1.3.7" },
+    { name = "daq-config-server", specifier = ">=1.5.1" },
     { name = "deepdiff" },
-    { name = "dls-dodal", specifier = ">=2.5.3" },
+    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal?rev=main" },
     { name = "fastapi", extras = ["all"] },
     { name = "flask-restful" },
     { name = "jupyterlab" },
@@ -2137,7 +2133,7 @@ requires-dist = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "ophyd", specifier = ">=1.10.5" },
-    { name = "ophyd-async", specifier = "==0.20.1" },
+    { name = "ophyd-async", specifier = ">=0.20.1" },
     { name = "pydantic" },
     { name = "pydantic-extra-types", specifier = ">=2.10.1" },
     { name = "pyepics" },
@@ -2689,7 +2685,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.20.1"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2703,9 +2699,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/e1/8faa491911abd3426273daf2249769ca54786ca2a70f928afa89dd75e226/ophyd_async-0.20.1.tar.gz", hash = "sha256:a98f502d8868e35ab593aef2819730f3263445a256b7729bf43aa791feae575e", size = 660613, upload-time = "2026-07-22T11:25:59.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/4a/823545c9f0bd1b8a9695c658caece4a9f0e52d6a0138bd7e02825f7c9cba/ophyd_async-0.21.0.tar.gz", hash = "sha256:082a1494276d69b6e893049c268d13b25a28c7d1528f983d6d1a79faa9b34fdc", size = 668561, upload-time = "2026-08-03T12:17:32.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/a3/fead51df9547035d674b98c6c583064decd09a282ef2bb94122b254fac2d/ophyd_async-0.20.1-py3-none-any.whl", hash = "sha256:95f83ba007d33a86b4eb15b423deddc65dcd3f7b228b424523087c3b10eeb718", size = 255614, upload-time = "2026-07-22T11:25:57.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/26/8b1bc3feaea1dcfbcea03c48224b418dd04a2b4849c0ed6f0f83e2661899/ophyd_async-0.21.0-py3-none-any.whl", hash = "sha256:a018bc483d904bfcb1146ec714758e026b5386c7d3b626408ea61250713cfd6b", size = 258829, upload-time = "2026-08-03T12:17:31.302Z" },
 ]
 
 [package.optional-dependencies]
@@ -3672,16 +3668,16 @@ wheels = [
 
 [[package]]
 name = "scanspec"
-version = "0.10.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9d9de144ca0e0be895caf824f30e2c8d809c032b248fb3a6c92a4df30660/scanspec-0.10.0.tar.gz", hash = "sha256:8d0d93c4b5a3c74d983a38c6f6001d3cc574429a7a26604a31a61b82c373f0a9", size = 266550, upload-time = "2026-02-02T12:59:56.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/c3/7b3621a0eec53b7e348457de68a33a93314c5626523ab1481395811aa09e/scanspec-1.0.0.tar.gz", hash = "sha256:31d297861978e56bb6cfcaa15527bad5ba3dc158b3fc52142ecb5611a22e1b5a", size = 285029, upload-time = "2026-04-28T12:12:54.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/6d/8500f4bece0aa7cd2af374739f2944c9fa52f0fc5e1d9e65a366f37f494a/scanspec-0.10.0-py3-none-any.whl", hash = "sha256:0979cdcf9790573478f863c36844e1446e87996f945b1bd9c1dcbd7fb663ad92", size = 37728, upload-time = "2026-02-02T12:59:55.843Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b9/f44b139096467996b4d85589d9880fd55f0c80a204d298a1b73d0adc2654/scanspec-1.0.0-py3-none-any.whl", hash = "sha256:4ad6dccd6ac19dbd8af888c80c5db53c70d6b8aee9d26c0ca174cebd3c396730", size = 37825, upload-time = "2026-04-28T12:12:53.084Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ requires-dist = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "ophyd", specifier = ">=1.10.5" },
-    { name = "ophyd-async", specifier = "==0.19.4" },
+    { name = "ophyd-async", specifier = "==0.20.1" },
     { name = "pydantic" },
     { name = "pydantic-extra-types", specifier = ">=2.10.1" },
     { name = "pyepics" },
@@ -2689,7 +2689,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.4"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2703,9 +2703,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/07/22e05906c87e8cc1eb32b6753a09ad84bb382c723f332f5010f777bcf4d2/ophyd_async-0.19.4.tar.gz", hash = "sha256:f484c02487c6bcd82307db7caea42fe922cf66979680a3e6e11a1d9622e700ba", size = 643368, upload-time = "2026-07-15T15:30:01.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/e1/8faa491911abd3426273daf2249769ca54786ca2a70f928afa89dd75e226/ophyd_async-0.20.1.tar.gz", hash = "sha256:a98f502d8868e35ab593aef2819730f3263445a256b7729bf43aa791feae575e", size = 660613, upload-time = "2026-07-22T11:25:59.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/27/00fd0ce52333ffdc4527e3bb3b33b3170dfb851faa9214cbdd9566bdd3f4/ophyd_async-0.19.4-py3-none-any.whl", hash = "sha256:c161709f0fa18cd5c993a630aba8f40fb35213f8e600583f1f414d0b6ce17ecd", size = 253459, upload-time = "2026-07-15T15:30:00.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/fead51df9547035d674b98c6c583064decd09a282ef2bb94122b254fac2d/ophyd_async-0.20.1-py3-none-any.whl", hash = "sha256:95f83ba007d33a86b4eb15b423deddc65dcd3f7b228b424523087c3b10eeb718", size = 255614, upload-time = "2026-07-22T11:25:57.768Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes mx-bluesky to work against `ophyd-async` 0.2.0

Requires:
  * DiamondLightSource/dodal#2122
  * bluesky/ophyd-async#1369

(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

Note:

This PR cannot be merged standalone as DiamondLightSource/dodal#2122 is merged on top of
* DiamondLightSource/dodal#2099 which introduces breaking changes in daq-config-server

The changes that fix this are in 
* DiamondLightSource/mx-bluesky#1812

Hence the tests for this PR are expected to fail

### Instructions to reviewer on how to test:

1. Do thing x
2. Confirm thing y happens

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
