### PR TITLE
Fix mx-bluesky to run against latest daq-config-server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ dependencies = [
     "daq-config-server >= 1.5.1",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
-    # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795
-    "ophyd-async == 0.20.1",
+    "ophyd-async >= 0.20.1",
     "bluesky >= 1.14.6",
     "dls-dodal @ git+https://github.com/DiamondLightSource/dodal@main",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     # These dependencies may be issued as pre-release versions and should have a pin constraint
     # as by default pip-install will not upgrade to a pre-release.
     #
-    "daq-config-server >= 1.3.7",
+    "daq-config-server >= 1.5.1",
     "blueapi >= 1.12.0",
     "ophyd >= 1.10.5",
     # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     # Pin ophyd-async until we support 0.2.0 https://github.com/DiamondLightSource/mx-bluesky/issues/1795
     "ophyd-async == 0.20.1",
     "bluesky >= 1.14.6",
-    "dls-dodal >= 2.5.3",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal@main",
 ]
 
 

--- a/src/mx_bluesky/hyperion/__main__.py
+++ b/src/mx_bluesky/hyperion/__main__.py
@@ -5,7 +5,7 @@ from sys import argv
 
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.core import BlueskyContext
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.common.beamlines.beamline_utils import set_config_client
 
 from mx_bluesky.common.external_interaction import alerting
@@ -50,7 +50,7 @@ def initialise_globals(args: HyperionArgs):
 
 def initialise_config_server():
     config_client_url = os.getenv("CONFIG_SERVER_URL", DEFAULT_CONFIG_SERVER_ENDPOINT)
-    client = ConfigClient(config_client_url)
+    client = ConfigClient.from_url(config_client_url)
     set_config_client(client)
 
 

--- a/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/mx_bluesky/hyperion/external_interaction/callbacks/__main__.py
@@ -14,7 +14,7 @@ from bluesky.callbacks import CallbackBase
 from bluesky.callbacks.zmq import Proxy, RemoteDispatcher
 from bluesky_stomp.messaging import StompClient
 from bluesky_stomp.models import Broker
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.common.beamlines.beamline_parameters import CONFIG_SERVER_URL_ENV_VAR
 from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.log import LOGGER as DODAL_LOGGER
@@ -159,7 +159,7 @@ def create_config_client() -> ConfigClient:
         raise ValueError(
             f"{CONFIG_SERVER_URL_ENV_VAR} must be specified to run external callbacks."
         )
-    return ConfigClient(config_server_url)
+    return ConfigClient.from_url(config_server_url)
 
 
 def log_info(msg, *args, **kwargs):

