### PR TITLE
Added two parameters and a change to chip collect i24

### DIFF
--- a/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_chip_collect_py3v1.py
+++ b/src/mx_bluesky/beamlines/i24/serial/fixed_target/i24ssx_chip_collect_py3v1.py
@@ -81,6 +81,8 @@ def write_userlog(
         Pump status \t{parameters.pump_repeat}\n
         Pump exp time \t{parameters.laser_dwell_s}\n
         Pump delay \t{parameters.laser_delay_s}\n
+        Checker pattern \t{parameters.checker_pattern}\n
+        Pump2 expt time \t{parameters.pre_pump_exposure_s}\n
     """
     with open(userlog_path / userlog_fid, "w") as f:
         f.write(text)
@@ -345,6 +347,8 @@ def start_i24(
         # DCID process depends on detector PVs being set up already
         SSX_LOGGER.debug("Start DCID process")
         complete_filename = cagetstring(pv.eiger_od_filename_rbv)
+        if isinstance(complete_filename, bytes):
+            complete_filename = complete_filename.decode()
         filetemplate = f"{complete_filename}.nxs"
         dcid.generate_dcid(
             beam_settings=beam_settings,
@@ -384,6 +388,12 @@ def start_i24(
         SSX_LOGGER.error(msg)
         raise ValueError(msg)
 
+    # Test moved to start_i24
+    transmission = float(caget(pv.requested_transmission))
+    wavelength = yield from bps.rd(dcm.wavelength_in_a)
+
+    write_userlog(parameters, complete_filename, transmission, wavelength)
+
     # Open the hutch shutter
     yield from bps.abs_set(shutter, ShutterDemand.OPEN, wait=True)
 
@@ -403,15 +413,10 @@ def finish_i24(
         f"Finish I24 data collection with {parameters.detector_name} detector."
     )
 
-    complete_filename: str
-    transmission = float(caget(pv.requested_transmission))
-    wavelength = yield from bps.rd(dcm.wavelength_in_a)
-
     if parameters.detector_name == "eiger":
         SSX_LOGGER.debug("Finish I24 Eiger")
         yield from reset_zebra_when_collection_done_plan(zebra)
         yield from sup.eiger("return-to-normal", None, dcm, detector_stage)
-        complete_filename = cagetstring(pv.eiger_od_filename_rbv)  # type: ignore
     else:
         raise ValueError(f"{parameters.detector_name} unrecognised")
 
@@ -420,9 +425,6 @@ def finish_i24(
     yield from bps.trigger(pmac.to_xyz_zero)
     SSX_LOGGER.info("Closing shutter")
     yield from bps.abs_set(shutter, ShutterDemand.CLOSE, wait=True)
-
-    # Write a record of what was collected to the processing directory
-    write_userlog(parameters, complete_filename, transmission, wavelength)
 
 
 def run_aborted_plan(pmac: PMAC, dcid: DCID, exception: Exception):

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
@@ -260,7 +260,6 @@ def test_finish_i24(
     fake_caget,
     fake_cagetstring,
     fake_sleep,
-    fake_userlog,
     zebra,
     pmac,
     shutter,

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
@@ -165,7 +165,11 @@ def test_load_motion_program_data(
 @patch(
     "mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_chip_collect_py3v1.datetime"
 )
+@patch(
+    "mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_chip_collect_py3v1.write_userlog"
+)
 def test_start_i24_with_eiger(
+    fake_userlog,
     fake_datetime,
     fake_sleep,
     fake_sup,
@@ -234,10 +238,9 @@ def test_start_i24_with_eiger(
     mock_shutter = get_mock_put(shutter.control)
     mock_shutter.assert_has_calls(shutter_call_list)
 
+    fake_userlog.assert_called_once_with(dummy_params_without_pp, "chip_01", 0.0, 0.6)
 
-@patch(
-    "mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_chip_collect_py3v1.write_userlog"
-)
+
 @patch(
     "mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_chip_collect_py3v1.bps.sleep"
 )
@@ -284,8 +287,6 @@ def test_finish_i24(
 
     mock_shutter = get_mock_put(shutter.control)
     mock_shutter.assert_has_calls([call("Close")])
-
-    fake_userlog.assert_called_once_with(dummy_params_without_pp, "chip_01", 0.0, 0.6)
 
 
 @patch("mx_bluesky.beamlines.i24.serial.fixed_target.i24ssx_chip_collect_py3v1.DCID")

--- a/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
+++ b/tests/unit_tests/beamlines/i24/serial/fixed_target/test_ft_collect.py
@@ -238,7 +238,7 @@ def test_start_i24_with_eiger(
     mock_shutter = get_mock_put(shutter.control)
     mock_shutter.assert_has_calls(shutter_call_list)
 
-    fake_userlog.assert_called_once_with(dummy_params_without_pp, "chip_01", 0.0, 0.6)
+    fake_userlog.assert_called_once_with(dummy_params_without_pp, "chip_0001", 1.0, 0.6)
 
 
 @patch(


### PR DESCRIPTION
Notes on some things that might also be worth fixing/changing or not, mentioned to simply confirm.
```Removed use_control_machine: bool = true from deploy_mx_bluesky.py, is that fine?

Values are different so worth checking?

cs_maker.json
DiamondExtruder-I24-py3v1.edl (beginScreenProperties x and y)
DiamondChipI24-py3v1.edl (several x and y values through the file)
pumpprobe-py3v1.edl (two x and y values)
QiamondChipI24-py3v1.edl, qumpprobe-py3v1.edl, qumpprobe-py3v2.edl, qumpprobe-py3v3.edl seem to be old files that are not needed anymore but maybe double check.
i24/serial/setup_beamline/pv_abstract.py has different values
test_ispyb_dev_connection.py
It had focalspotsizeatsamplex and y to be missing but can't find commit that removes them

Setup_panda is now load_panda_yaml.py now it seems, just want to confirm if the refactor is true or not because I wasn't too sure.```