### PR TITLE
Fix system tests for reserved attributes

### DIFF
--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -253,8 +253,8 @@ def zocalo_for_system_test() -> Generator[ZocaloResults, None, None]:
         patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection"),
     ):
         workflows.recipe.wrap_subscribe.side_effect = mock_worfklow_subscribe
-        with patch.object(zocalo, "trigger", side_effect=mock_zocalo_complete):
-            yield zocalo
+        set_mock_attr(zocalo, "trigger", MagicMock(side_effect=mock_zocalo_complete))
+        yield zocalo
 
 
 @pytest.fixture
@@ -344,14 +344,20 @@ def grid_detect_then_xray_centre_composite(
         patch.object(eiger, "wait_on_arming_if_started"),
         # xsize, ysize will always be wrong since computed as 0 before we get here
         # patch up load_microns_per_pixel connect to receive non-zero values
-        patch.object(
-            ophyd_pin_tip_detection, "trigger", side_effect=mock_pin_tip_detect
-        ),
-        patch.object(fast_grid_scan, "kickoff", side_effect=lambda: completed_status()),
-        patch.object(
-            fast_grid_scan, "complete", side_effect=lambda: completed_status()
-        ),
     ):
+        set_mock_attr(
+            ophyd_pin_tip_detection,
+            "trigger",
+            MagicMock(side_effect=mock_pin_tip_detect),
+        )
+        set_mock_attr(
+            fast_grid_scan, "kickoff", MagicMock(side_effect=lambda: completed_status())
+        )
+        set_mock_attr(
+            fast_grid_scan,
+            "complete",
+            MagicMock(side_effect=lambda: completed_status()),
+        )
         yield composite
 
 

--- a/tests/system_tests/hyperion/external_interaction/conftest.py
+++ b/tests/system_tests/hyperion/external_interaction/conftest.py
@@ -426,8 +426,10 @@ def pin_tip_no_pin_found(ophyd_pin_tip_detection):
             numpy.array([]),
         )
 
-    with patch.object(ophyd_pin_tip_detection, "trigger", side_effect=no_pin_tip_found):
-        yield ophyd_pin_tip_detection
+    set_mock_attr(
+        ophyd_pin_tip_detection, "trigger", MagicMock(side_effect=no_pin_tip_found)
+    )
+    yield ophyd_pin_tip_detection
 
 
 @pytest.fixture

--- a/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
+++ b/tests/system_tests/hyperion/external_interaction/test_load_centre_collect_full_plan.py
@@ -289,8 +289,8 @@ def composite_with_no_diffraction(
     async def mock_zocalo_complete():
         await zocalo._put_results([], {"dcid": 0, "dcgid": 0})
 
-    with patch.object(zocalo, "trigger", side_effect=mock_zocalo_complete):
-        yield load_centre_collect_composite
+    set_mock_attr(zocalo, "trigger", MagicMock(side_effect=mock_zocalo_complete))
+    yield load_centre_collect_composite
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -810,8 +810,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.5.4.dev8+g9c419b297"
-source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#9c419b29768b3852bf384881772989fcaea16186" }
+version = "2.5.4.dev9+g9dad391fc"
+source = { git = "https://github.com/DiamondLightSource/dodal?rev=main#9dad391fc7a40c5fa0c017f7c90650672d420709" }
 dependencies = [
     { name = "aiofiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
Fixes the system tests following ophyd async changes to make certain attributes non-settable.

Link to dodal PR (if required): #N/A
(remember to update `pyproject.toml` with the dodal commit tag if you need it for tests to pass!)

### Instructions to reviewer on how to test:

1. System tests pass - https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/pipelines/133573/test_report

### Checks for reviewer

- [ ] Would the PR title make sense to a user on a set of release notes