--- a/tests/system_tests/common/daq_config_server/test_daq_config_server.py
+++ b/tests/system_tests/common/daq_config_server/test_daq_config_server.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.feature_settings.hyperion_feature_settings import (
     HyperionFeatureSettings,
 )

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientResponse
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.beamlines import i03
 from dodal.common.beamlines.beamline_utils import clear_config_client
 from dodal.devices.aperturescatterguard import (

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from dodal.devices.beamsize.beamsize import BeamsizeBase
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection

--- a/tests/unit_tests/beamlines/i04/test_thawing.py
+++ b/tests/unit_tests/beamlines/i04/test_thawing.py
@@ -6,8 +6,9 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import assert_message_and_return_remaining
 from bluesky.utils import MsgGenerator
-from daq_config_server import ConfigClient
+from daq_config_server.testing import PathToMockDataDict
 from dodal.beamlines import i04
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.beamlines.i04.murko_results import MurkoResultsDevice
 from dodal.devices.oav.oav_detector import OAV, OAVBeamCentrePV, OAVConfig
 from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder, Source
@@ -39,8 +40,10 @@ class MyError(Exception):
 
 
 @pytest.fixture
-async def oav_full_screen(test_config_files: ConfigFilesForTests) -> OAV:
-    oav_config = OAVConfig(test_config_files["zoom_params_file"], ConfigClient(""))
+async def oav_full_screen(
+    mock_daq_config: PathToMockDataDict, test_config_files: ConfigFilesForTests
+) -> OAV:
+    oav_config = OAVConfig(test_config_files["zoom_params_file"], get_config_client())
     async with init_devices(mock=True, connect=True):
         oav = OAVBeamCentrePV(
             "", config=oav_config, name="oav_full_screen", mjpeg_prefix="XTAL"
@@ -52,8 +55,10 @@ async def oav_full_screen(test_config_files: ConfigFilesForTests) -> OAV:
 
 
 @pytest.fixture
-async def oav_roi(test_config_files: ConfigFilesForTests) -> OAV:
-    oav_config = OAVConfig(test_config_files["zoom_params_file"], ConfigClient(""))
+async def oav_roi(
+    mock_daq_config: PathToMockDataDict, test_config_files: ConfigFilesForTests
+) -> OAV:
+    oav_config = OAVConfig(test_config_files["zoom_params_file"], get_config_client())
     async with init_devices(mock=True, connect=True):
         oav = OAVBeamCentrePV("", config=oav_config, name="oav")
     set_mock_value(oav.zoom_controller.level, "5.0x")

--- a/tests/unit_tests/common/experiment_plans/test_common_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_common_grid_detect_then_xray_centre_plan.py
@@ -6,7 +6,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from bluesky.utils import Msg
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import ApertureValue
 from dodal.devices.backlight import InOut
 from dodal.devices.mx_phase1.beamstop import BeamstopPositions
@@ -170,7 +170,7 @@ def _do_detect_grid_and_gridscan_then_wait_for_backlight(
         composite,
         parameters=test_full_grid_scan_params,
         oav_params=OAVParameters(
-            ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+            get_config_client(), "xrayCentring", test_config_files["oav_config_json"]
         ),
         xrc_params_type=HyperionSpecifiedThreeDGridScan,
         construct_beamline_specific=construct_beamline_specific_xrc_features,
@@ -193,7 +193,7 @@ def test_when_full_grid_scan_run_then_parameters_sent_to_fgs_as_expected(
     construct_beamline_specific: ConstructBeamlineSpecificFeatures,
 ):
     oav_params = OAVParameters(
-        ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+        get_config_client(), "xrayCentring", test_config_files["oav_config_json"]
     )
 
     run_engine(
@@ -263,7 +263,9 @@ def test_detect_grid_and_do_gridscan_does_not_activate_ispyb_callback(
             grid_detect_xrc_devices,
             test_full_grid_scan_params,
             OAVParameters(
-                ConfigClient(""), "xrayCentring", test_config_files["oav_config_json"]
+                get_config_client(),
+                "xrayCentring",
+                test_config_files["oav_config_json"],
             ),
             xrc_params_type=HyperionSpecifiedThreeDGridScan,
             construct_beamline_specific=construct_beamline_specific,

--- a/tests/unit_tests/common/experiment_plans/test_grid_detection_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_grid_detection_plan.py
@@ -8,8 +8,8 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from bluesky.utils import Msg
-from daq_config_server import ConfigClient
 from dodal.beamlines import i03
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAVConfigBeamCentre
 from dodal.devices.oav.oav_parameters import OAVParameters
@@ -61,7 +61,7 @@ def fake_devices(
     params = OAVConfigBeamCentre(
         test_config_files["zoom_params_file"],
         test_config_files["display_config"],
-        ConfigClient(""),
+        get_config_client(),
     )
     oav = i03.oav.build(connect_immediately=True, mock=True, params=params)
     set_mock_value(oav.zoom_controller.level, "5.0x")
@@ -116,7 +116,7 @@ def test_grid_detection_plan_runs_and_triggers_snapshots(
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, image_save = fake_devices
 
@@ -148,7 +148,7 @@ async def test_grid_detection_plan_gives_warning_error_if_tip_not_found(
     )
 
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
 
     with pytest.raises(WarningError) as excinfo:
@@ -165,7 +165,7 @@ async def test_given_when_grid_detect_then_start_position_as_expected(
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     box_size_um = 0.2
     composite, _ = fake_devices
@@ -211,7 +211,7 @@ async def test_when_grid_detection_plan_run_then_ispyb_callback_gets_correct_val
     dummy_rotation_data_collection_group_info,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
     cb = GridDetectAndScanISPyBCallback(param_type=GenericGrid)
@@ -277,7 +277,7 @@ def test_when_grid_detection_plan_run_then_grid_detection_callback_gets_correct_
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
     box_size_um = 20
@@ -315,7 +315,7 @@ def test_when_grid_detection_plan_run_with_different_omega_order_then_grid_detec
     tmp_path: Path,
 ):
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     composite, _ = fake_devices
 
@@ -397,7 +397,7 @@ async def test_when_detected_grid_has_odd_y_steps_then_add_a_y_step_and_shift_gr
 ):
     composite, _ = fake_devices
     params = OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
     box_size_um = 20
     microns_per_pixel_y = await composite.oav.microns_per_pixel_y.get_value()

--- a/tests/unit_tests/common/experiment_plans/test_oav_snapshot_plan.py
+++ b/tests/unit_tests/common/experiment_plans/test_oav_snapshot_plan.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pydantic
 import pytest
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.areadetector.plugins.cam import ColorMode
 from dodal.devices.backlight import Backlight
@@ -75,7 +75,8 @@ def test_oav_snapshot_plan_issues_rotations_and_generates_events(
             oav_snapshot_composite,
             oav_snapshot_params,
             OAVParameters(
-                ConfigClient(""), oav_config_json=test_config_files["oav_config_json"]
+                get_config_client(),
+                oav_config_json=test_config_files["oav_config_json"],
             ),
         )
     )

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -13,8 +13,10 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
+from daq_config_server.testing import MockServerResponse, PathToMockDataDict
 from dodal.beamlines import i03
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.aperturescatterguard import (
     ApertureScatterguard,
     ApertureValue,
@@ -109,8 +111,6 @@ from mx_bluesky.hyperion.parameters.device_composites import (
 )
 from tests.conftest import TEST_BEAMLINE_PARAMETERS, raw_params_from_file
 from tests.test_data.oav import TEST_DISPLAY_CONFIG, TEST_OAV_ZOOM_LEVELS
-
-pytest_plugins = ["dodal.testing.fixtures.config_server"]
 
 i03.DAQ_CONFIGURATION_PATH = "tests/test_data/test_daq_configuration"
 
@@ -230,6 +230,22 @@ def create_gridscan_callbacks() -> tuple[
             ),
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_daq_config() -> Generator[PathToMockDataDict, None, None]:
+    mutable_dict = {}
+    mock_config_server = ConfigClient(MockServerResponse(mutable_dict))
+    with (
+        patch(
+            "dodal.common.beamlines.beamline_utils.CONFIG_CLIENT", mock_config_server
+        ),
+        patch(
+            "daq_config_server.client.ConfigClient.from_url",
+            return_value=mock_config_server,
+        ),
+    ):
+        yield mutable_dict
 
 
 @pytest.fixture(autouse=True)
@@ -661,18 +677,20 @@ def patch_config_paths(monkeypatch):
 
 
 @pytest.fixture
-def oav_parameters_for_rotation(test_config_files) -> OAVParameters:
-    return OAVParameters(
-        ConfigClient(""), oav_config_json=test_config_files["oav_config_json"]
-    )
+def oav_parameters_for_rotation(
+    mock_daq_config: PathToMockDataDict, test_config_files
+) -> OAVParameters:
+    oav_config_path = test_config_files["oav_config_json"]
+    # mock_daq_config[oav_config_path] = json.loads(oav_config_path)
+    return OAVParameters(get_config_client(), oav_config_json=oav_config_path)
 
 
 @pytest.fixture
-def oav(test_config_files):
+def oav(mock_daq_config: PathToMockDataDict, test_config_files):
     parameters = OAVConfigBeamCentre(
         test_config_files["zoom_params_file"],
         test_config_files["display_config"],
-        ConfigClient(""),
+        get_config_client(),
     )
     oav = i03.oav.build(mock=True, connect_immediately=True, params=parameters)
 

--- a/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
+++ b/tests/unit_tests/hyperion/device_setup_plans/test_setup_oav.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -20,7 +20,7 @@ from tests.conftest import ConfigFilesForTests
 @pytest.fixture
 def mock_parameters(test_config_files: ConfigFilesForTests):
     return OAVParameters(
-        ConfigClient(""), "loopCentring", test_config_files["oav_config_json"]
+        get_config_client(), "loopCentring", test_config_files["oav_config_json"]
     )
 
 

--- a/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
+++ b/tests/unit_tests/hyperion/external_interaction/test_agamemnon.py
@@ -6,11 +6,9 @@ from typing import cast
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-from daq_config_server import ConfigClient
 from daq_config_server.models.feature_settings.hyperion_feature_settings import (
     HyperionFeatureSettings,
 )
-from dodal.common.beamlines.beamline_utils import set_config_client
 from dodal.devices.zebra.zebra import RotationDirection
 from requests import ConnectionError, HTTPError, Response, Timeout
 
@@ -31,11 +29,6 @@ from mx_bluesky.hyperion.external_interaction.agamemnon import (
     create_parameters_from_agamemnon,
 )
 from mx_bluesky.hyperion.plan_runner import PlanError
-
-
-@pytest.fixture(autouse=True)
-def mock_config_client():
-    set_config_client(ConfigClient("http://localhost"))
 
 
 def set_up_agamemnon_params(

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -274,7 +274,7 @@ def test_sending_main_process_sigterm_in_udc_mode_performs_clean_prompt_shutdown
     main()
 
 
-@patch("mx_bluesky.hyperion.__main__.ConfigClient")
+@patch("mx_bluesky.hyperion.__main__.ConfigClient.from_url")
 @patch("mx_bluesky.hyperion.__main__.set_config_client")
 @patch(
     "sys.argv",
@@ -291,7 +291,7 @@ def test_sending_main_process_sigterm_in_udc_mode_performs_clean_prompt_shutdown
 )
 def test_supervisor_start_reads_config_client_url(
     mock_set_config_client: MagicMock,
-    mock_config_client_cls: MagicMock,
+    mock_from_url: MagicMock,
     mock_supervisor_mode: MagicMock,
     monkeypatch,
 ):
@@ -300,5 +300,5 @@ def test_supervisor_start_reads_config_client_url(
 
     main()
 
-    mock_config_client_cls.assert_called_once_with(test_url)
-    mock_set_config_client.assert_called_once_with(mock_config_client_cls.return_value)
+    mock_from_url.assert_called_once_with(test_url)
+    mock_set_config_client.assert_called_once_with(mock_from_url.return_value)

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.7"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -707,9 +707,9 @@ dependencies = [
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "xmltodict", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/93/c913c56425bf937c3c6b8733ac88bdb6b03a49dd10f068215473b511f12f/daq_config_server-1.3.7.tar.gz", hash = "sha256:6dc0c0613c88198eb16cd86c84c731de97090499ebcf39ccfe9be67dad84caae", size = 233043, upload-time = "2026-06-25T10:00:58.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a2/2fc42d3231be454be244c1dd19a1e36204fe68957b275fc37775efffc9ba/daq_config_server-1.5.1.tar.gz", hash = "sha256:e7dbcd335a1ec06faa777bc0f03039c90aa067b3b71df599cb59ae7cf5fac368", size = 236115, upload-time = "2026-07-28T14:03:52.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0b/0472e9ab51f04a5fd00d477edf8567bdf320a6f245bd6414b3f208f49684/daq_config_server-1.3.7-py3-none-any.whl", hash = "sha256:ecf11b770d059248d70b3418b75701842dce398d4945e26a8a16ac5049a845c5", size = 35113, upload-time = "2026-06-25T10:00:57.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/7a8d2a4d7c35f1e384e58c559b44fa41d90878b67e1c9689831fe2a1d125/daq_config_server-1.5.1-py3-none-any.whl", hash = "sha256:3076083c3a9a007f635562654d834c8528997316e1764b4cbd46cb324e3904be", size = 35620, upload-time = "2026-07-28T14:03:51.285Z" },
 ]
 
 [[package]]
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.3"
-source = { registry = "https://pypi.org/simple" }
+version = "2.5.4.dev7+g36e3b03da"
+source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#36e3b03da324c3a567d0720e86fc86a6f67eb87d" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -833,10 +833,6 @@ dependencies = [
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scanspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "zocalo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/3c/36b192e29e1f26298f6fd1ec0f7d9c74fa12e45355fa0f404fdcc505f6ce/dls_dodal-2.5.3.tar.gz", hash = "sha256:32c6af01222c80a7c558b376f417e2c6d3bfd4ba03d6f8fb0114a7630e987afb", size = 1720734, upload-time = "2026-07-21T10:45:44.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/3d/fc1ad68dabdcb669ed3b273966d2a423ff8675db7386600e85643a6ad610/dls_dodal-2.5.3-py3-none-any.whl", hash = "sha256:dd1de29502be760ad679c6c7d991fb785cb3d38317334d22f79caf225398c95a", size = 437446, upload-time = "2026-07-21T10:45:42.565Z" },
 ]
 
 [[package]]
@@ -2123,9 +2119,9 @@ requires-dist = [
     { name = "bluesky-stomp", specifier = ">=0.2.0" },
     { name = "cachetools" },
     { name = "caproto" },
-    { name = "daq-config-server", specifier = ">=1.3.7" },
+    { name = "daq-config-server", specifier = ">=1.5.1" },
     { name = "deepdiff" },
-    { name = "dls-dodal", specifier = ">=2.5.3" },
+    { name = "dls-dodal", git = "https://github.com/DiamondLightSource/dodal?rev=main" },
     { name = "fastapi", extras = ["all"] },
     { name = "flask-restful" },
     { name = "jupyterlab" },
@@ -2137,7 +2133,7 @@ requires-dist = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "ophyd", specifier = ">=1.10.5" },
-    { name = "ophyd-async", specifier = "==0.20.1" },
+    { name = "ophyd-async", specifier = ">=0.20.1" },
     { name = "pydantic" },
     { name = "pydantic-extra-types", specifier = ">=2.10.1" },
     { name = "pyepics" },
@@ -2689,7 +2685,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.20.1"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2703,9 +2699,9 @@ dependencies = [
     { name = "stamina", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "velocity-profile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/e1/8faa491911abd3426273daf2249769ca54786ca2a70f928afa89dd75e226/ophyd_async-0.20.1.tar.gz", hash = "sha256:a98f502d8868e35ab593aef2819730f3263445a256b7729bf43aa791feae575e", size = 660613, upload-time = "2026-07-22T11:25:59.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/4a/823545c9f0bd1b8a9695c658caece4a9f0e52d6a0138bd7e02825f7c9cba/ophyd_async-0.21.0.tar.gz", hash = "sha256:082a1494276d69b6e893049c268d13b25a28c7d1528f983d6d1a79faa9b34fdc", size = 668561, upload-time = "2026-08-03T12:17:32.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/a3/fead51df9547035d674b98c6c583064decd09a282ef2bb94122b254fac2d/ophyd_async-0.20.1-py3-none-any.whl", hash = "sha256:95f83ba007d33a86b4eb15b423deddc65dcd3f7b228b424523087c3b10eeb718", size = 255614, upload-time = "2026-07-22T11:25:57.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/26/8b1bc3feaea1dcfbcea03c48224b418dd04a2b4849c0ed6f0f83e2661899/ophyd_async-0.21.0-py3-none-any.whl", hash = "sha256:a018bc483d904bfcb1146ec714758e026b5386c7d3b626408ea61250713cfd6b", size = 258829, upload-time = "2026-08-03T12:17:31.302Z" },
 ]
 
 [package.optional-dependencies]
@@ -3672,16 +3668,16 @@ wheels = [
 
 [[package]]
 name = "scanspec"
-version = "0.10.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9d9de144ca0e0be895caf824f30e2c8d809c032b248fb3a6c92a4df30660/scanspec-0.10.0.tar.gz", hash = "sha256:8d0d93c4b5a3c74d983a38c6f6001d3cc574429a7a26604a31a61b82c373f0a9", size = 266550, upload-time = "2026-02-02T12:59:56.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/c3/7b3621a0eec53b7e348457de68a33a93314c5626523ab1481395811aa09e/scanspec-1.0.0.tar.gz", hash = "sha256:31d297861978e56bb6cfcaa15527bad5ba3dc158b3fc52142ecb5611a22e1b5a", size = 285029, upload-time = "2026-04-28T12:12:54.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/6d/8500f4bece0aa7cd2af374739f2944c9fa52f0fc5e1d9e65a366f37f494a/scanspec-0.10.0-py3-none-any.whl", hash = "sha256:0979cdcf9790573478f863c36844e1446e87996f945b1bd9c1dcbd7fb663ad92", size = 37728, upload-time = "2026-02-02T12:59:55.843Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b9/f44b139096467996b4d85589d9880fd55f0c80a204d298a1b73d0adc2654/scanspec-1.0.0-py3-none-any.whl", hash = "sha256:4ad6dccd6ac19dbd8af888c80c5db53c70d6b8aee9d26c0ca174cebd3c396730", size = 37825, upload-time = "2026-04-28T12:12:53.084Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates mx-bluesky to use the latest dodal, which has a dependency on newer versions of `daq-config-server`

Link to dodal PR (if required):
* DiamondLightSource/dodal#2099

This PR requires and builds on 
* #1799 

(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. Tests pass


### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
